### PR TITLE
Allow using ClientAssertion when setting ResponseType

### DIFF
--- a/src/Auth0.AspNetCore.Authentication/AuthenticationBuilderExtensions.cs
+++ b/src/Auth0.AspNetCore.Authentication/AuthenticationBuilderExtensions.cs
@@ -100,9 +100,17 @@ namespace Auth0.AspNetCore.Authentication
 
         private static void ValidateOptions(Auth0WebAppOptions auth0Options)
         {
-            if (CodeResponseTypes.Contains(auth0Options.ResponseType!) && string.IsNullOrWhiteSpace(auth0Options.ClientSecret))
+            if (CodeResponseTypes.Contains(auth0Options.ResponseType!))
             {
-                throw new ArgumentNullException(nameof(auth0Options.ClientSecret), "Client Secret can not be null when using `code` or `code id_token` as the response_type.");
+                if (string.IsNullOrWhiteSpace(auth0Options.ClientSecret) && auth0Options.ClientAssertionSecurityKey == null)
+                {
+                    throw new ArgumentNullException("Both Client Secret and Client Assertion can not be null when using `code` or `code id_token` as the response_type.");
+                }
+
+                if (!string.IsNullOrWhiteSpace(auth0Options.ClientSecret) && auth0Options.ClientAssertionSecurityKey != null)
+                {
+                    throw new ArgumentNullException("Both Client Secret and Client Assertion can not be set at the same time when using `code` or `code id_token` as the response_type.");
+                }
             }
         }
     }

--- a/src/Auth0.AspNetCore.Authentication/AuthenticationBuilderExtensions.cs
+++ b/src/Auth0.AspNetCore.Authentication/AuthenticationBuilderExtensions.cs
@@ -104,12 +104,12 @@ namespace Auth0.AspNetCore.Authentication
             {
                 if (string.IsNullOrWhiteSpace(auth0Options.ClientSecret) && auth0Options.ClientAssertionSecurityKey == null)
                 {
-                    throw new ArgumentNullException("Both Client Secret and Client Assertion can not be null when using `code` or `code id_token` as the response_type.");
+                    throw new InvalidOperationException("Both Client Secret and Client Assertion can not be null when using `code` or `code id_token` as the response_type.");
                 }
 
                 if (!string.IsNullOrWhiteSpace(auth0Options.ClientSecret) && auth0Options.ClientAssertionSecurityKey != null)
                 {
-                    throw new ArgumentNullException("Both Client Secret and Client Assertion can not be set at the same time when using `code` or `code id_token` as the response_type.");
+                    throw new InvalidOperationException("Both Client Secret and Client Assertion can not be set at the same time when using `code` or `code id_token` as the response_type.");
                 }
             }
         }

--- a/tests/Auth0.AspNetCore.Authentication.IntegrationTests/Auth0MiddlewareTests.cs
+++ b/tests/Auth0.AspNetCore.Authentication.IntegrationTests/Auth0MiddlewareTests.cs
@@ -555,6 +555,41 @@ namespace Auth0.AspNetCore.Authentication.IntegrationTests
         }
 
         [Fact]
+        public void Should_Allow_Setting_Code_Without_ClientSecret()
+        {
+            var provider = new RSACryptoServiceProvider();
+            Func<TestServer> act = () => TestServerBuilder.CreateServer(options =>
+            {
+                options.ResponseType = "code";
+                options.ClientAssertionSecurityKey = new RsaSecurityKey(provider);
+                options.ClientAssertionSecurityKeyAlgorithm = SecurityAlgorithms.RsaSha256;
+            }, options =>
+            {
+                options.Audience = "http://local.auth0";
+            });
+
+            act.Should()
+                .NotThrow<Exception>();
+        }
+
+        [Fact]
+        public void Should_Allow_Setting_Code_Without_ClientAssertion()
+        {
+            var provider = new RSACryptoServiceProvider();
+            Func<TestServer> act = () => TestServerBuilder.CreateServer(options =>
+            {
+                options.ResponseType = "code";
+                options.ClientSecret = "123";
+            }, options =>
+            {
+                options.Audience = "http://local.auth0";
+            });
+
+            act.Should()
+                .NotThrow<Exception>();
+        }
+
+        [Fact]
         public void Should_Allow_Configuring_WithAccessToken_Without_ClientAssertion()
         {
             Func<TestServer> act = () => TestServerBuilder.CreateServer(options =>
@@ -575,7 +610,6 @@ namespace Auth0.AspNetCore.Authentication.IntegrationTests
             var provider = new RSACryptoServiceProvider();
             Func<TestServer> act = () => TestServerBuilder.CreateServer(options =>
             {
-
                 options.ClientAssertionSecurityKey = new RsaSecurityKey(provider);
                 options.ClientAssertionSecurityKeyAlgorithm = SecurityAlgorithms.RsaSha256;
             }, options =>
@@ -584,7 +618,7 @@ namespace Auth0.AspNetCore.Authentication.IntegrationTests
             });
 
             act.Should()
-                .NotThrow<InvalidOperationException>();
+                .NotThrow<Exception>();
         }
 
         [Fact]

--- a/tests/Auth0.AspNetCore.Authentication.IntegrationTests/Auth0MiddlewareTests.cs
+++ b/tests/Auth0.AspNetCore.Authentication.IntegrationTests/Auth0MiddlewareTests.cs
@@ -510,7 +510,7 @@ namespace Auth0.AspNetCore.Authentication.IntegrationTests
         }
 
         [Fact]
-        public void Should_Not_Allow_ResponseType_Code_Without_ClientSecret()
+        public void Should_Not_Allow_ResponseType_Code_Without_ClientSecret_Or_ClientAssertion()
         {
             Func<TestServer> act = () => TestServerBuilder.CreateServer(options =>
             {
@@ -518,8 +518,8 @@ namespace Auth0.AspNetCore.Authentication.IntegrationTests
             });
 
             act.Should()
-                .Throw<ArgumentNullException>()
-                .Which.Message.Should().Be("Client Secret can not be null when using `code` or `code id_token` as the response_type. (Parameter 'ClientSecret')");
+                .Throw<InvalidOperationException>()
+                .Which.Message.Should().Be("Both Client Secret and Client Assertion can not be null when using `code` or `code id_token` as the response_type.");
         }
 
         [Fact]


### PR DESCRIPTION
### Description

When setting the `ResponseType` explicitly, our SDK would not allow to use ClientAssertion.

This PR rectifies that.

### Testing

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `main`
