### PR TITLE
Allow SaveTokens to be set to false

### DIFF
--- a/src/Auth0.AspNetCore.Authentication/Auth0WebAppOptions.cs
+++ b/src/Auth0.AspNetCore.Authentication/Auth0WebAppOptions.cs
@@ -151,5 +151,13 @@ namespace Auth0.AspNetCore.Authentication
         /// Set the target to the current scheme to disable forwarding and allow normal processing.
         /// </summary>
         public string? ForwardSignOut { get; set; }
+        
+        /// <summary>
+        /// Defines whether access and refresh tokens should be stored in the <see cref="AuthenticationProperties"/> 
+        /// after a successful authorization.  This property is set to <c>true</c> by default to
+        /// ensure there are no breaking changes with previous versions of the sdk.  Storing tokens will
+        /// increase the size of the final authentication cookie.  
+        /// </summary>
+        public bool SaveTokens { get; set; } = true;
     }
 }

--- a/src/Auth0.AspNetCore.Authentication/AuthenticationBuilderExtensions.cs
+++ b/src/Auth0.AspNetCore.Authentication/AuthenticationBuilderExtensions.cs
@@ -91,7 +91,7 @@ namespace Auth0.AspNetCore.Authentication
             oidcOptions.Scope.Clear();
             oidcOptions.Scope.AddRange(auth0Options.Scope.Split(" "));
             oidcOptions.CallbackPath = new PathString(auth0Options.CallbackPath ?? Auth0Constants.DefaultCallbackPath);
-            oidcOptions.SaveTokens = true;
+            oidcOptions.SaveTokens = auth0Options.SaveTokens;
             oidcOptions.ResponseType = auth0Options.ResponseType ?? oidcOptions.ResponseType;
             oidcOptions.Backchannel = auth0Options.Backchannel!;
             oidcOptions.MaxAge = auth0Options.MaxAge;

--- a/tests/Auth0.AspNetCore.Authentication.IntegrationTests/Controllers/AccountController.cs
+++ b/tests/Auth0.AspNetCore.Authentication.IntegrationTests/Controllers/AccountController.cs
@@ -101,6 +101,18 @@ namespace Auth0.AspNetCore.Authentication.IntegrationTests.Controllers
         {
             return View();
         }
+        
+        public IActionResult Tokens()
+        {
+            var authItems = HttpContext.Features.Get<IAuthenticateResultFeature>()?.AuthenticateResult?.Properties?.Items;
+            if (authItems == null) return BadRequest("Error with authentication result object.");
+            if (authItems.ContainsKey(".Token.access_token")
+                && authItems.ContainsKey(".Token.refresh_token")
+                && authItems.ContainsKey(".Token.id_token"))
+                return Ok($"TokensExist=True");
+            else
+                return Ok($"TokensExist=False");
+        }
 
         private Dictionary<string, string> ObjectToDictionary(object values)
         {

--- a/tests/Auth0.AspNetCore.Authentication.IntegrationTests/Infrastructure/TestServerBuilder.cs
+++ b/tests/Auth0.AspNetCore.Authentication.IntegrationTests/Infrastructure/TestServerBuilder.cs
@@ -23,6 +23,7 @@ namespace Auth0.AspNetCore.Authentication.IntegrationTests.Infrastructure
         public static readonly string Process = "Process";
         public static readonly string Logout = "Account/Logout";
         public static readonly string Callback = "Callback";
+        public static readonly string Tokens = "Account/Tokens";
         public static readonly string ExtraProviderScheme = "ExtraProviderScheme";
 
         /// <summary>


### PR DESCRIPTION

### Description

The current SDK defaults the SetTokens property to true, which stores the ID, access, and refresh tokens in the Authentication cookie.  This behaviour is the opposite of how the OpenIdConnect SDK works and increases the size of the cookies. 

This PR allows users to configure the SaveTokens property via Auth0WebAppOptions.cs.  The default value of this property is true, which ensures there are no breaking changes for current implementations.


### References

https://learn.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.builder.openidconnectoptions

![image](https://github.com/auth0/auth0-aspnetcore-authentication/assets/48587259/99ec35a9-55bc-4e95-8455-2971de9620c2)


### Testing

To test this feature works, I followed the structure of some of the other integration tests that sign the user into the application.  The easiest way to prove whether the tokens were present in the authorisation cookie was to create another method on the Account controller and access HttpContext directly.  I created two tests: -

- Don't Save - I set the SaveTokens to false using Auth0WebAppOptions.
- Save - I don't set anything to prove there are no breaking changes. 
