### PR TITLE
Target both .NET Core 3.1 and .NET 5

### DIFF
--- a/src/Auth0.AspNetCore.Mvc/Auth0.AspNetCore.Mvc.csproj
+++ b/src/Auth0.AspNetCore.Mvc/Auth0.AspNetCore.Mvc.csproj
@@ -6,7 +6,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Authentication" Version="2.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="5.0.5" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="3.1.15" Condition="'$(TargetFramework)' == 'netcoreapp3.1'" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="5.0.5"  Condition="'$(TargetFramework)' == 'net5.0'" />
     <PackageReference Include="System.Text.Encodings.Web" Version="4.5.1" />
   </ItemGroup>
 


### PR DESCRIPTION
As this SDK should be able to support both .NET Core 3.1 and .NET 5 without a problem, it now targets both to support that.

Apart from being usable in both versions, it should also define the corresponding dependencies as .NET Core 3.1 needs a different version for OpenIdConnect as opposed to .NET 5.

This is also shown in the published Nuget package:

![image](https://user-images.githubusercontent.com/2146903/119795608-eb032f80-bed8-11eb-89d2-e05edab5072c.png)
