### PR TITLE
Add example to integrate in blazor server

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -318,7 +318,7 @@ public IActionResult Admin()
 The `Auth0-AspNetCore-Authentication` SDK works with Blazor Server in an almost identical way as how it's integrated in ASP.NET Core MVC.
 
 ### Register the SDK
-Registering the SDK is identical as with ASP.NET Core MVC, where you should call `builder.Services.AddAuth0WebAppAuthentication` inside `Program.cs` and ensure to register the authentication middleware (`UseAuthentication()` and `UseAuthorization()`).
+Registering the SDK is identical as with ASP.NET Core MVC, where you should call `builder.Services.AddAuth0WebAppAuthentication` inside `Program.cs`, and ensure the authentication middleware (`UseAuthentication()` and `UseAuthorization()`) is registered.
 
 ```csharp
 builder.Services.AddAuth0WebAppAuthentication(options =>
@@ -336,8 +336,8 @@ app.UseAuthentication();
 app.UseAuthorization();
 ```
 
-### Adding Login and Logout
-Adding Login and Logout is different in the sense that you should create a `PageModel` implementation for both to allow the user to be redirected to and redirect further to Auth0.
+### Add login and logout
+Adding login and logout capabilities is different in the sense that you should create a `PageModel` implementation for both to allow the user to be redirected to Auth0.
 
 ```csharp
 public class LoginModel : PageModel

--- a/README.md
+++ b/README.md
@@ -111,6 +111,8 @@ public async Task Logout()
 
 For more code samples on how to integrate the **auth0-aspnetcore-authentication** SDK in your **ASP.NET MVC** application, have a look at our [examples](https://github.com/auth0/auth0-aspnetcore-authentication/blob/main/EXAMPLES.md).
 
+> This SDK also works with Blazor Server, for more info see [the Blazor Server section in our examples](https://github.com/auth0/auth0-aspnetcore-authentication/blob/main/EXAMPLES.md#blazor-server).
+
 ## API reference
 Explore public API's available in auth0-aspnetcore-authentication.
 


### PR DESCRIPTION
### Description

Adds an example on how to integrate blazor server using the SDK.

Note: The link to the blazor server sample application will 404 until we make it public, which should happen somewhere next week. For the time being, the information in the example should be a good starting point.

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `main`
