### PR TITLE
Update Microsoft.IdentityModel.Protocols.OpenIdConnect dependency to avoid memory leak

### DIFF
--- a/src/Auth0.AspNetCore.Authentication/Auth0.AspNetCore.Authentication.csproj
+++ b/src/Auth0.AspNetCore.Authentication/Auth0.AspNetCore.Authentication.csproj
@@ -8,7 +8,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="3.1.*" Condition="'$(TargetFramework)' == 'netcoreapp3.1'" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="5.0.*" Condition="'$(TargetFramework)' == 'net5.0'" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="6.0.*" Condition="'$(TargetFramework)' == 'net6.0'" />
-    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="6.10.2" Condition="'$(TargetFramework)' == 'net6.0'" />
+    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="6.*" Condition="'$(TargetFramework)' == 'net6.0'" />
     <PackageReference Include="System.Text.Encodings.Web" Version="4.5.1" />
   </ItemGroup>
 


### PR DESCRIPTION
### Description

When Installing `Microsoft.AspNetCore.Authentication.OpenIdConnect`, `Microsoft.IdentityModel.Protocols.OpenIdConnect` v6.10.0 is installed, which contains a memory leak that is solved in v6.12.0.

This PR ensures the latest version is used.

### References

https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/releases/tag/6.12.0
https://github.com/auth0/auth0-aspnetcore-authentication/issues/86
https://github.com/auth0/auth0-aspnetcore-authentication/issues/80

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `main`
