### PR TITLE
Allow override of authentication cookie options, such as login path

### DIFF
--- a/playground/Auth0.AspNetCore.Authentication.Playground/Startup.cs
+++ b/playground/Auth0.AspNetCore.Authentication.Playground/Startup.cs
@@ -27,6 +27,7 @@ namespace Auth0.AspNetCore.Authentication.Playground
                     options.Domain = Configuration["Auth0:Domain"];
                     options.ClientId = Configuration["Auth0:ClientId"];
                     options.ClientSecret = Configuration["Auth0:ClientSecret"];
+                    options.CookieAuthenticationOptions.LoginPath = "/account/login2";
                 })
                 .WithAccessToken(options =>
                 {

--- a/src/Auth0.AspNetCore.Authentication/Auth0WebAppOptions.cs
+++ b/src/Auth0.AspNetCore.Authentication/Auth0WebAppOptions.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Net.Http;
+using Microsoft.AspNetCore.Authentication.Cookies;
 
 namespace Auth0.AspNetCore.Authentication
 {
@@ -44,6 +45,11 @@ namespace Auth0.AspNetCore.Authentication
         /// </summary>
         /// <remarks>Defaults to false.</remarks> 
         public bool SkipCookieMiddleware { get; set; } = false;
+
+        /// <summary>
+        /// Control authentication cookie settings
+        /// </summary>
+        public CookieAuthenticationOptions CookieAuthenticationOptions { get; } = new CookieAuthenticationOptions();
 
         /// <summary>
         /// The Id of the organization to which the users should log in to.

--- a/tests/Auth0.AspNetCore.Authentication.IntegrationTests/Auth0MiddlewareTests.cs
+++ b/tests/Auth0.AspNetCore.Authentication.IntegrationTests/Auth0MiddlewareTests.cs
@@ -29,6 +29,20 @@ namespace Auth0.AspNetCore.Authentication.IntegrationTests
         }
 
         [Fact]
+        public async Task Login_Path_Should_Reflect_Specified_Override()
+        {
+            using (var server = TestServerBuilder.CreateServer(o=>o.CookieAuthenticationOptions.LoginPath = "/xxx", null, false, true))
+            {
+                using (var client = server.CreateClient())
+                {
+                    var response = (await client.SendAsync($"{TestServerBuilder.Host}/{TestServerBuilder.Protected}"));
+                    response.StatusCode.Should().Be(HttpStatusCode.Found);
+                    response.Headers.Location.AbsoluteUri.Should().Contain("xxx");
+                }
+            }
+        }
+
+        [Fact]
         public async Task Should_Redirect_To_Login_When_Using_Service_Collection_Extensions()
         {
             using (var server = TestServerBuilder.CreateServer(null, null, false, true))


### PR DESCRIPTION
### Description

After a few attempts and some Googling, it didn't seem possible (or at least I failed to find the solution) for changing the default login url (`Account/Login?returnUrl={param}`), or any of the other settings normally set via `CookieAuthenticationOptions`.

I first considered just exposing the couple of properties I cared about, but upon further consideration I thought it might be more useful to just expose `CookieAuthenticationOptions` via `Auth0WebAppOptions`.  The default behavior should remain the same, this change should allow only for overrides.





### Testing

I added 1 new unit test, `Login_Path_Should_Reflect_Specified_Override()`, further, the playground already conveniently had 2 login methods (Login() and Login2()).  I modified `Startup` to now redirect the user to `Login2()` to prove that the change works.


### Checklist

- [ x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ x] All active GitHub checks for tests, formatting, and security are passing
- [ x] The correct base branch is being used, if not `main`
