### PR TITLE
[SDK-3100] Add support for specifying scheme

### DIFF
--- a/playground/Auth0.AspNetCore.Authentication.Playground/Controllers/AccountController.cs
+++ b/playground/Auth0.AspNetCore.Authentication.Playground/Controllers/AccountController.cs
@@ -21,6 +21,15 @@ namespace Auth0.AspNetCore.Authentication.Playground.Controllers
             await HttpContext.ChallengeAsync(PlaygroundConstants.AuthenticationScheme, authenticationProperties);
         }
 
+        public async Task Login2(string returnUrl = "/")
+        {
+            var authenticationProperties = new LoginAuthenticationPropertiesBuilder()
+                .WithRedirectUri(returnUrl)
+                .Build();
+
+            await HttpContext.ChallengeAsync(PlaygroundConstants.AuthenticationScheme2, authenticationProperties);
+        }
+
         [Authorize]
         public async Task Logout()
         {
@@ -32,6 +41,20 @@ namespace Auth0.AspNetCore.Authentication.Playground.Controllers
                 .Build();
 
             await HttpContext.SignOutAsync(PlaygroundConstants.AuthenticationScheme, authenticationProperties);
+            await HttpContext.SignOutAsync(CookieAuthenticationDefaults.AuthenticationScheme);
+        }
+
+        [Authorize]
+        public async Task Logout2()
+        {
+            // Indicate here where Auth0 should redirect the user after a logout.
+            // Note that the resulting absolute Uri must be whitelisted in the
+            // **Allowed Logout URLs** settings for the client.
+            var authenticationProperties = new LogoutAuthenticationPropertiesBuilder()
+                .WithRedirectUri(Url.Action("Index", "Home"))
+                .Build();
+
+            await HttpContext.SignOutAsync(PlaygroundConstants.AuthenticationScheme2, authenticationProperties);
             await HttpContext.SignOutAsync(CookieAuthenticationDefaults.AuthenticationScheme);
         }
 

--- a/playground/Auth0.AspNetCore.Authentication.Playground/Controllers/AccountController.cs
+++ b/playground/Auth0.AspNetCore.Authentication.Playground/Controllers/AccountController.cs
@@ -41,7 +41,7 @@ namespace Auth0.AspNetCore.Authentication.Playground.Controllers
                 .Build();
 
             await HttpContext.SignOutAsync(PlaygroundConstants.AuthenticationScheme, authenticationProperties);
-            await HttpContext.SignOutAsync(CookieAuthenticationDefaults.AuthenticationScheme);
+            await HttpContext.SignOutAsync(PlaygroundConstants.CookieAuthenticationScheme);
         }
 
         [Authorize]
@@ -55,7 +55,7 @@ namespace Auth0.AspNetCore.Authentication.Playground.Controllers
                 .Build();
 
             await HttpContext.SignOutAsync(PlaygroundConstants.AuthenticationScheme2, authenticationProperties);
-            await HttpContext.SignOutAsync(CookieAuthenticationDefaults.AuthenticationScheme);
+            await HttpContext.SignOutAsync(PlaygroundConstants.CookieAuthenticationScheme2);
         }
 
         [Authorize]

--- a/playground/Auth0.AspNetCore.Authentication.Playground/Controllers/AccountController.cs
+++ b/playground/Auth0.AspNetCore.Authentication.Playground/Controllers/AccountController.cs
@@ -41,7 +41,7 @@ namespace Auth0.AspNetCore.Authentication.Playground.Controllers
                 .Build();
 
             await HttpContext.SignOutAsync(PlaygroundConstants.AuthenticationScheme, authenticationProperties);
-            await HttpContext.SignOutAsync(PlaygroundConstants.CookieAuthenticationScheme);
+            await HttpContext.SignOutAsync(CookieAuthenticationDefaults.AuthenticationScheme);
         }
 
         [Authorize]
@@ -55,7 +55,7 @@ namespace Auth0.AspNetCore.Authentication.Playground.Controllers
                 .Build();
 
             await HttpContext.SignOutAsync(PlaygroundConstants.AuthenticationScheme2, authenticationProperties);
-            await HttpContext.SignOutAsync(PlaygroundConstants.CookieAuthenticationScheme2);
+            await HttpContext.SignOutAsync(CookieAuthenticationDefaults.AuthenticationScheme);
         }
 
         [Authorize]

--- a/playground/Auth0.AspNetCore.Authentication.Playground/Controllers/AccountController.cs
+++ b/playground/Auth0.AspNetCore.Authentication.Playground/Controllers/AccountController.cs
@@ -18,7 +18,7 @@ namespace Auth0.AspNetCore.Authentication.Playground.Controllers
                 .WithRedirectUri(returnUrl)
                 .Build();
 
-            await HttpContext.ChallengeAsync(Auth0Constants.AuthenticationScheme, authenticationProperties);
+            await HttpContext.ChallengeAsync("fdsfsd", authenticationProperties);
         }
 
         [Authorize]
@@ -31,7 +31,7 @@ namespace Auth0.AspNetCore.Authentication.Playground.Controllers
                 .WithRedirectUri(Url.Action("Index", "Home"))
                 .Build();
 
-            await HttpContext.SignOutAsync(Auth0Constants.AuthenticationScheme, authenticationProperties);
+            await HttpContext.SignOutAsync("fdsfsd", authenticationProperties);
             await HttpContext.SignOutAsync(CookieAuthenticationDefaults.AuthenticationScheme);
         }
 

--- a/playground/Auth0.AspNetCore.Authentication.Playground/Controllers/AccountController.cs
+++ b/playground/Auth0.AspNetCore.Authentication.Playground/Controllers/AccountController.cs
@@ -18,7 +18,7 @@ namespace Auth0.AspNetCore.Authentication.Playground.Controllers
                 .WithRedirectUri(returnUrl)
                 .Build();
 
-            await HttpContext.ChallengeAsync("fdsfsd", authenticationProperties);
+            await HttpContext.ChallengeAsync(PlaygroundConstants.AuthenticationScheme, authenticationProperties);
         }
 
         [Authorize]
@@ -31,7 +31,7 @@ namespace Auth0.AspNetCore.Authentication.Playground.Controllers
                 .WithRedirectUri(Url.Action("Index", "Home"))
                 .Build();
 
