### PR TITLE
Avoid creating HttpClient when using refresh tokens

### DIFF
--- a/src/Auth0.AspNetCore.Authentication/Auth0WebAppWithAccessTokenAuthenticationBuilder.cs
+++ b/src/Auth0.AspNetCore.Authentication/Auth0WebAppWithAccessTokenAuthenticationBuilder.cs
@@ -184,12 +184,11 @@ namespace Auth0.AspNetCore.Authentication
             };
         }
 
-        private static async Task<AccessTokenResponse?> RefreshTokens(Auth0WebAppOptions options, string refreshToken, HttpClient? httpClient = null)
+        private static async Task<AccessTokenResponse?> RefreshTokens(Auth0WebAppOptions options, string refreshToken, HttpClient httpClient)
         {
-            using (var tokenClient = new TokenClient(httpClient))
-            {
-                return await tokenClient.Refresh(options, refreshToken);
-            }
+            var tokenClient = new TokenClient(httpClient);
+            
+            return await tokenClient.Refresh(options, refreshToken);
         }
 
         private static void ValidateOptions(Auth0WebAppOptions options)

--- a/src/Auth0.AspNetCore.Authentication/TokenClient.cs
+++ b/src/Auth0.AspNetCore.Authentication/TokenClient.cs
@@ -9,27 +9,17 @@ using System.Threading.Tasks;
 
 namespace Auth0.AspNetCore.Authentication
 {
-    internal class TokenClient : IDisposable
+    internal class TokenClient
     {
         private readonly HttpClient _httpClient;
-        private readonly bool _isHttpClientOwner;
         private readonly JsonSerializerOptions _jsonSerializerOptions = new JsonSerializerOptions()
         {
             IgnoreNullValues = true,
         };
 
-        public TokenClient(HttpClient? httpClient = null)
+        public TokenClient(HttpClient httpClient)
         {
-            _isHttpClientOwner = httpClient == null;
-            _httpClient = httpClient ?? new HttpClient();
-        }
-
-        public void Dispose()
-        {
-            if (_isHttpClientOwner)
-            {
-                _httpClient.Dispose();
-            }
+            _httpClient = httpClient;
         }
 
         public async Task<AccessTokenResponse?> Refresh(Auth0WebAppOptions options, string refreshToken)

--- a/tests/Auth0.AspNetCore.Authentication.IntegrationTests/TokenClientTests.cs
+++ b/tests/Auth0.AspNetCore.Authentication.IntegrationTests/TokenClientTests.cs
@@ -13,14 +13,6 @@ namespace Auth0.AspNetCore.Authentication.IntegrationTests
     public class TokenClientTests
     {
         [Fact]
-        public async Task Disposes_HttpClient_it_creates_on_dispose()
-        {
-            var client = new TokenClient();
-            client.Dispose();
-            await Assert.ThrowsAsync<ObjectDisposedException>(() => client.Refresh(new Auth0WebAppOptions { Domain = "local.auth0.com" }, ""));
-        }
-
-        [Fact]
         public async Task Returns_Null_When_No_Success_StatusCode()
         {
             var mockHandler = new Mock<HttpMessageHandler>();


### PR DESCRIPTION
### Description

Backchannel is always available, either provided by the user or generated by the OidcConnect library.
Therefore, the code that creates our own HttpClient was obsolete and never used.

This PR removes this.

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `main`
