### PR TITLE
Pin version of Microsoft.IdentityModel.Protocols.OpenIdConnect

### DIFF
--- a/src/Auth0.AspNetCore.Authentication/Auth0.AspNetCore.Authentication.csproj
+++ b/src/Auth0.AspNetCore.Authentication/Auth0.AspNetCore.Authentication.csproj
@@ -8,6 +8,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="3.1.*" Condition="'$(TargetFramework)' == 'netcoreapp3.1'" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="5.0.*" Condition="'$(TargetFramework)' == 'net5.0'" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="6.0.*" Condition="'$(TargetFramework)' == 'net6.0'" />
+    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="6.10.2" Condition="'$(TargetFramework)' == 'net6.0'" />
     <PackageReference Include="System.Text.Encodings.Web" Version="4.5.1" />
   </ItemGroup>
 


### PR DESCRIPTION
In `Microsoft.IdentityModel.Protocols.OpenIdConnect`, a bug got introduced in https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/commit/183c04ad613b1c0355b68ad3278d5a45e5c8835b. This bug got fixed in https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/commit/d6f2b66d788195b50f2b1f700beb497851194c73 and released as part of version 6.10.2. We should ensure our users use any version equal or above 6.10.2

Closes #71

Related: https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/issues/1627