-            await HttpContext.SignOutAsync("fdsfsd", authenticationProperties);
+            await HttpContext.SignOutAsync(PlaygroundConstants.AuthenticationScheme, authenticationProperties);
             await HttpContext.SignOutAsync(CookieAuthenticationDefaults.AuthenticationScheme);
         }
 

--- a/playground/Auth0.AspNetCore.Authentication.Playground/Controllers/HomeController.cs
+++ b/playground/Auth0.AspNetCore.Authentication.Playground/Controllers/HomeController.cs
@@ -8,11 +8,6 @@ namespace Auth0.AspNetCore.Authentication.Playground.Controllers
 {
     public class HomeController : Controller
     {
-        private readonly Auth0WebAppOptions _snapshotOptions;
-        public HomeController(IOptionsSnapshot<Auth0WebAppOptions> namedOptionsAccessor)
-        {
-            _snapshotOptions = namedOptionsAccessor.Get(Auth0Constants.AuthenticationScheme);
-        }
         public IActionResult Index()
         {
             return View();

--- a/playground/Auth0.AspNetCore.Authentication.Playground/Controllers/HomeController.cs
+++ b/playground/Auth0.AspNetCore.Authentication.Playground/Controllers/HomeController.cs
@@ -1,13 +1,18 @@
 ﻿using Auth0.AspNetCore.Authentication.Playground.Models;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
 using System.Diagnostics;
 
 namespace Auth0.AspNetCore.Authentication.Playground.Controllers
 {
     public class HomeController : Controller
     {
-
+        private readonly Auth0WebAppOptions _snapshotOptions;
+        public HomeController(IOptionsSnapshot<Auth0WebAppOptions> namedOptionsAccessor)
+        {
+            _snapshotOptions = namedOptionsAccessor.Get(Auth0Constants.AuthenticationScheme);
+        }
         public IActionResult Index()
         {
             return View();

--- a/playground/Auth0.AspNetCore.Authentication.Playground/Controllers/HomeController.cs
+++ b/playground/Auth0.AspNetCore.Authentication.Playground/Controllers/HomeController.cs
@@ -1,7 +1,6 @@
 ﻿using Auth0.AspNetCore.Authentication.Playground.Models;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.Options;
 using System.Diagnostics;
 
 namespace Auth0.AspNetCore.Authentication.Playground.Controllers

--- a/playground/Auth0.AspNetCore.Authentication.Playground/PlaygroundConstants.cs
+++ b/playground/Auth0.AspNetCore.Authentication.Playground/PlaygroundConstants.cs
@@ -6,5 +6,9 @@
         /// The Authentication Scheme, used when configuring OpenIdConnect
         /// </summary>
         public static string AuthenticationScheme = "Auth0";
+        /// <summary>
+        /// The second Authentication Scheme, used when configuring OpenIdConnect
+        /// </summary>
+        public static string AuthenticationScheme2 = "Auth02";
     }
 }

--- a/playground/Auth0.AspNetCore.Authentication.Playground/PlaygroundConstants.cs
+++ b/playground/Auth0.AspNetCore.Authentication.Playground/PlaygroundConstants.cs
@@ -1,0 +1,10 @@
+﻿namespace Auth0.AspNetCore.Authentication.Playground
+{
+    internal class PlaygroundConstants
+    {
+        /// <summary>
+        /// The Authentication Scheme, used when configuring OpenIdConnect
+        /// </summary>
+        public static string AuthenticationScheme = "Auth0";
+    }
+}

--- a/playground/Auth0.AspNetCore.Authentication.Playground/PlaygroundConstants.cs
+++ b/playground/Auth0.AspNetCore.Authentication.Playground/PlaygroundConstants.cs
@@ -10,5 +10,13 @@
         /// The second Authentication Scheme, used when configuring OpenIdConnect
         /// </summary>
         public static string AuthenticationScheme2 = "Auth02";
+        /// <summary>
+        /// The Authentication Scheme, used when configuring OpenIdConnect
+        /// </summary>
+        public static string CookieAuthenticationScheme = "Auth0.Cookies";
+        /// <summary>
+        /// The Authentication Scheme, used when configuring OpenIdConnect
+        /// </summary>
+        public static string CookieAuthenticationScheme2 = "Auth02.Cookies";
     }
 }

--- a/playground/Auth0.AspNetCore.Authentication.Playground/Startup.cs
+++ b/playground/Auth0.AspNetCore.Authentication.Playground/Startup.cs
@@ -20,7 +20,13 @@ namespace Auth0.AspNetCore.Authentication.Playground
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
-            services.AddAuth0WebAppAuthentication(options =>
+            services.AddAuthentication(options =>
+            {
+                options.DefaultAuthenticateScheme = CookieAuthenticationDefaults.AuthenticationScheme;
+                options.DefaultSignInScheme = CookieAuthenticationDefaults.AuthenticationScheme;
+                options.DefaultChallengeScheme = CookieAuthenticationDefaults.AuthenticationScheme;
+            })
+                .AddAuth0WebAppAuthentication("fdsfsd", options =>
             {
                 options.Domain = Configuration["Auth0:Domain"];
                 options.ClientId = Configuration["Auth0:ClientId"];
@@ -36,7 +42,7 @@ namespace Auth0.AspNetCore.Authentication.Playground
                     {
                         await context.SignOutAsync(CookieAuthenticationDefaults.AuthenticationScheme);
                         var authenticationProperties = new LoginAuthenticationPropertiesBuilder().WithRedirectUri("/").Build();
-                        await context.ChallengeAsync(Auth0Constants.AuthenticationScheme, authenticationProperties);
+                        await context.ChallengeAsync("fdsfsd", authenticationProperties);
                     }
                 };
             });

--- a/playground/Auth0.AspNetCore.Authentication.Playground/Startup.cs
+++ b/playground/Auth0.AspNetCore.Authentication.Playground/Startup.cs
@@ -22,16 +22,17 @@ namespace Auth0.AspNetCore.Authentication.Playground
         {
             var authBuilder = services.AddAuthentication(options =>
             {
-                options.DefaultAuthenticateScheme = CookieAuthenticationDefaults.AuthenticationScheme;
-                options.DefaultSignInScheme = CookieAuthenticationDefaults.AuthenticationScheme;
-                options.DefaultChallengeScheme = CookieAuthenticationDefaults.AuthenticationScheme;
-            });
-                
+                options.DefaultAuthenticateScheme = PlaygroundConstants.CookieAuthenticationScheme;
+                options.DefaultSignInScheme = PlaygroundConstants.CookieAuthenticationScheme;
+                options.DefaultChallengeScheme = PlaygroundConstants.CookieAuthenticationScheme;
+            }).AddCookie(PlaygroundConstants.CookieAuthenticationScheme);
+
             authBuilder.AddAuth0WebAppAuthentication(PlaygroundConstants.AuthenticationScheme, options =>
             {
                 options.Domain = Configuration["Auth0:Domain"];
                 options.ClientId = Configuration["Auth0:ClientId"];
                 options.ClientSecret = Configuration["Auth0:ClientSecret"];
+                options.AddCookieMiddleware = false;
             }).WithAccessToken(options =>
             {
                 options.Audience = Configuration["Auth0:Audience"];
@@ -48,7 +49,14 @@ namespace Auth0.AspNetCore.Authentication.Playground
                 };
             });
 
