### PR TITLE
Ensure CookieName is configurable

### DIFF
--- a/src/Auth0.AspNetCore.Authentication/Auth0WebAppOptions.cs
+++ b/src/Auth0.AspNetCore.Authentication/Auth0WebAppOptions.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Authentication.OpenIdConnect;
+﻿using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 using Microsoft.IdentityModel.Tokens;
 using System;
 using System.Collections.Generic;
@@ -11,6 +12,14 @@ namespace Auth0.AspNetCore.Authentication
     /// </summary>
     public class Auth0WebAppOptions
     {
+        /// <summary>
+        /// The name of the cookie scheme to use
+        /// </summary>
+        /// <remarks>
+        /// The default is <see cref="CookieAuthenticationDefaults.AuthenticationScheme"/>
+        /// </remarks>
+        public string CookieName { get; set; } = CookieAuthenticationDefaults.AuthenticationScheme;
+
         /// <summary>
         /// Auth0 domain name, e.g. tenant.auth0.com.
         /// </summary>

--- a/src/Auth0.AspNetCore.Authentication/Auth0WebAppOptions.cs
+++ b/src/Auth0.AspNetCore.Authentication/Auth0WebAppOptions.cs
@@ -18,7 +18,7 @@ namespace Auth0.AspNetCore.Authentication
         /// <remarks>
         /// The default is <see cref="CookieAuthenticationDefaults.AuthenticationScheme"/>
         /// </remarks>
-        public string CookieName { get; set; } = CookieAuthenticationDefaults.AuthenticationScheme;
+        public string CookieAuthenticationScheme { get; set; } = CookieAuthenticationDefaults.AuthenticationScheme;
 
         /// <summary>
         /// Auth0 domain name, e.g. tenant.auth0.com.

--- a/src/Auth0.AspNetCore.Authentication/Auth0WebAppWithAccessTokenAuthenticationBuilder.cs
+++ b/src/Auth0.AspNetCore.Authentication/Auth0WebAppWithAccessTokenAuthenticationBuilder.cs
@@ -82,7 +82,7 @@ namespace Auth0.AspNetCore.Authentication
                     options.Events.OnRedirectToIdentityProvider = Utils.ProxyEvent(CreateOnRedirectToIdentityProvider(_authenticationScheme), options.Events.OnRedirectToIdentityProvider);
                 });
 
-            _services.AddOptions<CookieAuthenticationOptions>(CookieAuthenticationDefaults.AuthenticationScheme)
+            _services.AddOptions<CookieAuthenticationOptions>(_options.CookieName)
                 .Configure(options =>
                 {
                     options.Events.OnValidatePrincipal = Utils.ProxyEvent(CreateOnValidatePrincipal(_authenticationScheme), options.Events.OnValidatePrincipal);

--- a/src/Auth0.AspNetCore.Authentication/Auth0WebAppWithAccessTokenAuthenticationBuilder.cs
+++ b/src/Auth0.AspNetCore.Authentication/Auth0WebAppWithAccessTokenAuthenticationBuilder.cs
@@ -82,7 +82,7 @@ namespace Auth0.AspNetCore.Authentication
                     options.Events.OnRedirectToIdentityProvider = Utils.ProxyEvent(CreateOnRedirectToIdentityProvider(_authenticationScheme), options.Events.OnRedirectToIdentityProvider);
                 });
 
-            _services.AddOptions<CookieAuthenticationOptions>(_options.CookieName)
+            _services.AddOptions<CookieAuthenticationOptions>(_options.CookieAuthenticationScheme)
                 .Configure(options =>
                 {
                     options.Events.OnValidatePrincipal = Utils.ProxyEvent(CreateOnValidatePrincipal(_authenticationScheme), options.Events.OnValidatePrincipal);

--- a/src/Auth0.AspNetCore.Authentication/AuthenticationBuilderExtensions.cs
+++ b/src/Auth0.AspNetCore.Authentication/AuthenticationBuilderExtensions.cs
@@ -52,7 +52,7 @@ namespace Auth0.AspNetCore.Authentication
 
             if (!auth0Options.SkipCookieMiddleware)
             {
-                builder.AddCookie();
+                builder.AddCookie(auth0Options.CookieAuthenticationScheme);
             }
 
             builder.Services.Configure(authenticationScheme, configureOptions);

--- a/src/Auth0.AspNetCore.Authentication/ServiceCollectionExtensions.cs
+++ b/src/Auth0.AspNetCore.Authentication/ServiceCollectionExtensions.cs
@@ -31,9 +31,13 @@ namespace Auth0.AspNetCore.Authentication
             return services
                 .AddAuthentication(options =>
                 {
-                    options.DefaultAuthenticateScheme = CookieAuthenticationDefaults.AuthenticationScheme;
-                    options.DefaultSignInScheme = CookieAuthenticationDefaults.AuthenticationScheme;
-                    options.DefaultChallengeScheme = CookieAuthenticationDefaults.AuthenticationScheme;
+                    var authOptions = new Auth0WebAppOptions();
+
+                    configureOptions(authOptions);
+
+                    options.DefaultAuthenticateScheme = authOptions.CookieAuthenticationScheme;
+                    options.DefaultSignInScheme = authOptions.CookieAuthenticationScheme;
+                    options.DefaultChallengeScheme = authOptions.CookieAuthenticationScheme;
                 })
                 .AddAuth0WebAppAuthentication(authenticationScheme, configureOptions);
         }

--- a/tests/Auth0.AspNetCore.Authentication.IntegrationTests/Controllers/AccountController.cs
+++ b/tests/Auth0.AspNetCore.Authentication.IntegrationTests/Controllers/AccountController.cs
@@ -55,7 +55,7 @@ namespace Auth0.AspNetCore.Authentication.IntegrationTests.Controllers
         }
 
         [Authorize]
-        public async Task Logout([FromQuery(Name = "extraParameters")] Dictionary<string, string> extraParameters = null)
+        public async Task Logout([FromQuery(Name = "extraParameters")] Dictionary<string, string> extraParameters = null, [FromQuery(Name = "cookieAuthenticationScheme")] string cookieAuthenticationScheme = null)
         {
             // Indicate here where Auth0 should redirect the user after a logout.
             // Note that the resulting absolute Uri must be whitelisted in the
@@ -72,7 +72,7 @@ namespace Auth0.AspNetCore.Authentication.IntegrationTests.Controllers
             }
 
             await HttpContext.SignOutAsync(Auth0Constants.AuthenticationScheme, authenticationPropertiesBuilder.Build());
-            await HttpContext.SignOutAsync(CookieAuthenticationDefaults.AuthenticationScheme);
+            await HttpContext.SignOutAsync(cookieAuthenticationScheme ?? CookieAuthenticationDefaults.AuthenticationScheme);
         }
 
         [Authorize]


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

Add the ability to specify the cookie scheme used

### Testing

Create aspnet project with custom cookie.

```csharp
services
  .AddAuthentication()
  .AddCookie("MyCookieScheme", () => {})
  .AddAuth0WebAppAuthentication(options => {
    options.CookieName = "MyCookieScheme";
  });
- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `main`
