### PR TITLE
[SDK-2506] Save tokens to be able to retrieve them

### DIFF
--- a/playground/Auth0.AspNetCore.Mvc.Playground/Controllers/AccountController.cs
+++ b/playground/Auth0.AspNetCore.Mvc.Playground/Controllers/AccountController.cs
@@ -30,8 +30,11 @@ namespace Auth0.AspNetCore.Mvc.Playground.Controllers
         }
 
         [Authorize]
-        public IActionResult Profile()
+        public async Task<IActionResult> Profile()
         {
+            var accessToken = await HttpContext.GetTokenAsync("access_token");
+            var idToken = await HttpContext.GetTokenAsync("id_token");
+            var refreshToken = await HttpContext.GetTokenAsync("refresh_token");
             return View(new UserProfileViewModel()
             {
                 Name = User.Identity.Name,

--- a/src/Auth0.AspNetCore.Mvc/Auth0AuthenticationBuilderExtensions.cs
+++ b/src/Auth0.AspNetCore.Mvc/Auth0AuthenticationBuilderExtensions.cs
@@ -51,6 +51,7 @@ namespace Auth0.AspNetCore.Mvc
             oidcOptions.Scope.AddRange(auth0Options.Scope.Split(" "));
             oidcOptions.CallbackPath = new PathString(auth0Options.CallbackPath ?? Constants.DefaultCallbackPath);
             oidcOptions.ClaimsIssuer = Constants.ClaimsIssuer;
+            oidcOptions.SaveTokens = true;
 
             oidcOptions.TokenValidationParameters = new TokenValidationParameters
             {


### PR DESCRIPTION
This PR sets SaveTokens to `true` without making it configurable.
Doing so ensures users can retrieve the tokens from the `HttpContext`:

```
var accessToken = await HttpContext.GetTokenAsync("access_token");
var idToken = await HttpContext.GetTokenAsync("id_token");
var refreshToken = await HttpContext.GetTokenAsync("refresh_token");
```