-            authBuilder.AddAuth0WebAppAuthentication(PlaygroundConstants.AuthenticationScheme2, options =>
+            var authBuilder2 = services.AddAuthentication(options =>
+            {
+                options.DefaultAuthenticateScheme = PlaygroundConstants.CookieAuthenticationScheme2;
+                options.DefaultSignInScheme = PlaygroundConstants.CookieAuthenticationScheme2;
+                options.DefaultChallengeScheme = PlaygroundConstants.CookieAuthenticationScheme2;
+            }).AddCookie(PlaygroundConstants.CookieAuthenticationScheme2);
+
+            authBuilder2.AddAuth0WebAppAuthentication(PlaygroundConstants.AuthenticationScheme2, options =>
             {
                 options.Domain = Configuration["Auth02:Domain"];
                 options.ClientId = Configuration["Auth02:ClientId"];

--- a/playground/Auth0.AspNetCore.Authentication.Playground/Startup.cs
+++ b/playground/Auth0.AspNetCore.Authentication.Playground/Startup.cs
@@ -20,13 +20,14 @@ namespace Auth0.AspNetCore.Authentication.Playground
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
-            services.AddAuthentication(options =>
+            var authBuilder = services.AddAuthentication(options =>
             {
                 options.DefaultAuthenticateScheme = CookieAuthenticationDefaults.AuthenticationScheme;
                 options.DefaultSignInScheme = CookieAuthenticationDefaults.AuthenticationScheme;
                 options.DefaultChallengeScheme = CookieAuthenticationDefaults.AuthenticationScheme;
-            })
-                .AddAuth0WebAppAuthentication(PlaygroundConstants.AuthenticationScheme, options =>
+            });
+                
+            authBuilder.AddAuth0WebAppAuthentication(PlaygroundConstants.AuthenticationScheme, options =>
             {
                 options.Domain = Configuration["Auth0:Domain"];
                 options.ClientId = Configuration["Auth0:ClientId"];
@@ -43,6 +44,29 @@ namespace Auth0.AspNetCore.Authentication.Playground
                         await context.SignOutAsync(CookieAuthenticationDefaults.AuthenticationScheme);
                         var authenticationProperties = new LoginAuthenticationPropertiesBuilder().WithRedirectUri("/").Build();
                         await context.ChallengeAsync(PlaygroundConstants.AuthenticationScheme, authenticationProperties);
+                    }
+                };
+            });
+
+            authBuilder.AddAuth0WebAppAuthentication(PlaygroundConstants.AuthenticationScheme2, options =>
+            {
+                options.Domain = Configuration["Auth02:Domain"];
+                options.ClientId = Configuration["Auth02:ClientId"];
+                options.ClientSecret = Configuration["Auth02:ClientSecret"];
+                options.AddCookieMiddleware = false;
+                options.CallbackPath = "/callback2";
+            }).WithAccessToken(options =>
+            {
+                options.Audience = Configuration["Auth02:Audience"];
+                options.UseRefreshTokens = true;
+
+                options.Events = new Auth0WebAppWithAccessTokenEvents
+                {
+                    OnMissingRefreshToken = async (context) =>
+                    {
+                        await context.SignOutAsync(CookieAuthenticationDefaults.AuthenticationScheme);
+                        var authenticationProperties = new LoginAuthenticationPropertiesBuilder().WithRedirectUri("/").Build();
+                        await context.ChallengeAsync(PlaygroundConstants.AuthenticationScheme2, authenticationProperties);
                     }
                 };
             });

--- a/playground/Auth0.AspNetCore.Authentication.Playground/Startup.cs
+++ b/playground/Auth0.AspNetCore.Authentication.Playground/Startup.cs
@@ -26,7 +26,7 @@ namespace Auth0.AspNetCore.Authentication.Playground
                 options.DefaultSignInScheme = CookieAuthenticationDefaults.AuthenticationScheme;
                 options.DefaultChallengeScheme = CookieAuthenticationDefaults.AuthenticationScheme;
             })
-                .AddAuth0WebAppAuthentication("fdsfsd", options =>
+                .AddAuth0WebAppAuthentication(PlaygroundConstants.AuthenticationScheme, options =>
             {
                 options.Domain = Configuration["Auth0:Domain"];
                 options.ClientId = Configuration["Auth0:ClientId"];
@@ -42,7 +42,7 @@ namespace Auth0.AspNetCore.Authentication.Playground
                     {
                         await context.SignOutAsync(CookieAuthenticationDefaults.AuthenticationScheme);
                         var authenticationProperties = new LoginAuthenticationPropertiesBuilder().WithRedirectUri("/").Build();
-                        await context.ChallengeAsync("fdsfsd", authenticationProperties);
+                        await context.ChallengeAsync(PlaygroundConstants.AuthenticationScheme, authenticationProperties);
                     }
                 };
             });

--- a/playground/Auth0.AspNetCore.Authentication.Playground/Views/Shared/_Layout.cshtml
+++ b/playground/Auth0.AspNetCore.Authentication.Playground/Views/Shared/_Layout.cshtml
@@ -31,10 +31,12 @@
                         {
                             <li><a asp-controller="Account" class="nav-link" asp-action="Profile">Hello @User.Identity.Name!</a></li>
                             <li><a id="qsLogoutBtn" class="nav-link" asp-controller="Account" asp-action="Logout">Logout</a></li>
+                            <li><a id="qsLogoutBtn" class="nav-link" asp-controller="Account" asp-action="Logout2">Logout (2nd provider)</a></li>
                         }
                         else
                         {
                             <li><a id="qsLoginBtn" class="nav-link" asp-controller="Account" asp-action="Login">Login</a></li>
+                            <li><a id="qsLoginBtn" class="nav-link" asp-controller="Account" asp-action="Login2">Login (2nd provider)</a></li>
                         }
                     </ul>
                 </div>

