### PR TITLE
Drop .NET Core 3.1; Add .NET 7

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ A library based on `Microsoft.AspNetCore.Authentication.OpenIdConnect` to make i
 ## Getting started
 ### Requirements
 
-This library supports .NET Core 3.1 and .NET 6.
+This library supports .NET 6 and .NET 7.
 
 ### Installation
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,7 +8,7 @@ steps:
 - task: UseDotNet@2
   displayName: 'Use .Net Core SDK'
   inputs:
-    version: 5.0.x
+    version: 6.0.x
 
 - task: DotNetCoreCLI@2
   displayName: Restore

--- a/docs-source/index.md
+++ b/docs-source/index.md
@@ -19,7 +19,7 @@ A library based on `Microsoft.AspNetCore.Authentication.OpenIdConnect` to make i
 ## Getting started
 ### Requirements
 
-This library supports .NET Core 3.1 and .NET 6.
+This library supports .NET 6 and .NET 7.
 
 ### Installation
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -77,7 +77,7 @@
 </ul>
 <h2 id="getting-started">Getting started</h2>
 <h3 id="requirements">Requirements</h3>
-<p>This library supports .NET Core 3.1, .NET 5 and .NET 6.</p>
+<p>This library supports .NET 6 and .NET 7.</p>
 <h3 id="installation">Installation</h3>
 <p>The SDK is available on <a href="https://www.nuget.org/packages/Auth0.AspNetCore.Authentication">Nuget</a> and can be installed through the UI or using the Package Manager Console:</p>
 <pre><code>Install-Package Auth0.AspNetCore.Authentication

--- a/src/Auth0.AspNetCore.Authentication/Auth0.AspNetCore.Authentication.csproj
+++ b/src/Auth0.AspNetCore.Authentication/Auth0.AspNetCore.Authentication.csproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="3.1.*" Condition="'$(TargetFramework)' == 'netcoreapp3.1'" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="6.0.*" Condition="'$(TargetFramework)' == 'net6.0'" />
     <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="6.*" Condition="'$(TargetFramework)' == 'net6.0'" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="7.0.*" Condition="'$(TargetFramework)' == 'net7.0'" />
     <PackageReference Include="System.Text.Encodings.Web" Version="4.5.1" />
   </ItemGroup>
 


### PR DESCRIPTION
### Description

This PR drops support for .NET Core 3.1, and adds support for .NET 7.


### References

With .NET Core 3.1 going End of Life on 2022-12-13, we will stop supporting this version of .NET with ongoing releases.

https://dotnet.microsoft.com/en-us/platform/support/policy/dotnet-core.

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `main`
