### PR TITLE
Support OpenIdConnectOptions.AccessDeniedPath

### DIFF
--- a/src/Auth0.AspNetCore.Authentication/Auth0WebAppOptions.cs
+++ b/src/Auth0.AspNetCore.Authentication/Auth0WebAppOptions.cs
@@ -4,6 +4,7 @@ using Microsoft.IdentityModel.Tokens;
 using System;
 using System.Collections.Generic;
 using System.Net.Http;
+using Microsoft.AspNetCore.Http;
 
 namespace Auth0.AspNetCore.Authentication
 {
@@ -109,5 +110,13 @@ namespace Auth0.AspNetCore.Authentication
         /// the user will be prompted to re-authenticate.
         /// </summary>
         public TimeSpan? MaxAge { get; set; }
+        
+        /// <summary>
+        /// Gets or sets the optional path the user agent is redirected to if the user
+        /// doesn't approve the authorization demand requested by the remote server.
+        /// This property is not set by default. In this case, an exception is thrown
+        /// if an access_denied response is returned by the remote authorization server.
+        /// </summary>
+        public PathString AccessDeniedPath { get; set; }
     }
 }

--- a/src/Auth0.AspNetCore.Authentication/AuthenticationBuilderExtensions.cs
+++ b/src/Auth0.AspNetCore.Authentication/AuthenticationBuilderExtensions.cs
@@ -52,7 +52,7 @@ namespace Auth0.AspNetCore.Authentication
 
             if (!auth0Options.SkipCookieMiddleware)
             {
-                builder.AddCookie(auth0Options.CookieAuthenticationScheme);
+                builder.AddCookie(auth0Options.CookieAuthenticationScheme );
             }
 
             builder.Services.Configure(authenticationScheme, configureOptions);
@@ -78,6 +78,7 @@ namespace Auth0.AspNetCore.Authentication
             oidcOptions.ResponseType = auth0Options.ResponseType ?? oidcOptions.ResponseType;
             oidcOptions.Backchannel = auth0Options.Backchannel!;
             oidcOptions.MaxAge = auth0Options.MaxAge;
+            oidcOptions.AccessDeniedPath = auth0Options.AccessDeniedPath;
 
             if (!oidcOptions.Scope.Contains("openid"))
             {

--- a/src/Auth0.AspNetCore.Authentication/AuthenticationBuilderExtensions.cs
+++ b/src/Auth0.AspNetCore.Authentication/AuthenticationBuilderExtensions.cs
@@ -52,7 +52,7 @@ namespace Auth0.AspNetCore.Authentication
 
             if (!auth0Options.SkipCookieMiddleware)
             {
-                builder.AddCookie(auth0Options.CookieAuthenticationScheme );
+                builder.AddCookie(auth0Options.CookieAuthenticationScheme);
             }
 
             builder.Services.Configure(authenticationScheme, configureOptions);


### PR DESCRIPTION
### Description

This PR exposes the OpenIdConnectOptions.AccessDeniedPath property to control the path to use when an access denied error is thrown from the IDP.

```cs
builder.Services
  .AddAuth0WebAppAuthentication(options => {
    options.Domain = builder.Configuration["Auth0:Domain"];
    options.ClientId = builder.Configuration["Auth0:ClientId"];
    options.AccessDeniedPath = new PathString("/Path/To/Handle/AccessDenied");
});
```

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `main`