--- a/playground/Auth0.AspNetCore.Authentication.Playground/appsettings.json
+++ b/playground/Auth0.AspNetCore.Authentication.Playground/appsettings.json
@@ -12,5 +12,11 @@
     "ClientId": "{CLIENT_ID}",
     "ClientSecret": "{CLIENT_SECRET}",
     "Audience": "{API_IDENTIFIER}"
+  },
+  "Auth02": {
+    "Domain": "{DOMAIN}",
+    "ClientId": "{CLIENT_ID}",
+    "ClientSecret": "{CLIENT_SECRET}",
+    "Audience": "{API_IDENTIFIER}"
   }
 }

--- a/src/Auth0.AspNetCore.Authentication/Auth0WebAppAuthenticationBuilder.cs
+++ b/src/Auth0.AspNetCore.Authentication/Auth0WebAppAuthenticationBuilder.cs
@@ -16,6 +16,15 @@ namespace Auth0.AspNetCore.Authentication
         /// Constructs an instance of <see cref="Auth0WebAppAuthenticationBuilder"/>
         /// </summary>
         /// <param name="services">The original <see href="https://docs.microsoft.com/en-us/dotnet/api/microsoft.extensions.dependencyinjection.iservicecollection">IServiceCollection</see> instance</param>
+        /// <param name="options">The <see cref="Auth0WebAppOptions"/> used when calling AddAuth0WebAppAuthentication.</param>
+        public Auth0WebAppAuthenticationBuilder(IServiceCollection services, Auth0WebAppOptions options) : this(services, Auth0Constants.AuthenticationScheme, options)
+        {
+        }
+
+        /// <summary>
+        /// Constructs an instance of <see cref="Auth0WebAppAuthenticationBuilder"/>
+        /// </summary>
+        /// <param name="services">The original <see href="https://docs.microsoft.com/en-us/dotnet/api/microsoft.extensions.dependencyinjection.iservicecollection">IServiceCollection</see> instance</param>
         /// <param name="authenticationScheme">The authentication scheme to use.</param>
         /// <param name="options">The <see cref="Auth0WebAppOptions"/> used when calling AddAuth0WebAppAuthentication.</param>
         public Auth0WebAppAuthenticationBuilder(IServiceCollection services, string authenticationScheme, Auth0WebAppOptions options)

--- a/src/Auth0.AspNetCore.Authentication/Auth0WebAppAuthenticationBuilder.cs
+++ b/src/Auth0.AspNetCore.Authentication/Auth0WebAppAuthenticationBuilder.cs
@@ -17,11 +17,11 @@ namespace Auth0.AspNetCore.Authentication
         /// </summary>
         /// <param name="services">The original <see href="https://docs.microsoft.com/en-us/dotnet/api/microsoft.extensions.dependencyinjection.iservicecollection">IServiceCollection</see> instance</param>
         /// <param name="options">The <see cref="Auth0WebAppOptions"/> used when calling AddAuth0WebAppAuthentication.</param>
-        public Auth0WebAppAuthenticationBuilder(IServiceCollection services, Auth0WebAppOptions options, string? authenticationScheme)
+        public Auth0WebAppAuthenticationBuilder(IServiceCollection services, string authenticationScheme, Auth0WebAppOptions options)
         {
             _services = services;
             _options = options;
-            _authenticationScheme = authenticationScheme ?? Auth0Constants.AuthenticationScheme;
+            _authenticationScheme = authenticationScheme;
         }
 
         /// <summary>

--- a/src/Auth0.AspNetCore.Authentication/Auth0WebAppAuthenticationBuilder.cs
+++ b/src/Auth0.AspNetCore.Authentication/Auth0WebAppAuthenticationBuilder.cs
@@ -10,16 +10,18 @@ namespace Auth0.AspNetCore.Authentication
     {
         private readonly IServiceCollection _services;
         private readonly Auth0WebAppOptions _options;
+        private readonly string _authenticationScheme;
 
         /// <summary>
         /// Constructs an instance of <see cref="Auth0WebAppAuthenticationBuilder"/>
         /// </summary>
         /// <param name="services">The original <see href="https://docs.microsoft.com/en-us/dotnet/api/microsoft.extensions.dependencyinjection.iservicecollection">IServiceCollection</see> instance</param>
         /// <param name="options">The <see cref="Auth0WebAppOptions"/> used when calling AddAuth0WebAppAuthentication.</param>
-        public Auth0WebAppAuthenticationBuilder(IServiceCollection services, Auth0WebAppOptions options)
+        public Auth0WebAppAuthenticationBuilder(IServiceCollection services, Auth0WebAppOptions options, string? authenticationScheme)
         {
             _services = services;
             _options = options;
+            _authenticationScheme = authenticationScheme ?? Auth0Constants.AuthenticationScheme;
         }
 
         /// <summary>
@@ -29,7 +31,7 @@ namespace Auth0.AspNetCore.Authentication
         /// <returns>An instance of <see cref="Auth0WebAppWithAccessTokenAuthenticationBuilder"/></returns>
         public Auth0WebAppWithAccessTokenAuthenticationBuilder WithAccessToken(Action<Auth0WebAppWithAccessTokenOptions> configureOptions)
         {
-            return new Auth0WebAppWithAccessTokenAuthenticationBuilder(_services, configureOptions, _options);
+            return new Auth0WebAppWithAccessTokenAuthenticationBuilder(_services, configureOptions, _options, _authenticationScheme);
         }
     }
 }

--- a/src/Auth0.AspNetCore.Authentication/Auth0WebAppAuthenticationBuilder.cs
+++ b/src/Auth0.AspNetCore.Authentication/Auth0WebAppAuthenticationBuilder.cs
@@ -16,6 +16,7 @@ namespace Auth0.AspNetCore.Authentication
         /// Constructs an instance of <see cref="Auth0WebAppAuthenticationBuilder"/>
         /// </summary>
         /// <param name="services">The original <see href="https://docs.microsoft.com/en-us/dotnet/api/microsoft.extensions.dependencyinjection.iservicecollection">IServiceCollection</see> instance</param>
