### PR TITLE
Avoid target-typed conditional

### DIFF
--- a/src/Auth0.AspNetCore.Mvc/IdTokenValidator.cs
+++ b/src/Auth0.AspNetCore.Mvc/IdTokenValidator.cs
@@ -59,7 +59,7 @@ namespace Auth0.AspNetCore.Mvc
             if (auth0Options.MaxAge.HasValue)
             {
                 var authTimeRaw = token.Claims.SingleOrDefault(claim => claim.Type == JwtRegisteredClaimNames.AuthTime)?.Value;
-                long? authTime = !string.IsNullOrWhiteSpace(authTimeRaw) ? (long)Convert.ToDouble(authTimeRaw, CultureInfo.InvariantCulture) : null;
+                long? authTime = !string.IsNullOrWhiteSpace(authTimeRaw) ? (long?)Convert.ToDouble(authTimeRaw, CultureInfo.InvariantCulture) : null;
 
                 if (!authTime.HasValue)
                 {


### PR DESCRIPTION
This PR removes feature that is only available in C# 9 as there is no real need to rely on C# 9 only for that one line.