### PR TITLE
include scopes in refresh tokens

### DIFF
--- a/src/Auth0.AspNetCore.Authentication/Auth0WebAppOptions.cs
+++ b/src/Auth0.AspNetCore.Authentication/Auth0WebAppOptions.cs
@@ -105,5 +105,7 @@ namespace Auth0.AspNetCore.Authentication
         /// the user will be prompted to re-authenticate.
         /// </summary>
         public TimeSpan? MaxAge { get; set; }
+
+        public bool? ForceScopeInRefreshRequests { get; set; }
     }
 }

--- a/src/Auth0.AspNetCore.Authentication/TokenClient.cs
+++ b/src/Auth0.AspNetCore.Authentication/TokenClient.cs
@@ -27,8 +27,12 @@ namespace Auth0.AspNetCore.Authentication
             var body = new Dictionary<string, string> {
                 { "grant_type", "refresh_token" },
                 { "client_id", options.ClientId },
-                { "refresh_token", refreshToken }
+                { "refresh_token", refreshToken },                
             };
+
+            if (options.ForceScopeInRefreshRequests == true) {
+                body.Add("scope", options.Scope);
+            }
 
             ApplyClientAuthentication(options, body);
 


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

> Describe the purpose of this PR along with any background information and the impacts of the proposed change. For the benefit of the community, please do not assume prior context.
>
> Provide details that support your chosen implementation, including: breaking changes, alternatives considered, changes to the API, etc.
>
> If the UI is being changed, please provide screenshots.

I noticed that when using scopes in auth0 that NOT including a scope param in the body of a refresh token request causes the access token returned to not have the same scope. Not sure if feature or bug. This change allows for the scope inclusion to be an opt-in (as otherwise I believe it would be considered a breaking change).

### References

> Include any links supporting this change such as a:
>
> - GitHub Issue/PR number addressed or fixed
> - Auth0 Community post
> - StackOverflow post
> - Support forum thread
> - Related pull requests/issues from other repos
>
> If there are no references, simply delete this section.

### Testing

> Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.
>
> Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.
>
> Also include details of the environment this PR was developed in (language/platform/browser version).

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `main`