+        /// <param name="authenticationScheme">The authentication scheme to use.</param>
         /// <param name="options">The <see cref="Auth0WebAppOptions"/> used when calling AddAuth0WebAppAuthentication.</param>
         public Auth0WebAppAuthenticationBuilder(IServiceCollection services, string authenticationScheme, Auth0WebAppOptions options)
         {

--- a/src/Auth0.AspNetCore.Authentication/Auth0WebAppOptions.cs
+++ b/src/Auth0.AspNetCore.Authentication/Auth0WebAppOptions.cs
@@ -40,6 +40,12 @@ namespace Auth0.AspNetCore.Authentication
         public string? CallbackPath { get; set; }
 
         /// <summary>
+        /// Whether or not to add the Cookie Middleware.
+        /// </summary>
+        /// <remarks>Defaults to true.</remarks> 
+        public bool AddCookieMiddleware { get; set; } = true;
+
+        /// <summary>
         /// The Id of the organization to which the users should log in to.
         /// </summary>
         public string? Organization { get; set; }

--- a/src/Auth0.AspNetCore.Authentication/Auth0WebAppOptions.cs
+++ b/src/Auth0.AspNetCore.Authentication/Auth0WebAppOptions.cs
@@ -40,10 +40,10 @@ namespace Auth0.AspNetCore.Authentication
         public string? CallbackPath { get; set; }
 
         /// <summary>
-        /// Whether or not to add the Cookie Middleware.
+        /// Whether or not to skip adding the Cookie Middleware.
         /// </summary>
-        /// <remarks>Defaults to true.</remarks> 
-        public bool AddCookieMiddleware { get; set; } = true;
+        /// <remarks>Defaults to false.</remarks> 
+        public bool SkipCookieMiddleware { get; set; } = false;
 
         /// <summary>
         /// The Id of the organization to which the users should log in to.

--- a/src/Auth0.AspNetCore.Authentication/Auth0WebAppWithAccessTokenAuthenticationBuilder.cs
+++ b/src/Auth0.AspNetCore.Authentication/Auth0WebAppWithAccessTokenAuthenticationBuilder.cs
@@ -108,11 +108,12 @@ namespace Auth0.AspNetCore.Authentication
 
                 if (context.Properties.Items.TryGetValue(".AuthScheme", out var authScheme))
                 {
-                    if (authScheme != authenticationScheme)
+                    if (!string.IsNullOrEmpty(authScheme) && authScheme != authenticationScheme)
                     {
                         return;
                     }
                 }
+
                 if (context.Properties.Items.TryGetValue(".Token.access_token", out _))
                 {
                     if (optionsWithAccessToken.UseRefreshTokens)

--- a/src/Auth0.AspNetCore.Authentication/Auth0WebAppWithAccessTokenAuthenticationBuilder.cs
+++ b/src/Auth0.AspNetCore.Authentication/Auth0WebAppWithAccessTokenAuthenticationBuilder.cs
@@ -106,6 +106,13 @@ namespace Auth0.AspNetCore.Authentication
                 var optionsWithAccessToken = context.HttpContext.RequestServices.GetRequiredService<IOptionsSnapshot<Auth0WebAppWithAccessTokenOptions>>().Get(authenticationScheme);
                 var oidcOptions = context.HttpContext.RequestServices.GetRequiredService<IOptionsSnapshot<OpenIdConnectOptions>>().Get(authenticationScheme);
 
+                if (context.Properties.Items.TryGetValue(".AuthScheme", out var authScheme))
+                {
+                    if (authScheme != authenticationScheme)
+                    {
+                        return;
+                    }
+                }
                 if (context.Properties.Items.TryGetValue(".Token.access_token", out _))
                 {
                     if (optionsWithAccessToken.UseRefreshTokens)

--- a/src/Auth0.AspNetCore.Authentication/Auth0WebAppWithAccessTokenAuthenticationBuilder.cs
+++ b/src/Auth0.AspNetCore.Authentication/Auth0WebAppWithAccessTokenAuthenticationBuilder.cs
@@ -20,6 +20,7 @@ namespace Auth0.AspNetCore.Authentication
         private readonly IServiceCollection _services;
         private readonly Action<Auth0WebAppWithAccessTokenOptions> _configureOptions;
         private readonly Auth0WebAppOptions _options;
+        private readonly string _authenticationScheme;
 
         private static readonly IList<string> CodeResponseTypes = new List<string>() {
             OpenIdConnectResponseType.Code,
@@ -32,16 +33,18 @@ namespace Auth0.AspNetCore.Authentication
         /// <param name="services">The original <see href="https://docs.microsoft.com/en-us/dotnet/api/microsoft.extensions.dependencyinjection.iservicecollection">IServiceCollection</see> instance</param>
         /// <param name="configureOptions">A delegate used to configure the <see cref="Auth0WebAppWithAccessTokenOptions"/></param>
         /// <param name="options">The <see cref="Auth0WebAppOptions"/> used when calling AddAuth0WebAppAuthentication.</param>
+        /// <param name="authenticationScheme">The authentication scheme to use.</param>
         public Auth0WebAppWithAccessTokenAuthenticationBuilder(IServiceCollection services, Action<Auth0WebAppWithAccessTokenOptions> configureOptions, Auth0WebAppOptions options, string authenticationScheme)
         {
             _services = services;
             _configureOptions = configureOptions;
             _options = options;
+            _authenticationScheme = authenticationScheme;
 
-            EnableWithAccessToken(authenticationScheme);
+            EnableWithAccessToken();
         }
 
-        private void EnableWithAccessToken(string authenticationScheme)
+        private void EnableWithAccessToken()
         {
             var auth0WithAccessTokensOptions = new Auth0WebAppWithAccessTokenOptions();
 
@@ -49,8 +52,8 @@ namespace Auth0.AspNetCore.Authentication
             
             ValidateOptions(_options);
 
-            _services.Configure(authenticationScheme, _configureOptions);
-            _services.AddOptions<OpenIdConnectOptions>(authenticationScheme)
+            _services.Configure(_authenticationScheme, _configureOptions);
+            _services.AddOptions<OpenIdConnectOptions>(_authenticationScheme)
                 .Configure(options =>
                 {
                     options.ResponseType = OpenIdConnectResponseType.Code;
@@ -65,13 +68,13 @@ namespace Auth0.AspNetCore.Authentication
                         options.Scope.AddSafe("offline_access");
                     }
 
-                    options.Events.OnRedirectToIdentityProvider = Utils.ProxyEvent(CreateOnRedirectToIdentityProvider(authenticationScheme), options.Events.OnRedirectToIdentityProvider);
+                    options.Events.OnRedirectToIdentityProvider = Utils.ProxyEvent(CreateOnRedirectToIdentityProvider(_authenticationScheme), options.Events.OnRedirectToIdentityProvider);
                 });
 
             _services.AddOptions<CookieAuthenticationOptions>(CookieAuthenticationDefaults.AuthenticationScheme)
                 .Configure(options =>
                 {
-                    options.Events.OnValidatePrincipal = Utils.ProxyEvent(CreateOnValidatePrincipal(authenticationScheme), options.Events.OnValidatePrincipal);
+                    options.Events.OnValidatePrincipal = Utils.ProxyEvent(CreateOnValidatePrincipal(_authenticationScheme), options.Events.OnValidatePrincipal);
                 });
         }
 

--- a/src/Auth0.AspNetCore.Authentication/Auth0WebAppWithAccessTokenAuthenticationBuilder.cs
+++ b/src/Auth0.AspNetCore.Authentication/Auth0WebAppWithAccessTokenAuthenticationBuilder.cs
@@ -33,6 +33,17 @@ namespace Auth0.AspNetCore.Authentication
         /// <param name="services">The original <see href="https://docs.microsoft.com/en-us/dotnet/api/microsoft.extensions.dependencyinjection.iservicecollection">IServiceCollection</see> instance</param>
         /// <param name="configureOptions">A delegate used to configure the <see cref="Auth0WebAppWithAccessTokenOptions"/></param>
         /// <param name="options">The <see cref="Auth0WebAppOptions"/> used when calling AddAuth0WebAppAuthentication.</param>
+        public Auth0WebAppWithAccessTokenAuthenticationBuilder(IServiceCollection services, Action<Auth0WebAppWithAccessTokenOptions> configureOptions, Auth0WebAppOptions options) 
+            : this(services, configureOptions, options, Auth0Constants.AuthenticationScheme)
+        {
+        }
+
+        /// <summary>
+        /// Constructs an instance of <see cref="Auth0WebAppWithAccessTokenAuthenticationBuilder"/>
+        /// </summary>
+        /// <param name="services">The original <see href="https://docs.microsoft.com/en-us/dotnet/api/microsoft.extensions.dependencyinjection.iservicecollection">IServiceCollection</see> instance</param>
+        /// <param name="configureOptions">A delegate used to configure the <see cref="Auth0WebAppWithAccessTokenOptions"/></param>
+        /// <param name="options">The <see cref="Auth0WebAppOptions"/> used when calling AddAuth0WebAppAuthentication.</param>
         /// <param name="authenticationScheme">The authentication scheme to use.</param>
         public Auth0WebAppWithAccessTokenAuthenticationBuilder(IServiceCollection services, Action<Auth0WebAppWithAccessTokenOptions> configureOptions, Auth0WebAppOptions options, string authenticationScheme)
         {
@@ -49,7 +60,7 @@ namespace Auth0.AspNetCore.Authentication
             var auth0WithAccessTokensOptions = new Auth0WebAppWithAccessTokenOptions();
 
             _configureOptions(auth0WithAccessTokensOptions);
-            
+
             ValidateOptions(_options);
 
             _services.Configure(_authenticationScheme, _configureOptions);

--- a/src/Auth0.AspNetCore.Authentication/AuthenticationBuilderExtensions.cs
+++ b/src/Auth0.AspNetCore.Authentication/AuthenticationBuilderExtensions.cs
@@ -50,7 +50,7 @@ namespace Auth0.AspNetCore.Authentication
 
             builder.AddOpenIdConnect(authenticationScheme, options => ConfigureOpenIdConnect(options, auth0Options));
 
-            if (auth0Options.AddCookieMiddleware)
+            if (!auth0Options.SkipCookieMiddleware)
             {
                 builder.AddCookie();
             }

--- a/src/Auth0.AspNetCore.Authentication/AuthenticationBuilderExtensions.cs
+++ b/src/Auth0.AspNetCore.Authentication/AuthenticationBuilderExtensions.cs
@@ -58,7 +58,7 @@ namespace Auth0.AspNetCore.Authentication
             builder.Services.Configure(authenticationScheme, configureOptions);
             builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<IPostConfigureOptions<OpenIdConnectOptions>, Auth0OpenIdConnectPostConfigureOptions>());
 
-            return new Auth0WebAppAuthenticationBuilder(builder.Services, auth0Options, authenticationScheme);
+            return new Auth0WebAppAuthenticationBuilder(builder.Services, authenticationScheme, auth0Options);
         }
 
         /// <summary>

--- a/src/Auth0.AspNetCore.Authentication/AuthenticationBuilderExtensions.cs
+++ b/src/Auth0.AspNetCore.Authentication/AuthenticationBuilderExtensions.cs
@@ -37,7 +37,7 @@ namespace Auth0.AspNetCore.Authentication
         /// Add Auth0 configuration using Open ID Connect
         /// </summary>
         /// <param name="builder">The original <see href="https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.authentication.authenticationbuilder">AuthenticationBuilder</see> instance</param>
-        /// <param name="authenticationScheme">A delegate used to configure the <see cref="Auth0WebAppOptions"/></param>
+        /// <param name="authenticationScheme">The authentication scheme to use.</param>
         /// <param name="configureOptions">A delegate used to configure the <see cref="Auth0WebAppOptions"/></param>
         /// <returns>The <see href="https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.authentication.authenticationbuilder">AuthenticationBuilder</see> instance that has been configured.</returns>
 

--- a/src/Auth0.AspNetCore.Authentication/AuthenticationBuilderExtensions.cs
+++ b/src/Auth0.AspNetCore.Authentication/AuthenticationBuilderExtensions.cs
@@ -30,15 +30,33 @@ namespace Auth0.AspNetCore.Authentication
 
         public static Auth0WebAppAuthenticationBuilder AddAuth0WebAppAuthentication(this AuthenticationBuilder builder, Action<Auth0WebAppOptions> configureOptions)
         {
+            return AddAuth0WebAppAuthentication(builder, Auth0Constants.AuthenticationScheme, configureOptions);
+        }
+
+        /// <summary>
+        /// Add Auth0 configuration using Open ID Connect
+        /// </summary>
+        /// <param name="builder">The original <see href="https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.authentication.authenticationbuilder">AuthenticationBuilder</see> instance</param>
+        /// <param name="authenticationScheme">A delegate used to configure the <see cref="Auth0WebAppOptions"/></param>
+        /// <param name="configureOptions">A delegate used to configure the <see cref="Auth0WebAppOptions"/></param>
+        /// <returns>The <see href="https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.authentication.authenticationbuilder">AuthenticationBuilder</see> instance that has been configured.</returns>
+
+        public static Auth0WebAppAuthenticationBuilder AddAuth0WebAppAuthentication(this AuthenticationBuilder builder, string authenticationScheme, Action<Auth0WebAppOptions> configureOptions)
+        {
             var auth0Options = new Auth0WebAppOptions();
 
             configureOptions(auth0Options);
             ValidateOptions(auth0Options);
 
-            builder.AddCookie();
-            builder.AddOpenIdConnect(Auth0Constants.AuthenticationScheme, options => ConfigureOpenIdConnect(options, auth0Options));
+            builder.AddOpenIdConnect(authenticationScheme, options => ConfigureOpenIdConnect(options, auth0Options));
 
-            builder.Services.AddSingleton(auth0Options);
+            // Only add Cookie Authentication and Auth0WebAppOptions if configuring for the default Auth0 Scheme
+            if (authenticationScheme == Auth0Constants.AuthenticationScheme)
+            {
+                builder.AddCookie();
+                builder.Services.AddSingleton(auth0Options);
+            }
+
             builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<IPostConfigureOptions<OpenIdConnectOptions>, Auth0OpenIdConnectPostConfigureOptions>());
 
             return new Auth0WebAppAuthenticationBuilder(builder.Services, auth0Options);

--- a/src/Auth0.AspNetCore.Authentication/AuthenticationBuilderExtensions.cs
+++ b/src/Auth0.AspNetCore.Authentication/AuthenticationBuilderExtensions.cs
@@ -50,16 +50,15 @@ namespace Auth0.AspNetCore.Authentication
 
             builder.AddOpenIdConnect(authenticationScheme, options => ConfigureOpenIdConnect(options, auth0Options));
 
-            // Only add Cookie Authentication and Auth0WebAppOptions if configuring for the default Auth0 Scheme
-            if (authenticationScheme == Auth0Constants.AuthenticationScheme)
+            if (auth0Options.AddCookieMiddleware)
             {
                 builder.AddCookie();
-                builder.Services.AddSingleton(auth0Options);
             }
 
+            builder.Services.Configure(authenticationScheme, configureOptions);
             builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<IPostConfigureOptions<OpenIdConnectOptions>, Auth0OpenIdConnectPostConfigureOptions>());
 
-            return new Auth0WebAppAuthenticationBuilder(builder.Services, auth0Options);
+            return new Auth0WebAppAuthenticationBuilder(builder.Services, auth0Options, authenticationScheme);
         }
 
         /// <summary>

