### PR TITLE
Support Organization Name

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -187,7 +187,7 @@ Apart from being able to configure the organization globally, the SDK's `LoginAu
 
 ```csharp
 var authenticationProperties = new LoginAuthenticationPropertiesBuilder()
-    .WithOrganization("YOUR_ORGANIZATION")
+    .WithOrganization("YOUR_ORGANIZATION_ID_OR_NAME")
     .Build();
 
 await HttpContext.ChallengeAsync(Auth0Constants.AuthenticationScheme, authenticationProperties);
@@ -197,7 +197,7 @@ await HttpContext.ChallengeAsync(Auth0Constants.AuthenticationScheme, authentica
 
 ### Organization claim validation
 
-If you don't provide an `organization` parameter at login, the SDK can't validate the `org_id` claim you get back in the ID token. In that case, you should validate the `org_id` claim yourself (e.g. by checking it against a list of valid organization ID's or comparing it with the application's URL).
+If you don't provide an `organization` parameter at login, the SDK can't validate the `org_id` (or `org_name`) claim you get back in the ID token. In that case, you should validate the `org_id` (or `org_name`) claim yourself (e.g. by checking it against a list of valid organization ID's (or names) or comparing it with the application's URL).
 
 ```
 services.AddAuth0WebAppAuthentication(options =>

--- a/src/Auth0.AspNetCore.Authentication/Auth0WebAppOptions.cs
+++ b/src/Auth0.AspNetCore.Authentication/Auth0WebAppOptions.cs
@@ -66,8 +66,12 @@ namespace Auth0.AspNetCore.Authentication
         public bool SkipCookieMiddleware { get; set; } = false;
 
         /// <summary>
-        /// The Id of the organization to which the users should log in to.
+        /// The Organization to which the users should log in to.
         /// </summary>
+        /// <remarks>
+        /// - If you provide an Organization ID (a string with the prefix `org_`), it will be validated against the `org_id` claim of your user's ID Token. The validation is case-sensitive.
+        /// - If you provide an Organization Name (a string *without* the prefix `org_`), it will be validated against the `org_name` claim of your user's ID Token.The validation is case-insensitive.
+        /// </remarks>
         public string? Organization { get; set; }
 
         /// <summary>

--- a/src/Auth0.AspNetCore.Authentication/IdTokenValidator.cs
+++ b/src/Auth0.AspNetCore.Authentication/IdTokenValidator.cs
@@ -18,15 +18,18 @@ namespace Auth0.AspNetCore.Authentication
 
             if (!string.IsNullOrWhiteSpace(organization))
             {
-                var organizationClaimValue = token.Claims.SingleOrDefault(claim => claim.Type == "org_id")?.Value;
+                var organizationClaim = organization.StartsWith("org_") ? "org_id" : "org_name";
+                var rawOrganizationClaimValue = token.Claims.SingleOrDefault(claim => claim.Type == organizationClaim)?.Value;
+                var organizationClaimValue = organizationClaim == "org_name" ? rawOrganizationClaimValue?.ToLower() : rawOrganizationClaimValue;
+                var expectedOrganization = organizationClaim == "org_name" ? organization.ToLower() : organization;
 
                 if (string.IsNullOrWhiteSpace(organizationClaimValue))
                 {
-                    throw new IdTokenValidationException("Organization claim must be a string present in the ID token.");
+                    throw new IdTokenValidationException($"Organization claim ({organizationClaim}) must be a string present in the ID token.");
                 }
-                else if (organizationClaimValue != organization)
+                else if (organizationClaimValue != expectedOrganization)
                 {
-                    throw new IdTokenValidationException($"Organization claim mismatch in the ID token; expected \"{organization}\", found \"{organizationClaimValue}\".");
+                    throw new IdTokenValidationException($"Organization claim ({organizationClaim}) mismatch in the ID token; expected \"{expectedOrganization}\", found \"{organizationClaimValue}\".");
                 }
             }
 

--- a/src/Auth0.AspNetCore.Authentication/LoginAuthenticationPropertiesBuilder.cs
+++ b/src/Auth0.AspNetCore.Authentication/LoginAuthenticationPropertiesBuilder.cs
@@ -53,6 +53,10 @@ namespace Auth0.AspNetCore.Authentication
         /// <summary>
         /// Build the <see cref="AuthenticationProperties"/> using the provided organization
         /// </summary>
+        /// <remarks>
+        /// - If you provide an Organization ID (a string with the prefix `org_`), it will be validated against the `org_id` claim of your user's ID Token. The validation is case-sensitive.
+        /// - If you provide an Organization Name (a string *without* the prefix `org_`), it will be validated against the `org_name` claim of your user's ID Token. The validation is case-insensitive.
+        /// </remarks>
         /// <param name="organization">The organization used when logging in.</param>
         /// <returns>The current <see cref="LoginAuthenticationPropertiesBuilder"/> instance.</returns>
         public LoginAuthenticationPropertiesBuilder WithOrganization(string organization)

--- a/tests/Auth0.AspNetCore.Authentication.IntegrationTests/TokenValidationTests.cs
+++ b/tests/Auth0.AspNetCore.Authentication.IntegrationTests/TokenValidationTests.cs
@@ -600,7 +600,309 @@ namespace Auth0.AspNetCore.Authentication.IntegrationTests
 
         }
 
