### PR TITLE
Add support for Pushed Authorization Request

### DIFF
--- a/src/Auth0.AspNetCore.Authentication/Auth0WebAppOptions.cs
+++ b/src/Auth0.AspNetCore.Authentication/Auth0WebAppOptions.cs
@@ -118,5 +118,10 @@ namespace Auth0.AspNetCore.Authentication
         /// if an access_denied response is returned by the remote authorization server.
         /// </summary>
         public PathString AccessDeniedPath { get; set; }
+
+        /// <summary>
+        /// Sets whether to use pushed authorization requests or not.
+        /// </summary>
+        public bool UsePushedAuthorization { get; set; } = false;
     }
 }

--- a/src/Auth0.AspNetCore.Authentication/AuthenticationBuilderExtensions.cs
+++ b/src/Auth0.AspNetCore.Authentication/AuthenticationBuilderExtensions.cs
@@ -95,8 +95,7 @@ namespace Auth0.AspNetCore.Authentication
                 ValidateLifetime = true,
                 RequireExpirationTime = true,
             };
-
-            oidcOptions.Events = OpenIdConnectEventsFactory.Create(auth0Options);
+            oidcOptions.Events = OpenIdConnectEventsFactory.Create(auth0Options, oidcOptions);
         }
 
         private static void ValidateOptions(Auth0WebAppOptions auth0Options)

