### PR TITLE
Prepare project to integrate ship

### DIFF
--- a/.shiprc
+++ b/.shiprc
@@ -1,0 +1,7 @@
+{
+    "files": {
+        "src/Auth0.AspNetCore.Authentication/Auth0.AspNetCore.Authentication.csproj": []
+    },
+    "postbump": "docfx docs-source/docfx.json",
+    "prefixVersion": false
+}

--- a/src/Auth0.AspNetCore.Authentication/Auth0.AspNetCore.Authentication.csproj
+++ b/src/Auth0.AspNetCore.Authentication/Auth0.AspNetCore.Authentication.csproj
@@ -37,16 +37,13 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <PropertyGroup>
-    <Major>1</Major>
-    <Minor>0</Minor>
-    <Revision>3</Revision>
-    <Suffix></Suffix>
+    <Version>1.0.3</Version>
   </PropertyGroup>
   <PropertyGroup>
-    <AssemblyVersion>$(Major).$(Minor).$(Revision)</AssemblyVersion>
-    <AssemblyFileVersion>$(Major).$(Minor).$(Revision)</AssemblyFileVersion>
-    <InformationalVersion>$(Major).$(Minor).$(Revision)$(Suffix)</InformationalVersion>
-    <PackageVersion>$(Major).$(Minor).$(Revision)$(Suffix)</PackageVersion>
+    <AssemblyVersion>$(Version)</AssemblyVersion>
+    <AssemblyFileVersion>$(Version)</AssemblyFileVersion>
+    <InformationalVersion>$(Version)</InformationalVersion>
+    <PackageVersion>$(Version)</PackageVersion>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
This prepares the project to use ship:

- ensure ship can replace the version in csproj by using a single Version property
- add shiprc