### PR TITLE
[SDK-2495] Support configuring the callback path

### DIFF
--- a/src/Auth0.AspNetCore.Mvc/Auth0AuthenticationBuilderExtensions.cs
+++ b/src/Auth0.AspNetCore.Mvc/Auth0AuthenticationBuilderExtensions.cs
@@ -43,7 +43,7 @@ namespace Auth0.AspNetCore.Mvc
             oidcOptions.ResponseType = OpenIdConnectResponseType.Code;
             oidcOptions.Scope.Clear();
             oidcOptions.Scope.AddRange(auth0Options.Scope.Split(" "));
-            oidcOptions.CallbackPath = new PathString(Constants.DefaultCallbackPath);
+            oidcOptions.CallbackPath = new PathString(auth0Options.CallbackPath ?? Constants.DefaultCallbackPath);
             oidcOptions.ClaimsIssuer = Constants.ClaimsIssuer;
 
             oidcOptions.TokenValidationParameters = new TokenValidationParameters

--- a/src/Auth0.AspNetCore.Mvc/Auth0Options.cs
+++ b/src/Auth0.AspNetCore.Mvc/Auth0Options.cs
@@ -24,5 +24,11 @@
         /// Scopes to be used to request token(s).
         /// </summary>
         public string Scope { get; set; } = "openid profile email";
+
+        /// <summary>
+        /// The path within the application to redirect the user to.
+        /// </summary>
+        /// <remarks>Processed internally by the Open Id Connect middleware.</remarks> 
+        public string CallbackPath { get; set; }
     }
 }

--- a/tests/Auth0.AspNetCore.Mvc.UnitTests/Auth0ServiceCollectionExtensionsTests.cs
+++ b/tests/Auth0.AspNetCore.Mvc.UnitTests/Auth0ServiceCollectionExtensionsTests.cs
@@ -131,5 +131,29 @@ namespace Auth0.AspNetCore.Mvc.UnitTests
                 queryParameters["scope"].Should().Be("ScopeA ScopeB");
             });
         }
+
+        [Fact]
+        public async void Should_Allow_Configuring_CallbackPath()
+        {
+            await MockHttpContext.Configure(services =>
+            {
+                services.AddAuth0Mvc(options =>
+                {
+                    options.Domain = AUTH0_DOMAIN;
+                    options.ClientId = AUTH0_CLIENT_ID;
+                    options.ClientSecret = AUTH0_CLIENT_SECRET;
+                    options.CallbackPath = "/Test123";
+                });
+            }).RunAsync(async context =>
+            {
+                await context.ChallengeAsync("Auth0", new AuthenticationProperties() { RedirectUri = "/" });
+
+                var redirectUrl = context.Response.Headers[HeaderNames.Location];
+                var redirectUri = new Uri(redirectUrl);
+                var queryParameters = UriUtils.GetQueryParams(redirectUri);
+
+                queryParameters["redirect_uri"].Should().Be("https://local.auth0.com/Test123");
+            });
+        }
     }
 }


### PR DESCRIPTION
This PR ensures users can configure the callback path by adding it to the Auth0Options.