### PR TITLE
Editable RoleClaimType

### DIFF
--- a/src/Auth0.AspNetCore.Authentication/Auth0WebAppOptions.cs
+++ b/src/Auth0.AspNetCore.Authentication/Auth0WebAppOptions.cs
@@ -85,5 +85,10 @@ namespace Auth0.AspNetCore.Authentication
         /// the user will be prompted to re-authenticate.
         /// </summary>
         public TimeSpan? MaxAge { get; set; }
+
+        /// <summary>
+        /// Provide a role claim type if it's different from the default Microsoft schema 'http://schemas.microsoft.com/ws/2008/06/identity/claims/role'.
+        /// </summary>
+        public string? RoleClaimType { get; set; } = "http://schemas.microsoft.com/ws/2008/06/identity/claims/role";
     }
 }

--- a/src/Auth0.AspNetCore.Authentication/AuthenticationBuilderExtensions.cs
+++ b/src/Auth0.AspNetCore.Authentication/AuthenticationBuilderExtensions.cs
@@ -87,12 +87,13 @@ namespace Auth0.AspNetCore.Authentication
             oidcOptions.TokenValidationParameters = new TokenValidationParameters
             {
                 NameClaimType = "name",
+                RoleClaimType = auth0Options.RoleClaimType,
                 ValidateAudience = true,
                 ValidAudience = auth0Options.ClientId,
                 ValidateIssuer = true,
                 ValidIssuer = $"https://{auth0Options.Domain}/",
                 ValidateLifetime = true,
-                RequireExpirationTime = true,
+                RequireExpirationTime = true
             };
 
             oidcOptions.Events = OpenIdConnectEventsFactory.Create(auth0Options);


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

Adding a property RoleClaimType to Auth0WebAppOptions to make it possible to change the default role claim type "http://schemas.microsoft.com/ws/2008/06/identity/claims/role". 
No breaking changes made.


### References

https://docs.microsoft.com/en-us/dotnet/api/system.security.claims.claimsidentity.roleclaimtype?view=net-6.0
