### PR TITLE
[SDK-2489] Align yaml with Azure DevOps

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,3 +20,26 @@ steps:
   inputs:
     arguments: '-nowarn:CS1591 --configuration Release'
 
+- task: DotNetCoreCLI@2
+  displayName: Test
+  inputs:
+    command: test
+
+- task: DotNetCoreCLI@2
+  displayName: Pack
+  inputs:
+    command: pack
+
+- task: CopyFiles@2
+  displayName: Stage
+  inputs:
+    SourceFolder: '$(system.defaultworkingdirectory)'
+    Contents: '**\Auth0.*.nupkg'
+    TargetFolder: '$(build.artifactstagingdirectory)'
+
+- task: PublishBuildArtifacts@1
+  displayName: Publish
+  inputs:
+    PathtoPublish: '$(build.artifactstagingdirectory)'
+    ArtifactName: Auth0.Net.Packages
+


### PR DESCRIPTION
Even though we are not actualy using the yaml configuration in any of our .NET SDKs, I would hope to move towards doing so in the future.
As all other repositories already have an `azure-pipeline.yml` in place for that, I wanted to ensure our yaml file is also in line with the CI configuration.