--- a/src/Auth0.AspNetCore.Authentication/Exceptions/ApiError.cs
+++ b/src/Auth0.AspNetCore.Authentication/Exceptions/ApiError.cs
@@ -1,0 +1,58 @@
+using System.Net.Http;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading.Tasks;
+
+namespace Auth0.AspNetCore.Authentication.Exceptions;
+
+/// <summary>
+/// Error information captured from a failed API request.
+/// </summary>
+public class ApiError
+{
+    /// <summary>
+    /// Description of the failing HTTP Status Code.
+    /// </summary>
+    [JsonPropertyName("error")]
+    public string Error { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Description of the error.
+    /// </summary>
+    [JsonPropertyName("error_description")]
+    public string Message { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Parse a <see cref="HttpResponseMessage"/> into an <see cref="ApiError"/> asynchronously.
+    /// </summary>
+    /// <param name="response"><see cref="HttpResponseMessage"/> to parse.</param>
+    /// <returns><see cref="Task"/> representing the operation and associated <see cref="ApiError"/> on
+    /// successful completion.</returns>
+    public static async Task<ApiError?> Parse(HttpResponseMessage response)
+    {
+        var content = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+
+        return Parse(content);
+    }
+
+    internal static ApiError? Parse(string content)
+    {
+        try
+        {
+            return JsonSerializer.Deserialize<ApiError>(content) ?? new ApiError
+            {
+                Error = content,
+                Message = content
+            };
+        }
+        catch (JsonException)
+        {
+            return new ApiError
+            {
+                Error = content,
+                Message = content
+            };
+        }
+    }
+    
+}

--- a/src/Auth0.AspNetCore.Authentication/Exceptions/ApiException.cs
+++ b/src/Auth0.AspNetCore.Authentication/Exceptions/ApiException.cs
@@ -1,0 +1,76 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Runtime.Serialization;
+using System.Threading.Tasks;
+
+namespace Auth0.AspNetCore.Authentication.Exceptions;
+
+/// <summary>
+/// Represents errors that occur when making API calls.
+/// </summary>
+[Serializable]
+public class ErrorApiException : Exception
+{
+    /// <summary>
+    /// Optional <see cref="Exceptions.ApiError"/> from the failing API call.
+    /// </summary>
+    public ApiError? ApiError { get; }
+
+    /// <summary>
+    /// <see cref="HttpStatusCode"/> code from the failing API call.
+    /// </summary>
+    public HttpStatusCode StatusCode { get; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ErrorApiException"/> class.
+    /// </summary>
+    public ErrorApiException()
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ErrorApiException"/> class with a specified error message.
+    /// </summary>
+    /// <param name="message">The error message that explains the reason for the exception.</param>
+    public ErrorApiException(string message)
+        : base(message)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ErrorApiException"/> class with a specified error message
+    /// and a reference to the inner exception that is the cause of this exception.
+    /// </summary>
+    /// <param name="message">The error message that explains the reason for the exception.</param>
+    /// <param name="innerException">The exception that is the cause of the current exception, or a null 
+    /// reference if no inner exception is specified.</param>
+    public ErrorApiException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ApiException"/> class with a specified
+    /// <paramref name="statusCode"/> and optional <paramref name="apiError"/>.
+    /// </summary>
+    /// <param name="statusCode"><see cref="HttpStatusCode"/>code of the failing API call.</param>
+    /// <param name="apiError">Optional <see cref="ApiError"/> of the failing API call.</param>
+    public ErrorApiException(HttpStatusCode statusCode, ApiError? apiError = null)
+        : this(apiError == null ? statusCode.ToString() : apiError.Message)
+    {
+        StatusCode = statusCode;
+        ApiError = apiError;
+    }
+
+    /// <inheritdoc />
+    protected ErrorApiException(SerializationInfo serializationInfo, StreamingContext streamingContext)
+        : base(serializationInfo, streamingContext)
+    {
+    }
+
+    internal static async Task<ErrorApiException> CreateAsync(HttpResponseMessage response)
+    {
+        return new ErrorApiException(response.StatusCode, await ApiError.Parse(response).ConfigureAwait(false));
+    }
+}

--- a/src/Auth0.AspNetCore.Authentication/PushedAuthorizationRequest/PushedAuthorizationRequestHandler.cs
+++ b/src/Auth0.AspNetCore.Authentication/PushedAuthorizationRequest/PushedAuthorizationRequestHandler.cs
@@ -1,0 +1,121 @@
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Threading.Tasks;
+using Auth0.AspNetCore.Authentication.Exceptions;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.OpenIdConnect;
+using Microsoft.IdentityModel.Protocols.OpenIdConnect;
+
+namespace Auth0.AspNetCore.Authentication.PushedAuthorizationRequest;
+
+/// <summary>
+/// Handler used to support Pushed Authorization Request with Microsoft's Open Id Connect package.
+///
+/// This is needed because there is no built-in support for PAR in ASP.NET Core.
+/// Once https://github.com/dotnet/aspnetcore/issues/51686 is implemented, we should be able to replace our
+/// internal implementation and rely on the official implementation.
+/// </summary>
+internal static class PushedAuthorizationRequestHandler
+{
+    public static async Task HandleAsync(RedirectContext context, OpenIdConnectOptions oidcOptions)
+    {
+        // Read the PAR Endpoint from the OIDC configuration.
+        var oidcConfiguration =
+            await oidcOptions.ConfigurationManager?.GetConfigurationAsync(default)!;
+        var parEndpoint = oidcConfiguration?.AdditionalData["pushed_authorization_request_endpoint"] as string;
+
+        // If PAR was enabled in the options, but no `pushed_authorization_request_endpoint` value is find
+        // in the OIDC configuration, we will skip using Pushed Authorization Request.
+        if (string.IsNullOrEmpty(parEndpoint))
+        {
+            return;
+        }
+        
+        var message = context.ProtocolMessage;
+        var properties = context.Properties;
+        var clientId = message.ClientId;
+        
+        // As the client_secret isn't send through the front-channel,
+        // we need to ensure it is added when sending the request through the back-channel.
+        message.SetParameter("client_secret", oidcOptions.ClientSecret);
+
+        SetStateParameter(message, properties, oidcOptions);
+
+        var parResponse = await PostAuthorizationParameters(message, parEndpoint, oidcOptions.Backchannel);
+        
+        SetAuthorizeParameters(message, clientId, parResponse);
+        
+        // Mark the request as handled to avoid it attaches state to the request to /authorize.
+        context.HandleResponse();
+
+        RedirectToAuthorizeEndpoint(context, context.ProtocolMessage);
+    }
+
+    /// <summary>
+    /// Sets the State property on the provided <see cref="OpenIdConnectMessage"/> to a protected value of the <see cref="AuthenticationProperties"/>.
+    /// </summary>
+    /// <param name="message">The <see cref="OpenIdConnectMessage"/> for the current request.</param>
+    /// <param name="properties">The <see cref="AuthenticationProperties"/> for the current request.</param>
+    /// <param name="options">The globally configured <see cref="OpenIdConnectOptions"/>.</param>
+    /// <returns></returns>
+    private static void SetStateParameter(OpenIdConnectMessage message,
+        AuthenticationProperties properties, OpenIdConnectOptions options)
+    {
+        // When redeeming a 'code' for an AccessToken, this value is needed
+        properties.Items.Add(OpenIdConnectDefaults.RedirectUriForCodePropertiesKey, message.RedirectUri);
+
+        message.State = options.StateDataFormat.Protect(properties);
+    }
+
+    /// <summary>
+    /// 
+    /// </summary>
+    /// <param name="message">The <see cref="OpenIdConnectMessage"/> for the current request.</param>
+    /// <param name="parEndpoint">The PAR endpoint used to post the authorization parameters.</param>
+    /// <param name="httpClient">The <see cref="HttpClient"/> configured to use for the PAR request.</param>
+    /// <returns>An instance of <see cref="ParResponse"/>, containing the response details of the PAR request.</returns>
+    /// <exception cref="ErrorApiException"></exception>
+    private static async Task<PushedAuthorizationRequestResponse> PostAuthorizationParameters(OpenIdConnectMessage message, string parEndpoint,
+        HttpClient httpClient)
+    {
+        var requestBody = new FormUrlEncodedContent(message.Parameters);
+
+        var response = await httpClient.PostAsync(parEndpoint, requestBody);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            throw await ErrorApiException.CreateAsync(response).ConfigureAwait(false);
+        }
+
+        return (await response.Content.ReadFromJsonAsync<PushedAuthorizationRequestResponse>()) ?? new PushedAuthorizationRequestResponse();
+    }
+
+    /// <summary>
+    /// Clears the parameters for the current <see cref="OpenIdConnectMessage"/>, and sets the PAR values (clientId and RequestUri)
+    /// </summary>
+    /// <param name="message">The <see cref="OpenIdConnectMessage"/> for the current request.</param>
+    /// <param name="clientId">The currently configured client id used for the application.</param>
+    /// <param name="parResponse"></param>
+    private static void SetAuthorizeParameters(OpenIdConnectMessage message, string clientId, PushedAuthorizationRequestResponse parResponse)
+    {
+        // Remove all the parameters from the protocol message, and replace with what we got from the PAR response
+        message.Parameters.Clear();
+        // Then, set client id and request uri as parameters
+        message.ClientId = clientId;
+        message.RequestUri = parResponse.RequestUri;
+    }
+
+    /// <summary>
+    /// Redirect to the authorize endpoint after successfully posting the parameters to the PAR endpoint.
+    /// </summary>
+    /// <param name="context">The original <see cref="RedirectContext"/> from the OpenId Connect handler.</param>
+    /// <param name="message">The <see cref="OpenIdConnectMessage"/> for the current request.</param>
+    private static void RedirectToAuthorizeEndpoint(RedirectContext context, OpenIdConnectMessage message)
+    {
+        var redirectUri = message.CreateAuthenticationRequestUrl();
+
+        context.Response.Redirect(redirectUri);
+    }
+
+  
+}

--- a/src/Auth0.AspNetCore.Authentication/PushedAuthorizationRequest/PushedAuthorizationRequestResponse.cs
+++ b/src/Auth0.AspNetCore.Authentication/PushedAuthorizationRequest/PushedAuthorizationRequestResponse.cs
@@ -1,0 +1,12 @@
+using System.Text.Json.Serialization;
+
+namespace Auth0.AspNetCore.Authentication.PushedAuthorizationRequest;
+
+internal class PushedAuthorizationRequestResponse
+{
+    [JsonPropertyName("expires_in")] 
+    public int ExpiresIn { get; set; }
+
+    [JsonPropertyName("request_uri")] 
+    public string RequestUri { get; set; } = string.Empty;
+}

--- a/tests/Auth0.AspNetCore.Authentication.IntegrationTests/Auth0.AspNetCore.Authentication.IntegrationTests.csproj
+++ b/tests/Auth0.AspNetCore.Authentication.IntegrationTests/Auth0.AspNetCore.Authentication.IntegrationTests.csproj
@@ -7,6 +7,7 @@
   <ItemGroup>
     <EmbeddedResource Include="jwks.json" />
     <EmbeddedResource Include="wellknownconfig.json" />
+    <EmbeddedResource Include="wellknownconfig_without_par.json" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Auth0.AspNetCore.Authentication.IntegrationTests/Builders/OidcMockBuilder.cs
+++ b/tests/Auth0.AspNetCore.Authentication.IntegrationTests/Builders/OidcMockBuilder.cs
@@ -24,7 +24,7 @@ namespace Auth0.AspNetCore.Authentication.IntegrationTests.Builders
         /// Mock the `.well-known/openid-configuration` request.
         /// </summary>
         /// <returns>The contents of `wellknownconfig.json`, containing some dummy information needed for the tests.</returns>
-        public OidcMockBuilder MockOpenIdConfig()
+        public OidcMockBuilder MockOpenIdConfig(string configFile = "wellknownconfig.json")
         {
             _mockHandler
                    .Protected()
@@ -33,7 +33,7 @@ namespace Auth0.AspNetCore.Authentication.IntegrationTests.Builders
                           ItExpr.Is<HttpRequestMessage>(me => me.IsOpenIdConfigurationEndPoint()),
                           ItExpr.IsAny<CancellationToken>()
                        )
-                       .ReturnsAsync(ReturnResource("wellknownconfig.json").Result);
+                       .ReturnsAsync(ReturnResource(configFile).Result);
 
             return this;
         }

--- a/tests/Auth0.AspNetCore.Authentication.IntegrationTests/Extensions/HttpRequestMessageExtensions.cs
+++ b/tests/Auth0.AspNetCore.Authentication.IntegrationTests/Extensions/HttpRequestMessageExtensions.cs
@@ -36,6 +36,16 @@ namespace Auth0.AspNetCore.Authentication.IntegrationTests.Extensions
         {
             return me.RequestUri.AbsolutePath.Contains("oauth/token");
         }
+        
+        /// <summary>
+        /// Indicate whether or not the HttpRequestMessage points to `oauth/par`.
+        /// </summary>
+        /// <param name="me">The HttpRequestMessage to inspect.</param>
+        /// <returns>True if the request points to `oauth/par`, false if not.</returns>
+        public static bool IsPAREndPoint(this HttpRequestMessage me)
+        {
+            return me.RequestUri.AbsolutePath.Contains("oauth/par");
+        }
 
         /// <summary>
         /// Indicate whether or not the HttpRequestMessage countains the `Auth0-Client` header.

--- a/tests/Auth0.AspNetCore.Authentication.IntegrationTests/wellknownconfig.json
+++ b/tests/Auth0.AspNetCore.Authentication.IntegrationTests/wellknownconfig.json
@@ -2,6 +2,7 @@
   "issuer": "https://tenant.eu.auth0.com/",
   "authorization_endpoint": "https://tenant.eu.auth0.com/authorize",
   "token_endpoint": "https://tenant.eu.auth0.com/oauth/token",
+  "pushed_authorization_request_endpoint": "https://tenant.eu.auth0.com/oauth/par",
   "device_authorization_endpoint": "https://tenant.eu.auth0.com/oauth/device/code",
   "userinfo_endpoint": "https://tenant.eu.auth0.com/userinfo",
   "mfa_challenge_endpoint": "https://tenant.eu.auth0.com/mfa/challenge",

--- a/tests/Auth0.AspNetCore.Authentication.IntegrationTests/wellknownconfig_without_par.json
+++ b/tests/Auth0.AspNetCore.Authentication.IntegrationTests/wellknownconfig_without_par.json
@@ -1,0 +1,63 @@
+﻿{
+  "issuer": "https://tenant.eu.auth0.com/",
+  "authorization_endpoint": "https://tenant.eu.auth0.com/authorize",
+  "token_endpoint": "https://tenant.eu.auth0.com/oauth/token",
+  "device_authorization_endpoint": "https://tenant.eu.auth0.com/oauth/device/code",
+  "userinfo_endpoint": "https://tenant.eu.auth0.com/userinfo",
+  "mfa_challenge_endpoint": "https://tenant.eu.auth0.com/mfa/challenge",
+  "jwks_uri": "https://tenant.eu.auth0.com/.well-known/jwks.json",
+  "registration_endpoint": "https://tenant.eu.auth0.com/oidc/register",
+  "revocation_endpoint": "https://tenant.eu.auth0.com/oauth/revoke",
+  "scopes_supported": [
+    "openid",
+    "profile",
+    "offline_access",
+    "name",
+    "given_name",
+    "family_name",
+    "nickname",
+    "email",
+    "email_verified",
+    "picture",
+    "created_at",
+    "identities",
+    "phone",
+    "address"
+  ],
+  "response_types_supported": [
+    "code",
+    "token",
+    "id_token",
+    "code token",
+    "code id_token",
+    "token id_token",
+    "code token id_token"
+  ],
+  "code_challenge_methods_supported": [ "S256", "plain" ],
+  "response_modes_supported": [ "query", "fragment", "form_post" ],
+  "subject_types_supported": [ "public" ],
+  "id_token_signing_alg_values_supported": [ "HS256", "RS256" ],
+  "token_endpoint_auth_methods_supported": [
+    "client_secret_basic",
+    "client_secret_post"
+  ],
+  "claims_supported": [
+    "aud",
+    "auth_time",
+    "created_at",
+    "email",
+    "email_verified",
+    "exp",
+    "family_name",
+    "given_name",
+    "iat",
+    "identities",
+    "iss",
+    "name",
+    "nickname",
+    "phone_number",
+    "picture",
+    "sub"
+  ],
+  "request_uri_parameter_supported": "false"
+}


### PR DESCRIPTION
### Description

This PR adds support for PAR by intercepting the redirect to the IDP, and posting the parameters to the  `pushed_authorization_request_endpoint` before doing the actual redirect. It also ensures we remove every parameter from the actual redirect to `/authorize`, but ensures to add the `request_uri`.

This is needed because there is no support for PAR yet, see https://github.com/dotnet/aspnetcore/issues/51686.

### Testing

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `main`
