### PR TITLE
Use IOptionsMonitor instead of IOptionsSnapshot

### DIFF
--- a/src/Auth0.AspNetCore.Authentication/Auth0WebAppWithAccessTokenAuthenticationBuilder.cs
+++ b/src/Auth0.AspNetCore.Authentication/Auth0WebAppWithAccessTokenAuthenticationBuilder.cs
@@ -93,7 +93,7 @@ namespace Auth0.AspNetCore.Authentication
         {
             return (context) =>
             {
-                var optionsWithAccessToken = context.HttpContext.RequestServices.GetRequiredService<IOptionsSnapshot<Auth0WebAppWithAccessTokenOptions>>().Get(authenticationScheme);
+                var optionsWithAccessToken = context.HttpContext.RequestServices.GetRequiredService<IOptionsMonitor<Auth0WebAppWithAccessTokenOptions>>().Get(authenticationScheme);
 
                 if (!string.IsNullOrWhiteSpace(optionsWithAccessToken.Audience))
                 {
@@ -113,9 +113,9 @@ namespace Auth0.AspNetCore.Authentication
         {
             return async (context) =>
             {
-                var options = context.HttpContext.RequestServices.GetRequiredService<IOptionsSnapshot<Auth0WebAppOptions>>().Get(authenticationScheme);
-                var optionsWithAccessToken = context.HttpContext.RequestServices.GetRequiredService<IOptionsSnapshot<Auth0WebAppWithAccessTokenOptions>>().Get(authenticationScheme);
-                var oidcOptions = context.HttpContext.RequestServices.GetRequiredService<IOptionsSnapshot<OpenIdConnectOptions>>().Get(authenticationScheme);
+                var options = context.HttpContext.RequestServices.GetRequiredService<IOptionsMonitor<Auth0WebAppOptions>>().Get(authenticationScheme);
+                var optionsWithAccessToken = context.HttpContext.RequestServices.GetRequiredService<IOptionsMonitor<Auth0WebAppWithAccessTokenOptions>>().Get(authenticationScheme);
+                var oidcOptions = context.HttpContext.RequestServices.GetRequiredService<IOptionsMonitor<OpenIdConnectOptions>>().Get(authenticationScheme);
 
                 if (context.Properties.Items.TryGetValue(".AuthScheme", out var authScheme))
                 {


### PR DESCRIPTION
### Description

Using IOptionsMonitor has a benefit over IOptionsSnapshot where it's not re-evaluated every time it's injected. This can have some benefits in situations where the options is bound to the configuration.

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `main`
