### PR TITLE
[SDK-2499] Update playground for roles

### DIFF
--- a/playground/Auth0.AspNetCore.Mvc.Playground/Controllers/HomeController.cs
+++ b/playground/Auth0.AspNetCore.Mvc.Playground/Controllers/HomeController.cs
@@ -13,7 +13,7 @@ namespace Auth0.AspNetCore.Mvc.Playground.Controllers
             return View();
         }
 
-        [Authorize(Roles = "admin")]
+        [Authorize(Roles = "Admin")]
         public IActionResult Admin()
         {
             return View();

--- a/playground/Auth0.AspNetCore.Mvc.Playground/Views/Home/Admin.cshtml
+++ b/playground/Auth0.AspNetCore.Mvc.Playground/Views/Home/Admin.cshtml
@@ -1,0 +1,9 @@
+﻿@{
+    ViewData["Title"] = "Home Page";
+}
+
+<div class="row">
+    <div class="col-md-12">
+        <h2>Welcome to the <strong>Admin area</strong> of the Auth0 ASP.NET Core MVC Playground</h2>.
+    </div>
+</div>


### PR DESCRIPTION
This PR updates the playground to work with Roles.

The SDK uses the default roles namespace from .NET: `http://schemas.microsoft.com/ws/2008/06/identity/claims/role`.

In order to be able to use this, users should create a rule that sets the role namespace on the Id Token:

```
function (user, context, callback) {
  const assignedRoles = (context.authorization || {}).roles;
  const idTokenClaims = context.idToken || {};

  idTokenClaims['http://schemas.microsoft.com/ws/2008/06/identity/claims/role'] = assignedRoles;

  context.idToken = idTokenClaims;
  callback(null, user, context);
}
```