--- a/src/Auth0.AspNetCore.Authentication/ServiceCollectionExtensions.cs
+++ b/src/Auth0.AspNetCore.Authentication/ServiceCollectionExtensions.cs
@@ -17,6 +17,17 @@ namespace Auth0.AspNetCore.Authentication
         /// <returns>The <see cref="Auth0WebAppAuthenticationBuilder"/> instance that has been created.</returns>
         public static Auth0WebAppAuthenticationBuilder AddAuth0WebAppAuthentication(this IServiceCollection services, Action<Auth0WebAppOptions> configureOptions)
         {
+            return services.AddAuth0WebAppAuthentication(Auth0Constants.AuthenticationScheme, configureOptions);
+        }
+
+        /// <summary>
+        /// Add Auth0 configuration using Open ID Connect
+        /// </summary>
+        /// <param name="services">The original <see href="https://docs.microsoft.com/en-us/dotnet/api/microsoft.extensions.dependencyinjection.iservicecollection">IServiceCollection</see> instance</param>
+        /// <param name="configureOptions">A delegate used to configure the <see cref="Auth0WebAppOptions"/></param>
+        /// <returns>The <see cref="Auth0WebAppAuthenticationBuilder"/> instance that has been created.</returns>
+        public static Auth0WebAppAuthenticationBuilder AddAuth0WebAppAuthentication(this IServiceCollection services, string authenticationScheme, Action<Auth0WebAppOptions> configureOptions)
+        {
             return services
                 .AddAuthentication(options =>
                 {
@@ -24,7 +35,7 @@ namespace Auth0.AspNetCore.Authentication
                     options.DefaultSignInScheme = CookieAuthenticationDefaults.AuthenticationScheme;
                     options.DefaultChallengeScheme = CookieAuthenticationDefaults.AuthenticationScheme;
                 })
-                .AddAuth0WebAppAuthentication(configureOptions);
+                .AddAuth0WebAppAuthentication(authenticationScheme, configureOptions);
         }
     }
 }

