### PR TITLE
Add custom scheme support to AddAuth0WebAppAuthentication

### DIFF
--- a/src/Auth0.AspNetCore.Authentication/AuthenticationBuilderExtensions.cs
+++ b/src/Auth0.AspNetCore.Authentication/AuthenticationBuilderExtensions.cs
@@ -30,15 +30,33 @@ namespace Auth0.AspNetCore.Authentication
 
         public static Auth0WebAppAuthenticationBuilder AddAuth0WebAppAuthentication(this AuthenticationBuilder builder, Action<Auth0WebAppOptions> configureOptions)
         {
+            return AddAuth0WebAppAuthentication(builder, Auth0Constants.AuthenticationScheme, configureOptions);
+        }
+
+        /// <summary>
+        /// Add Auth0 configuration using Open ID Connect
+        /// </summary>
+        /// <param name="builder">The original <see href="https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.authentication.authenticationbuilder">AuthenticationBuilder</see> instance</param>
+        /// <param name="authenticationScheme">A delegate used to configure the <see cref="Auth0WebAppOptions"/></param>
+        /// <param name="configureOptions">A delegate used to configure the <see cref="Auth0WebAppOptions"/></param>
+        /// <returns>The <see href="https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.authentication.authenticationbuilder">AuthenticationBuilder</see> instance that has been configured.</returns>
+
+        public static Auth0WebAppAuthenticationBuilder AddAuth0WebAppAuthentication(this AuthenticationBuilder builder, string authenticationScheme, Action<Auth0WebAppOptions> configureOptions)
+        {
             var auth0Options = new Auth0WebAppOptions();
 
             configureOptions(auth0Options);
             ValidateOptions(auth0Options);
 
-            builder.AddCookie();
-            builder.AddOpenIdConnect(Auth0Constants.AuthenticationScheme, options => ConfigureOpenIdConnect(options, auth0Options));
+            builder.AddOpenIdConnect(authenticationScheme, options => ConfigureOpenIdConnect(options, auth0Options));
 
-            builder.Services.AddSingleton(auth0Options);
+            // Only add Cookie Authentication and Auth0WebAppOptions if configuring for the default Auth0 Scheme
+            if (authenticationScheme == Auth0Constants.AuthenticationScheme)
+            {
+                builder.AddCookie();
+                builder.Services.AddSingleton(auth0Options);
+            }
+
             builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<IPostConfigureOptions<OpenIdConnectOptions>, Auth0OpenIdConnectPostConfigureOptions>());
 
             return new Auth0WebAppAuthenticationBuilder(builder.Services, auth0Options);

--- a/tests/Auth0.AspNetCore.Authentication.IntegrationTests/Controllers/AccountController.cs
+++ b/tests/Auth0.AspNetCore.Authentication.IntegrationTests/Controllers/AccountController.cs
@@ -18,7 +18,8 @@ namespace Auth0.AspNetCore.Authentication.IntegrationTests.Controllers
             [FromQuery(Name = "extraParameters")] Dictionary<string, string> extraParameters = null,
             string organization = null,
             string invitation = null,
-            string audience = null)
+            string audience = null,
+            string scheme = null)
         {
             var authenticationPropertiesBuilder = new LoginAuthenticationPropertiesBuilder().WithRedirectUri(returnUrl);
 
@@ -32,7 +33,6 @@ namespace Auth0.AspNetCore.Authentication.IntegrationTests.Controllers
                 {
                     authenticationPropertiesBuilder = authenticationPropertiesBuilder.WithParameter(entry.Key, entry.Value);
                 }
-
             }
 
             if (!string.IsNullOrWhiteSpace(organization))
@@ -51,7 +51,7 @@ namespace Auth0.AspNetCore.Authentication.IntegrationTests.Controllers
             }
 
             var authenticationProperties = authenticationPropertiesBuilder.Build();
-            await HttpContext.ChallengeAsync(Auth0Constants.AuthenticationScheme, authenticationProperties);
+            await HttpContext.ChallengeAsync(scheme ?? Auth0Constants.AuthenticationScheme, authenticationProperties);
         }
 
         [Authorize]

--- a/tests/Auth0.AspNetCore.Authentication.IntegrationTests/appsettings.json
+++ b/tests/Auth0.AspNetCore.Authentication.IntegrationTests/appsettings.json
@@ -11,5 +11,10 @@
     "Domain": "dx-sdks-testing.us.auth0.com",
     "ClientId": "123",
     "ClientSecret": "123"
+  },
+  "Auth0:ExtraProvider": {
+    "Domain": "dx-sdks-testing.us.auth0.com",
+    "ClientId": "456",
+    "ClientSecret": "567"
   }
 }


### PR DESCRIPTION
### Description
This PR adds support for specifying a custom scheme in order to add more than one Auth0 connection to a web application. 

In order to minimize breaking change for existing users, adding a custom scheme means that cookie authentication is assumed to be added already the `AuthenticationBuilder` as well as that the `Auth0WebAppOptions` is not added. 

### References
See GitHub issue #55 

### Testing
I added some initial integration tests but do take suggestions for which tests might be useful to add, or if the tests should be restructured completely to support testing extra providers in a different way.

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `main`