-        private string GenerateToken(int userId, string issuer, string audience, string nonce, string subject, string orgId = null, bool expired = false, string extraAudience = null, string azp = null, DateTime? authTime = null)
+        [Fact]
+        public async Task Should_Throw_When_Missing_OrgId()
+        {
+            var nonce = "";
+            var configuration = TestConfiguration.GetConfiguration();
+            var domain = configuration["Auth0:Domain"];
+            var clientId = configuration["Auth0:ClientId"];
+            var mockHandler = new OidcMockBuilder()
+                .MockOpenIdConfig()
+                .MockJwks()
+                .MockToken(() => GenerateToken(1, $"https://{domain}/", clientId, nonce, "1", "organizationA"), (me) => me.HasAuth0ClientHeader())
+                .Build();
+
+            using (var server = TestServerBuilder.CreateServer(opt =>
+            {
+                opt.Backchannel = new HttpClient(mockHandler.Object);
+            }))
+            {
+                using (var client = server.CreateClient())
+                {
+                    var loginResponse = (await client.SendAsync($"{TestServerBuilder.Host}/{TestServerBuilder.Login}?organization=org_123"));
+                    var setCookie = Assert.Single(loginResponse.Headers, h => h.Key == "Set-Cookie");
+
+                    var queryParameters = UriUtils.GetQueryParams(loginResponse.Headers.Location);
+
+                    // Keep track of the nonce as we need to:
+                    // - Send it to the `/oauth/token` endpoint
+                    // - Include it in the generated ID Token
+                    nonce = queryParameters["nonce"];
+
+                    // Keep track of the state as we need to:
+                    // - Send it to the `/oauth/token` endpoint
+                    var state = queryParameters["state"];
+
+                    var message = new HttpRequestMessage(HttpMethod.Get, $"{TestServerBuilder.Host}/{TestServerBuilder.Callback}?state={state}&nonce={nonce}&code=123");
+
+                    Func<Task> act = async () =>
+                    {
+                        // Pass along the Set-Cookies to ensure `Nonce` and `Correlation` cookies are set.
+                        await client.SendAsync(message, setCookie.Value);
+                    };
+
+                    var innerException = act
+                        .Should()
+                        .Throw<Exception>()
+                        .And.InnerException;
+
+                    innerException
+                        .Should()
+                        .BeOfType<Exception>()
+                        .Which.Message.Should().Be("Organization claim (org_id) must be a string present in the ID token.");
+                }
+            }
+        }
+
+        [Fact]
+        public async Task Should_Throw_When_OrgId_Mismatch()
+        {
+            var nonce = "";
+            var configuration = TestConfiguration.GetConfiguration();
+            var domain = configuration["Auth0:Domain"];
+            var clientId = configuration["Auth0:ClientId"];
+            var mockHandler = new OidcMockBuilder()
+                .MockOpenIdConfig()
+                .MockJwks()
+                .MockToken(() => GenerateToken(1, $"https://{domain}/", clientId, nonce, "1", "org_abc"), (me) => me.HasAuth0ClientHeader())
+                .Build();
+
+            using (var server = TestServerBuilder.CreateServer(opt =>
+            {
+                opt.Backchannel = new HttpClient(mockHandler.Object);
+            }))
+            {
+                using (var client = server.CreateClient())
+                {
+                    var loginResponse = (await client.SendAsync($"{TestServerBuilder.Host}/{TestServerBuilder.Login}?organization=org_123"));
+                    var setCookie = Assert.Single(loginResponse.Headers, h => h.Key == "Set-Cookie");
+
+                    var queryParameters = UriUtils.GetQueryParams(loginResponse.Headers.Location);
+
+                    // Keep track of the nonce as we need to:
+                    // - Send it to the `/oauth/token` endpoint
+                    // - Include it in the generated ID Token
+                    nonce = queryParameters["nonce"];
+
+                    // Keep track of the state as we need to:
+                    // - Send it to the `/oauth/token` endpoint
+                    var state = queryParameters["state"];
+
+                    var message = new HttpRequestMessage(HttpMethod.Get, $"{TestServerBuilder.Host}/{TestServerBuilder.Callback}?state={state}&nonce={nonce}&code=123");
+
+                    Func<Task> act = async () =>
+                    {
+                        // Pass along the Set-Cookies to ensure `Nonce` and `Correlation` cookies are set.
+                        await client.SendAsync(message, setCookie.Value);
+                    };
+
+                    var innerException = act
+                        .Should()
+                        .Throw<Exception>()
+                        .And.InnerException;
+
+                    innerException
+                        .Should()
+                        .BeOfType<Exception>()
+                        .Which.Message.Should().Be($"Organization claim (org_id) mismatch in the ID token; expected \"org_123\", found \"org_abc\".");
+                }
+            }
+        }
+
+        [Fact]
+        public async Task Should_Not_Throw_When_OrgId_Match()
+        {
+            var nonce = "";
+            var configuration = TestConfiguration.GetConfiguration();
+            var domain = configuration["Auth0:Domain"];
+            var clientId = configuration["Auth0:ClientId"];
+            var mockHandler = new OidcMockBuilder()
+                .MockOpenIdConfig()
+                .MockJwks()
+                .MockToken(() => GenerateToken(1, $"https://{domain}/", clientId, nonce, "1", "org_123"), (me) => me.HasAuth0ClientHeader())
+                .Build();
+
+            using (var server = TestServerBuilder.CreateServer(opt =>
+            {
+                opt.Backchannel = new HttpClient(mockHandler.Object);
+            }))
+            {
+                using (var client = server.CreateClient())
+                {
+                    var loginResponse = (await client.SendAsync($"{TestServerBuilder.Host}/{TestServerBuilder.Login}?organization=org_123"));
+                    var setCookie = Assert.Single(loginResponse.Headers, h => h.Key == "Set-Cookie");
+
+                    var queryParameters = UriUtils.GetQueryParams(loginResponse.Headers.Location);
+
+                    // Keep track of the nonce as we need to:
+                    // - Send it to the `/oauth/token` endpoint
+                    // - Include it in the generated ID Token
+                    nonce = queryParameters["nonce"];
+
+                    // Keep track of the state as we need to:
+                    // - Send it to the `/oauth/token` endpoint
+                    var state = queryParameters["state"];
+
+                    var message = new HttpRequestMessage(HttpMethod.Get, $"{TestServerBuilder.Host}/{TestServerBuilder.Callback}?state={state}&nonce={nonce}&code=123");
+
+                    await client.SendAsync(message, setCookie.Value);
+                }
+            }
+        }
+
+        [Fact]
+        public async Task Should_Throw_When_Missing_OrgName()
+        {
+            var nonce = "";
+            var configuration = TestConfiguration.GetConfiguration();
+            var domain = configuration["Auth0:Domain"];
+            var clientId = configuration["Auth0:ClientId"];
+            var mockHandler = new OidcMockBuilder()
+                .MockOpenIdConfig()
+                .MockJwks()
+                .MockToken(() => GenerateToken(1, $"https://{domain}/", clientId, nonce, "1", "org_123"), (me) => me.HasAuth0ClientHeader())
+                .Build();
+
+            using (var server = TestServerBuilder.CreateServer(opt =>
+            {
+                opt.Backchannel = new HttpClient(mockHandler.Object);
+            }))
+            {
+                using (var client = server.CreateClient())
+                {
+                    var loginResponse = (await client.SendAsync($"{TestServerBuilder.Host}/{TestServerBuilder.Login}?organization=organizationA"));
+                    var setCookie = Assert.Single(loginResponse.Headers, h => h.Key == "Set-Cookie");
+
+                    var queryParameters = UriUtils.GetQueryParams(loginResponse.Headers.Location);
+
+                    // Keep track of the nonce as we need to:
+                    // - Send it to the `/oauth/token` endpoint
+                    // - Include it in the generated ID Token
+                    nonce = queryParameters["nonce"];
+
+                    // Keep track of the state as we need to:
+                    // - Send it to the `/oauth/token` endpoint
+                    var state = queryParameters["state"];
+
+                    var message = new HttpRequestMessage(HttpMethod.Get, $"{TestServerBuilder.Host}/{TestServerBuilder.Callback}?state={state}&nonce={nonce}&code=123");
+
+                    Func<Task> act = async () =>
+                    {
+                        // Pass along the Set-Cookies to ensure `Nonce` and `Correlation` cookies are set.
+                        await client.SendAsync(message, setCookie.Value);
+                    };
+
+                    var innerException = act
+                        .Should()
+                        .Throw<Exception>()
+                        .And.InnerException;
+
+                    innerException
+                        .Should()
+                        .BeOfType<Exception>()
+                        .Which.Message.Should().Be("Organization claim (org_name) must be a string present in the ID token.");
+                }
+            }
+        }
+
+        [Fact]
+        public async Task Should_Throw_When_OrgName_Mismatch()
+        {
+            var nonce = "";
+            var configuration = TestConfiguration.GetConfiguration();
+            var domain = configuration["Auth0:Domain"];
+            var clientId = configuration["Auth0:ClientId"];
+            var mockHandler = new OidcMockBuilder()
+                .MockOpenIdConfig()
+                .MockJwks()
+                .MockToken(() => GenerateToken(1, $"https://{domain}/", clientId, nonce, "1", "organizationb"), (me) => me.HasAuth0ClientHeader())
+                .Build();
+
+            using (var server = TestServerBuilder.CreateServer(opt =>
+            {
+                opt.Backchannel = new HttpClient(mockHandler.Object);
+            }))
+            {
+                using (var client = server.CreateClient())
+                {
+                    var loginResponse = (await client.SendAsync($"{TestServerBuilder.Host}/{TestServerBuilder.Login}?organization=organizationa"));
+                    var setCookie = Assert.Single(loginResponse.Headers, h => h.Key == "Set-Cookie");
+
+                    var queryParameters = UriUtils.GetQueryParams(loginResponse.Headers.Location);
+
+                    // Keep track of the nonce as we need to:
+                    // - Send it to the `/oauth/token` endpoint
+                    // - Include it in the generated ID Token
+                    nonce = queryParameters["nonce"];
+
+                    // Keep track of the state as we need to:
+                    // - Send it to the `/oauth/token` endpoint
+                    var state = queryParameters["state"];
+
+                    var message = new HttpRequestMessage(HttpMethod.Get, $"{TestServerBuilder.Host}/{TestServerBuilder.Callback}?state={state}&nonce={nonce}&code=123");
+
+                    Func<Task> act = async () =>
+                    {
+                        // Pass along the Set-Cookies to ensure `Nonce` and `Correlation` cookies are set.
+                        await client.SendAsync(message, setCookie.Value);
+                    };
+
+                    var innerException = act
+                        .Should()
+                        .Throw<Exception>()
+                        .And.InnerException;
+
+                    innerException
+                        .Should()
+                        .BeOfType<Exception>()
+                        .Which.Message.Should().Be($"Organization claim (org_name) mismatch in the ID token; expected \"organizationa\", found \"organizationb\".");
+                }
+            }
+        }
+
+        [Fact]
+        public async Task Should_Not_Throw_When_OrgName_Match()
+        {
+            var nonce = "";
+            var configuration = TestConfiguration.GetConfiguration();
+            var domain = configuration["Auth0:Domain"];
+            var clientId = configuration["Auth0:ClientId"];
+            var mockHandler = new OidcMockBuilder()
+                .MockOpenIdConfig()
+                .MockJwks()
+                .MockToken(() => GenerateToken(1, $"https://{domain}/", clientId, nonce, "1", "organizationa"), (me) => me.HasAuth0ClientHeader())
+                .Build();
+
+            using (var server = TestServerBuilder.CreateServer(opt =>
+            {
+                opt.Backchannel = new HttpClient(mockHandler.Object);
+            }))
+            {
+                using (var client = server.CreateClient())
+                {
+                    var loginResponse = (await client.SendAsync($"{TestServerBuilder.Host}/{TestServerBuilder.Login}?organization=organizationA"));
+                    var setCookie = Assert.Single(loginResponse.Headers, h => h.Key == "Set-Cookie");
+
+                    var queryParameters = UriUtils.GetQueryParams(loginResponse.Headers.Location);
+
+                    // Keep track of the nonce as we need to:
+                    // - Send it to the `/oauth/token` endpoint
+                    // - Include it in the generated ID Token
+                    nonce = queryParameters["nonce"];
+
+                    // Keep track of the state as we need to:
+                    // - Send it to the `/oauth/token` endpoint
+                    var state = queryParameters["state"];
+
+                    var message = new HttpRequestMessage(HttpMethod.Get, $"{TestServerBuilder.Host}/{TestServerBuilder.Callback}?state={state}&nonce={nonce}&code=123");
+
+                    await client.SendAsync(message, setCookie.Value);
+                }
+            }
+        }
+
+        private string GenerateToken(int userId, string issuer, string audience, string nonce, string subject, string organization = null, bool expired = false, string extraAudience = null, string azp = null, DateTime? authTime = null)
         {
             var tokenHandler = new JwtSecurityTokenHandler();
             var claims = new List<Claim>
@@ -618,9 +920,10 @@ namespace Auth0.AspNetCore.Authentication.IntegrationTests
                 claims.Add(new Claim(JwtRegisteredClaimNames.Aud, extraAudience));
             }
 
-            if (!string.IsNullOrWhiteSpace(orgId))
+            if (!string.IsNullOrWhiteSpace(organization))
             {
-                claims.Add(new Claim("org_id", orgId));
+                var organizationClaim = organization.StartsWith("org_") ? "org_id" : "org_name";
+                claims.Add(new Claim(organizationClaim, organization));
             }
 
             if (!string.IsNullOrWhiteSpace(nonce))


### PR DESCRIPTION
### Description

Adds support for the organization name by extending the ID Token validation as follows:

If organization is set and has the org_ prefix, we expect an org_id claim
If organization is set and does not have the org_ prefix, we expect an org_name claim

### Testing

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `main`