--- a/tests/Auth0.AspNetCore.Authentication.IntegrationTests/Auth0MiddlewareTests.cs
+++ b/tests/Auth0.AspNetCore.Authentication.IntegrationTests/Auth0MiddlewareTests.cs
@@ -10,7 +10,6 @@ using System.Threading.Tasks;
 using Xunit;
 using System.Net.Http;
 using Microsoft.IdentityModel.Protocols.OpenIdConnect;
-using Microsoft.Extensions.DependencyInjection;
 using System.Net;
 using Auth0.AspNetCore.Authentication.IntegrationTests.Builders;
 using Auth0.AspNetCore.Authentication.IntegrationTests.Extensions;
@@ -1004,6 +1003,7 @@ namespace Auth0.AspNetCore.Authentication.IntegrationTests
             {
                 opts.ClientSecret = "123";
                 opts.Backchannel = new HttpClient(mockHandler.Object);
+                opts.ResponseType = OpenIdConnectResponseType.Code;
 
             }, opts =>
             {
@@ -1048,10 +1048,6 @@ namespace Auth0.AspNetCore.Authentication.IntegrationTests
                     // Pass along the Set-Cookies to ensure `Nonce` and `Correlation` cookies are set.
                     var callbackResponse = (await client.SendAsync(message, setCookie.Value));
 
-                    var opts = server.Services.GetRequiredService<Auth0WebAppOptions>();
-
-                    opts.ResponseType = OpenIdConnectResponseType.Code;
-
                     var response = await client.SendAsync($"{TestServerBuilder.Host}/{TestServerBuilder.Process}", callbackResponse.Headers.GetValues("Set-Cookie"));
 
                     response.Headers.Location.AbsoluteUri.Should().Be("http://missing.at/");
@@ -1088,6 +1084,7 @@ namespace Auth0.AspNetCore.Authentication.IntegrationTests
                         return Task.CompletedTask;
                     }
                 };
