### PR TITLE
Add guidance for organization claim validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,17 +293,7 @@ await HttpContext.ChallengeAsync(Auth0Constants.AuthenticationScheme, authentica
 
 #### Organization Claim Validation
 
-Even though the SDK takes care of validating the `org_id` claim in some common scenario's, it is unable to cover all scenario's.
-
-If no `organization` parameter was given to the authorization endpoint, but an `org_id` claim is present in the ID Token, then the claim should be validated by the application to ensure that the value received is expected or known.
-
-Normally, validating the issuer would be enough to ensure that the token was issued by Auth0, and this check is performed by the SDK. In the case of organizations, additional checks should be made so that the organization within an Auth0 tenant is expected.
-
-In particular, the `org_id` claim should be checked to ensure it is a value that is already known to the application. This could be validated against a known list of organization IDs, or perhaps checked in conjunction with the current request URL. e.g. the sub-domain may hint at what organization should be used to validate the ID Token.
-
-If the claim cannot be validated, then the application should deem the token invalid.
-
-The following example demonstrates how you can add custom validation by comparing the `org_id` claim to a pre-configured list of expected organization IDs:
+If you don't provide an `organization` parameter at login, the SDK can't validate the `org_id` claim you get back in the ID Token. In that case, you should validate the `org_id` claim yourself (e.g. by checking it against a list of valid organization ID's or comparing it with the application's URL).
 
 ```
 services.AddAuth0WebAppAuthentication(options =>

--- a/docs-source/index.md
+++ b/docs-source/index.md
@@ -272,17 +272,7 @@ await HttpContext.ChallengeAsync(Auth0Constants.AuthenticationScheme, authentica
 
 #### Organization Claim Validation
 
-Even though the SDK takes care of validating the `org_id` claim in some common scenario's, it is unable to cover all scenario's.
-
-If no `organization` parameter was given to the authorization endpoint, but an `org_id` claim is present in the ID Token, then the claim should be validated by the application to ensure that the value received is expected or known.
-
-Normally, validating the issuer would be enough to ensure that the token was issued by Auth0, and this check is performed by the SDK. In the case of organizations, additional checks should be made so that the organization within an Auth0 tenant is expected.
-
-In particular, the `org_id` claim should be checked to ensure it is a value that is already known to the application. This could be validated against a known list of organization IDs, or perhaps checked in conjunction with the current request URL. e.g. the sub-domain may hint at what organization should be used to validate the ID Token.
-
-If the claim cannot be validated, then the application should deem the token invalid.
-
-The following example demonstrates how you can add custom validation by comparing the `org_id` claim to a pre-configured list of expected organization IDs:
+If you don't provide an `organization` parameter at login, the SDK can't validate the `org_id` claim you get back in the ID Token. In that case, you should validate the `org_id` claim yourself (e.g. by checking it against a list of valid organization ID's or comparing it with the application's URL).
 
 ```
 services.AddAuth0WebAppAuthentication(options =>

--- a/docs/index.html
+++ b/docs/index.html
@@ -280,12 +280,7 @@ await HttpContext.ChallengeAsync(Auth0Constants.AuthenticationScheme, authentica
 <p>Specifying the Organization when calling <code>HttpContext.ChallengeAsync</code> will take precedence over any globally configured Organization.</p>
 </div>
 <h4 id="organization-claim-validation">Organization Claim Validation</h4>
-<p>Even though the SDK takes care of validating the <code>org_id</code> claim in some common scenario's, it is unable to cover all scenario's.</p>
-<p>If no <code>organization</code> parameter was given to the authorization endpoint, but an <code>org_id</code> claim is present in the ID Token, then the claim should be validated by the application to ensure that the value received is expected or known.</p>
-<p>Normally, validating the issuer would be enough to ensure that the token was issued by Auth0, and this check is performed by the SDK. In the case of organizations, additional checks should be made so that the organization within an Auth0 tenant is expected.</p>
-<p>In particular, the <code>org_id</code> claim should be checked to ensure it is a value that is already known to the application. This could be validated against a known list of organization IDs, or perhaps checked in conjunction with the current request URL. e.g. the sub-domain may hint at what organization should be used to validate the ID Token.</p>
-<p>If the claim cannot be validated, then the application should deem the token invalid.</p>
-<p>The following example demonstrates how you can add custom validation by comparing the <code>org_id</code> claim to a pre-configured list of expected organization IDs:</p>
+<p>If you don't provide an <code>organization</code> parameter at login, the SDK can't validate the <code>org_id</code> claim you get back in the ID Token. In that case, you should validate the <code>org_id</code> claim yourself (e.g. by checking it against a list of valid organization ID's or comparing it with the application's URL).</p>
 <pre><code>services.AddAuth0WebAppAuthentication(options =&gt;
 {
     options.Domain = Configuration[&quot;Auth0:Domain&quot;];

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -31,7 +31,7 @@
       "output": {
         ".html": {
           "relative_path": "index.html",
-          "hash": "mZi+GIZefbl8zK2/cq2dfK7snC8p/CNp9M1FetmQQY4="
+          "hash": "FRNH/wY5k9gcYRCe7vp+5NJHryt2qc2YjYlTLz59N1k="
         }
       },
       "is_incremental": false,
@@ -46,7 +46,7 @@
           "hash": "hVs8KJgjTi4issLRkiUNjWjJL50UOSEDdpiXs27K878="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -58,7 +58,7 @@
           "hash": "BIMLLut/Mk0VtgNxFaQhe8e/iz1X9iZJufFRDJuw3Aw="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -70,7 +70,7 @@
           "hash": "O/H76P0/SwO0MALo01TrTAxQz+fmHS0+7l+QrQRila4="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -82,7 +82,7 @@
           "hash": "pROE4JMKrSM8d7OQiIT6Os9Ssfp/bvmQgwZQhVTv6qI="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -94,7 +94,7 @@
           "hash": "Tr9+4u6Pexbxj7NG14MMWKcZF/1KXCXgIX4wzSfKNUk="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -106,7 +106,7 @@
           "hash": "zG2Q/FnIx2ZOCMRsXMfFHSmU0mlSkfrcav1R+/L6wFQ="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -118,7 +118,7 @@
           "hash": "ZrCj5eUny8VnD+p6v2PFL3x+goUe0/ydCAOLxPMKUuQ="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -130,7 +130,7 @@
           "hash": "9jXI+H+No6eKculVYMmYj0w19OcCauCZ1UBSg4XsmgM="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -142,7 +142,7 @@
           "hash": "Vq2uph7cIefIcyeWnSWQdQ+dmkG18lufb63uyY9DuHI="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -154,7 +154,7 @@
           "hash": "m9DYtK9GaCKsmZdOk4pafclKhBOjyZ16oGgE/in7p9c="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -166,7 +166,7 @@
           "hash": "nACArSOpUgdOeEw1CdVm4clHpq7I4/8vH2ogo5JUX4E="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -178,7 +178,7 @@
           "hash": "6GGhvvnUrGYIoZn+y2Dt/lE9K6BvQAJPkB7I5vc39to="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -190,7 +190,7 @@
           "hash": "3XGW+r+9kB5dNQ8wkLuiEHrAk9SLjFMwDvbBRqbHyaA="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -237,7 +237,7 @@
           "can_incremental": true,
           "incrementalPhase": "build",
           "total_file_count": 13,
-          "skipped_file_count": 1
+          "skipped_file_count": 13
         },
         "ResourceDocumentProcessor": {
           "can_incremental": false,


### PR DESCRIPTION
This PR adds guidance around organization claim validation in the situation where the SDK can not validate that for the user.

In that case, the idea is that the user is expected to validate the organization claim themselves by comparing it to either a predefined list of organization IDs, or by comparing it to anything else that indicates the organization (e.g. URL).