### PR TITLE
[SDK-3619] Do not update refresh token when rotation is disabled

### DIFF
--- a/src/Auth0.AspNetCore.Authentication/Auth0WebAppWithAccessTokenAuthenticationBuilder.cs
+++ b/src/Auth0.AspNetCore.Authentication/Auth0WebAppWithAccessTokenAuthenticationBuilder.cs
@@ -144,7 +144,10 @@ namespace Auth0.AspNetCore.Authentication
                                 if (result != null)
                                 {
                                     context.Properties.UpdateTokenValue("access_token", result.AccessToken);
-                                    context.Properties.UpdateTokenValue("refresh_token", result.RefreshToken);
+                                    if (!string.IsNullOrEmpty(result.RefreshToken))
+                                    {
+                                        context.Properties.UpdateTokenValue("refresh_token", result.RefreshToken);
+                                    }
                                     context.Properties.UpdateTokenValue("id_token", result.IdToken);
                                     context.Properties.UpdateTokenValue("expires_at", DateTimeOffset.Now.AddSeconds(result.ExpiresIn).ToString("o"));
                                 }

--- a/tests/Auth0.AspNetCore.Authentication.IntegrationTests/Builders/OidcMockBuilder.cs
+++ b/tests/Auth0.AspNetCore.Authentication.IntegrationTests/Builders/OidcMockBuilder.cs
@@ -62,7 +62,7 @@ namespace Auth0.AspNetCore.Authentication.IntegrationTests.Builders
         /// <param name="idTokenFunc">Func that, when called, returns the ID Token to be used in thhe response.</param>
         /// <param name="matcher">Custom matcher Func to only match specific requests.</param>
         /// <returns></returns>
-        public OidcMockBuilder MockToken(Func<string> idTokenFunc, Func<HttpRequestMessage, bool> matcher = null, int expiresIn = 70, bool includeAccessToken = true, bool includeRefreshToken = true, HttpStatusCode statusCode = HttpStatusCode.OK)
+        public OidcMockBuilder MockToken(Func<string> idTokenFunc, Func<HttpRequestMessage, bool> matcher = null, int expiresIn = 70, bool includeAccessToken = true, HttpStatusCode statusCode = HttpStatusCode.OK, string refreshToken = "456")
         {
             _mockHandler
               .Protected()
@@ -74,7 +74,7 @@ namespace Auth0.AspNetCore.Authentication.IntegrationTests.Builders
               .ReturnsAsync(() => new HttpResponseMessage()
               {
                   StatusCode = statusCode,
-                  Content = new StringContent(BuildTokenResponse(idTokenFunc(), expiresIn, includeAccessToken, includeRefreshToken)),
+                  Content = new StringContent(BuildTokenResponse(idTokenFunc(), expiresIn, includeAccessToken, refreshToken)),
               })
               .Verifiable();
 
@@ -107,7 +107,7 @@ namespace Auth0.AspNetCore.Authentication.IntegrationTests.Builders
             }
         }
 
-        private string BuildTokenResponse(string idToken, int expiresIn, bool includeAccessToken, bool includeRefreshToken)
+        private string BuildTokenResponse(string idToken, int expiresIn, bool includeAccessToken, string refreshToken)
         {
             var tokenContents = new Dictionary<string, object>
             {
@@ -118,9 +118,9 @@ namespace Auth0.AspNetCore.Authentication.IntegrationTests.Builders
             {
                 tokenContents["access_token"] = "123";
             }
-            if (includeRefreshToken)
+            if (!string.IsNullOrEmpty(refreshToken))
             {
-                tokenContents["refresh_token"] = "456";
+                tokenContents["refresh_token"] = refreshToken;
             }
             var token = JsonConvert.SerializeObject(tokenContents);
             return token;


### PR DESCRIPTION
### Description

When RTR is disabled, Auth0 does not return a new refresh token when calling oauth/token using the refresh_grant. Therefore, we need to ensure we do not update the Refresh Token when we are not getting one back from Auth0.

### Testing

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `main`