+                opts.UseRefreshTokens = true;
             }))
             {
                 using (var client = server.CreateClient())
@@ -1110,10 +1107,6 @@ namespace Auth0.AspNetCore.Authentication.IntegrationTests
 
                     // Pass along the Set-Cookies to ensure `Nonce` and `Correlation` cookies are set.
                     var callbackResponse = (await client.SendAsync(message, setCookie.Value));
-
-                    var opts = server.Services.GetRequiredService<Auth0WebAppWithAccessTokenOptions>();
-
-                    opts.UseRefreshTokens = true;
 
                     var response = await client.SendAsync($"{TestServerBuilder.Host}/{TestServerBuilder.Process}", callbackResponse.Headers.GetValues("Set-Cookie"));
 

--- a/tests/Auth0.AspNetCore.Authentication.IntegrationTests/Controllers/AccountController.cs
+++ b/tests/Auth0.AspNetCore.Authentication.IntegrationTests/Controllers/AccountController.cs
@@ -18,7 +18,8 @@ namespace Auth0.AspNetCore.Authentication.IntegrationTests.Controllers
             [FromQuery(Name = "extraParameters")] Dictionary<string, string> extraParameters = null,
             string organization = null,
             string invitation = null,
-            string audience = null)
+            string audience = null,
+            string scheme = null)
         {
             var authenticationPropertiesBuilder = new LoginAuthenticationPropertiesBuilder().WithRedirectUri(returnUrl);
 
@@ -32,7 +33,6 @@ namespace Auth0.AspNetCore.Authentication.IntegrationTests.Controllers
                 {
                     authenticationPropertiesBuilder = authenticationPropertiesBuilder.WithParameter(entry.Key, entry.Value);
                 }
-
             }
 
             if (!string.IsNullOrWhiteSpace(organization))
@@ -51,7 +51,7 @@ namespace Auth0.AspNetCore.Authentication.IntegrationTests.Controllers
             }
 
             var authenticationProperties = authenticationPropertiesBuilder.Build();
-            await HttpContext.ChallengeAsync(Auth0Constants.AuthenticationScheme, authenticationProperties);
+            await HttpContext.ChallengeAsync(scheme ?? Auth0Constants.AuthenticationScheme, authenticationProperties);
         }
 
         [Authorize]

--- a/tests/Auth0.AspNetCore.Authentication.IntegrationTests/Infrastructure/TestServerBuilder.cs
+++ b/tests/Auth0.AspNetCore.Authentication.IntegrationTests/Infrastructure/TestServerBuilder.cs
@@ -106,7 +106,7 @@ namespace Auth0.AspNetCore.Authentication.IntegrationTests.Infrastructure
                                     {
                                         options.Domain = configuration["Auth0:ExtraProvider:Domain"];
                                         options.ClientId = configuration["Auth0:ExtraProvider:ClientId"];
-                                        options.AddCookieMiddleware = false;
+                                        options.SkipCookieMiddleware = true;
 
                                         if (configureAdditionalOptions != null) configureAdditionalOptions(options);
                                     });

--- a/tests/Auth0.AspNetCore.Authentication.IntegrationTests/Infrastructure/TestServerBuilder.cs
+++ b/tests/Auth0.AspNetCore.Authentication.IntegrationTests/Infrastructure/TestServerBuilder.cs
@@ -106,6 +106,7 @@ namespace Auth0.AspNetCore.Authentication.IntegrationTests.Infrastructure
                                     {
                                         options.Domain = configuration["Auth0:ExtraProvider:Domain"];
                                         options.ClientId = configuration["Auth0:ExtraProvider:ClientId"];
+                                        options.AddCookieMiddleware = false;
 
                                         if (configureAdditionalOptions != null) configureAdditionalOptions(options);
                                     });

--- a/tests/Auth0.AspNetCore.Authentication.IntegrationTests/appsettings.json
+++ b/tests/Auth0.AspNetCore.Authentication.IntegrationTests/appsettings.json
@@ -11,5 +11,10 @@
     "Domain": "dx-sdks-testing.us.auth0.com",
     "ClientId": "123",
     "ClientSecret": "123"
+  },
+  "Auth0:ExtraProvider": {
+    "Domain": "dx-sdks-testing.us.auth0.com",
+    "ClientId": "456",
+    "ClientSecret": "567"
   }
 }


### PR DESCRIPTION
This PR is a continuation of https://github.com/auth0/auth0-aspnetcore-authentication/pull/56, whose intention is to enable the possibility to configure multiple Auth0 providers (each using their own authentication scheme). This is possible when using the underlying OIDC middleware, but wasn't possible when using our SDK prior to this PR.

As it could conflict in terms of cookies, this PR also adds the ability to skip adding cookies by introducing the `skipCookieMiddleware` flag.

Also extended the playground to showcase how running multiple configurations would work.

```csharp
services
    .AddAuth0WebAppAuthentication(PlaygroundConstants.AuthenticationScheme, options =>
    {
        options.Domain = Configuration["Auth0:Domain"];
        options.ClientId = Configuration["Auth0:ClientId"];
    });

services
    .AddAuth0WebAppAuthentication(PlaygroundConstants.AuthenticationScheme2, options =>
    {
        options.Domain = Configuration["Auth02:Domain"];
        options.ClientId = Configuration["Auth02:ClientId"];
        options.SkipCookieMiddleware = true;
        options.CallbackPath = "/callback2";
    });
```