### PR TITLE
Adding `Auth0.AuthenticationApi` package dependency 

### DIFF
--- a/src/Auth0.AspNetCore.Authentication/Auth0.AspNetCore.Authentication.csproj
+++ b/src/Auth0.AspNetCore.Authentication/Auth0.AspNetCore.Authentication.csproj
@@ -5,6 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Auth0.AuthenticationApi" Version="7.*" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="6.0.*" Condition="'$(TargetFramework)' == 'net6.0'" />
     <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="6.*" Condition="'$(TargetFramework)' == 'net6.0'" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="7.0.*" Condition="'$(TargetFramework)' == 'net7.0'" />

--- a/src/Auth0.AspNetCore.Authentication/Auth0WebAppAuthenticationBuilder.cs
+++ b/src/Auth0.AspNetCore.Authentication/Auth0WebAppAuthenticationBuilder.cs
@@ -5,6 +5,7 @@ using Microsoft.IdentityModel.Protocols.OpenIdConnect;
 using System;
 using System.Threading.Tasks;
 using Auth0.AspNetCore.Authentication.BackchannelLogout;
+using Auth0.AuthenticationApi;
 
 namespace Auth0.AspNetCore.Authentication
 {
@@ -57,6 +58,23 @@ namespace Auth0.AspNetCore.Authentication
         public Auth0WebAppAuthenticationBuilder WithBackchannelLogout()
         {
             _services.AddTransient<BackchannelLogoutHandler>();
+            _services.AddTransient<ILogoutTokenHandler, DefaultLogoutTokenHandler>();
+            return this;
+        }
+
+        /// <summary>
+        /// Configures the IAuthenticationApiClient to leverage Auth0.AuthenticationApi 
+        /// </summary>
+        /// <returns></returns>
+        public Auth0WebAppAuthenticationBuilder WithAuthenticationApiClient()
+        {
+            _services.AddSingleton<IAuthenticationApiClient>(
+                sp =>
+                {
+                    var options = sp.GetRequiredService<IOptionsSnapshot<Auth0WebAppOptions>>().Value;
+                    return new AuthenticationApiClient(new Uri($"https://{options.Domain}"));
+                }
+            );
             _services.AddTransient<ILogoutTokenHandler, DefaultLogoutTokenHandler>();
             return this;
         }

--- a/src/Auth0.AspNetCore.Authentication/Auth0WebAppAuthenticationBuilder.cs
+++ b/src/Auth0.AspNetCore.Authentication/Auth0WebAppAuthenticationBuilder.cs
@@ -5,6 +5,7 @@ using Microsoft.IdentityModel.Protocols.OpenIdConnect;
 using System;
 using System.Threading.Tasks;
 using Auth0.AspNetCore.Authentication.BackchannelLogout;
+using Auth0.AspNetCore.Authentication.ClientInitiatedBackChannelAuthentication;
 using Auth0.AuthenticationApi;
 
 namespace Auth0.AspNetCore.Authentication
@@ -69,16 +70,21 @@ namespace Auth0.AspNetCore.Authentication
         public Auth0WebAppAuthenticationBuilder WithAuthenticationApiClient()
         {
             _services.AddSingleton<IAuthenticationApiClient>(
-                sp =>
-                {
-                    var options = sp.GetRequiredService<IOptionsSnapshot<Auth0WebAppOptions>>().Value;
-                    return new AuthenticationApiClient(new Uri($"https://{options.Domain}"));
-                }
-            );
+                _ => new AuthenticationApiClient(new Uri($"https://{_options.Domain}")));
             _services.AddTransient<ILogoutTokenHandler, DefaultLogoutTokenHandler>();
             return this;
         }
 
+        /// <summary>
+        /// Configures the IAuth0CibaService to leverage the CIBA features. 
+        /// </summary>
+        /// <returns></returns>
+        public Auth0WebAppAuthenticationBuilder WithClientInitiatedBackchannelAuthentication()
+        {
+            _services.AddScoped<IAuth0CibaService, Auth0CibaService>();
+            return this;
+        }
+        
         private void EnableWithAccessToken(Action<Auth0WebAppWithAccessTokenOptions> configureOptions)
         {
             var auth0WithAccessTokensOptions = new Auth0WebAppWithAccessTokenOptions();

--- a/src/Auth0.AspNetCore.Authentication/ClientInitiatedBackChannelAuthentication/Auth0CibaService.cs
+++ b/src/Auth0.AspNetCore.Authentication/ClientInitiatedBackChannelAuthentication/Auth0CibaService.cs
@@ -1,0 +1,119 @@
+using System;
+using System.Threading.Tasks;
+
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+using Auth0.AuthenticationApi;
+using Auth0.AuthenticationApi.Models.Ciba;
+using Auth0.Core.Exceptions;
+
+namespace Auth0.AspNetCore.Authentication.ClientInitiatedBackChannelAuthentication;
+
+internal class Auth0CibaService : IAuth0CibaService
+{
+    private readonly IAuthenticationApiClient _authenticationApiClient;
+    private readonly Auth0WebAppOptions _options;
+    private readonly ILogger<Auth0CibaService> _logger;
+
+    public Auth0CibaService(
+        IAuthenticationApiClient authenticationApiClient,
+        IOptions<Auth0WebAppOptions> optionsAccessor,
+        ILogger<Auth0CibaService> logger)
+    {
+        _authenticationApiClient = authenticationApiClient;
+        _options = optionsAccessor.Value;
+        _logger = logger;
+    }
+
+    public async Task<CibaInitiationDetails> InitiateAuthenticationAsync(CibaInitiationRequest request)
+    {
+        try
+        {
+            var cibaRequest = new ClientInitiatedBackchannelAuthorizationRequest
+            {
+                ClientId = _options.ClientId,
+                ClientSecret = _options.ClientSecret,
+                ClientAssertionSecurityKey = _options.ClientAssertionSecurityKey,
+                ClientAssertionSecurityKeyAlgorithm = _options.ClientAssertionSecurityKeyAlgorithm,
+                Audience = request.Audience,
+                LoginHint = request.LoginHint,
+                Scope = request.Scope,
+                RequestExpiry = request.RequestExpiry,
+                AdditionalProperties = request.AdditionalProperties,
+                BindingMessage = request.BindingMessage,
+            };
+
+            _logger.LogInformation("Initiating CIBA request!");
+            var response = await _authenticationApiClient.ClientInitiatedBackchannelAuthorization(cibaRequest);
+
+            return new CibaInitiationDetails()
+            {
+                AuthRequestId = response.AuthRequestId,
+                ExpiresIn = response.ExpiresIn,
+                Interval = response.Interval,
+                IsSuccessful = true,
+                ErrorMessage = null
+            };
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error initiating CIBA request");
+            throw;
+        }
+    }
+
+    public async Task<CibaCompletionDetails> PollForTokensAsync(CibaInitiationDetails initDetails)
+    {
+        var request = new ClientInitiatedBackchannelAuthorizationTokenRequest()
+        {
+            ClientId = _options.ClientId,
+            ClientSecret = _options.ClientSecret,
+            ClientAssertionSecurityKey = _options.ClientAssertionSecurityKey,
+            ClientAssertionSecurityKeyAlgorithm = _options.ClientAssertionSecurityKeyAlgorithm,
+            AuthRequestId = initDetails.AuthRequestId
+        };
+
+        while (true)
+        {
+            _logger.LogDebug($"Polling CIBA token endpoint for auth_req_id: {initDetails.AuthRequestId} ");
+            try
+            {
+                var response = await _authenticationApiClient.GetTokenAsync(request);
+               
+                return new CibaCompletionDetails
+                {
+                    AccessToken = response.AccessToken,
+                    IdToken = response.IdToken,
+                    TokenType = response.TokenType,
+                    Scope = response.Scope,
+                    ExpiresIn = response.ExpiresIn,
+                    RefreshToken = response.RefreshToken,
+                    IsSuccessful = true,
+                    IsAuthenticationPending = false,
+                };
+            }
+            catch (ErrorApiException ex)
+            {
+                _logger.LogWarning(
+                    ex,
+                    $"CIBA polling error for auth_req_id: {initDetails.AuthRequestId}." +
+                    $" Error: {ex.ApiError.Error}, Description: {ex.ApiError.Message}");
+
+                if (ex.ApiError.Error.Contains("authorization_pending", StringComparison.OrdinalIgnoreCase))
+                {
+                    await Task.Delay(TimeSpan.FromSeconds(initDetails.Interval ?? 5));
+                    continue;
+                }
+
+                return new CibaCompletionDetails
+                {
+                    IsAuthenticationPending = false,
+                    Error = ex.ApiError.Error,
+                    ErrorMessage = ex.ApiError.Message,
+                    IsSuccessful = false
+                };
+            }
+        }
+    }
+}

--- a/src/Auth0.AspNetCore.Authentication/ClientInitiatedBackChannelAuthentication/IAuth0CibaService.cs
+++ b/src/Auth0.AspNetCore.Authentication/ClientInitiatedBackChannelAuthentication/IAuth0CibaService.cs
@@ -1,0 +1,75 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+using Auth0.AuthenticationApi.Models.Ciba;
+
+namespace Auth0.AspNetCore.Authentication.ClientInitiatedBackChannelAuthentication;
+
+public class CibaInitiationDetails
+{
+    public string? AuthRequestId { get; init; }
+    public int ExpiresIn { get; init; }
+    public int? Interval { get; init; }
+    public bool IsSuccessful { get; init; } = true;
+    public string? ErrorMessage { get; init; }
+}
+
+public class CibaInitiationRequest
+{
+    /// <inheritdoc cref="Auth0.AuthenticationApi.Models.Ciba.ClientInitiatedBackchannelAuthorizationRequest.BindingMessage"/>
+    public string? BindingMessage { get; set; }
+
+    /// <inheritdoc cref="Auth0.AuthenticationApi.Models.Ciba.LoginHint"/>
+    public LoginHint? LoginHint { get; set; }
+
+    /// <inheritdoc cref="Auth0.AuthenticationApi.Models.Ciba.ClientInitiatedBackchannelAuthorizationRequest.Scope"/>
+    public string? Scope { get; set; }
+
+    /// <inheritdoc cref="Auth0.AuthenticationApi.Models.Ciba.ClientInitiatedBackchannelAuthorizationRequest.Audience"/>
+    public string? Audience { get; set; }
+
+    /// <inheritdoc cref="Auth0.AuthenticationApi.Models.Ciba.ClientInitiatedBackchannelAuthorizationRequest.RequestExpiry"/>
+    public int? RequestExpiry { get; set; }
+
+    /// <inheritdoc cref="Auth0.AuthenticationApi.Models.Ciba.ClientInitiatedBackchannelAuthorizationRequest.AdditionalProperties"/>
+    public IDictionary<string, string> AdditionalProperties { get; set; } = new Dictionary<string, string>();
+}
+
+public class CibaCompletionDetails : ClientInitiatedBackchannelAuthorizationTokenResponse
+{
+    /// <summary>
+    /// Signifies if the authentication is pending.
+    /// </summary>
+    public bool IsAuthenticationPending { get; set; } = true;
+
+    /// <summary>
+    /// Signifies if the authentication is successful.
+    /// </summary>
+    public bool IsSuccessful { get; set; } = false;
+
+    /// <summary>
+    /// The error received in case of expiry or consent rejection
+    /// </summary>
+    public string? Error { get; set; }
+
+    /// <summary>
+    /// The error message received in case of expiry or consent rejection
+    /// </summary>
+    public string? ErrorMessage { get; set; }
+}
+
+public interface IAuth0CibaService
+{
+    /// <summary>
+    /// Initiates a Client-Initiated Backchannel Authentication (CIBA) flow.
+    /// </summary>
+    /// <param name="request">Contains the information required for initiating the CIBA request.</param>
+    Task<CibaInitiationDetails> InitiateAuthenticationAsync(CibaInitiationRequest request);
+
+    /// <summary>
+    /// Polls the token endpoint to check the status of a CIBA request and retrieve tokens upon completion.
+    /// </summary>
+    /// <param name="cibaInitiationDetails">The information required to poll for the CIBA status.</param>
+    /// <returns>Details about the CIBA completion status or the retrieved tokens.</returns>
+    Task<CibaCompletionDetails> PollForTokensAsync(CibaInitiationDetails cibaInitiationDetails);
+}

--- a/tests/Auth0.AspNetCore.Authentication.IntegrationTests/Auth0CibaServiceTest.cs
+++ b/tests/Auth0.AspNetCore.Authentication.IntegrationTests/Auth0CibaServiceTest.cs
@@ -1,0 +1,192 @@
+using System;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Moq;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+using Auth0.AspNetCore.Authentication.ClientInitiatedBackChannelAuthentication;
+using Auth0.AuthenticationApi;
+using Auth0.AuthenticationApi.Models.Ciba;
+using Auth0.Core.Exceptions;
+
+namespace Auth0.AspNetCore.Authentication.IntegrationTests;
+
+public class Auth0CibaServiceTest
+{
+    private readonly IAuth0CibaService _auth0CibaService;
+    private readonly Mock<IAuthenticationApiClient> _mockAuthenticationApiClient = new();
+
+    public Auth0CibaServiceTest()
+    {
+        _auth0CibaService = new Auth0CibaService(_mockAuthenticationApiClient.Object, Options.Create(
+            new Auth0WebAppOptions()
+            {
+                ClientId = "clientId",
+                ClientSecret = "secret"
+            }), new NullLogger<Auth0CibaService>());
+    }
+
+    [Fact]
+    public async Task InitiateAuthenticationAsync_ReturnsCibaInitiationDetails_OnSuccessfulRequest()
+    {
+        // Arrange
+        var request = new CibaInitiationRequest
+        {
+            Audience = "test-audience",
+            LoginHint = new LoginHint { Format = "test-format", Issuer = "test-issuer", Subject = "test-subject" },
+            Scope = "openid",
+            RequestExpiry = 300,
+            AdditionalProperties = null,
+            BindingMessage = "test-binding-message"
+        };
+
+        var cibaResponse = new ClientInitiatedBackchannelAuthorizationResponse
+        {
+            AuthRequestId = "test-auth-request-id",
+            ExpiresIn = 300,
+            Interval = 5
+        };
+
+        _mockAuthenticationApiClient
+            .Setup(client =>
+                client.ClientInitiatedBackchannelAuthorization(
+                    It.IsAny<ClientInitiatedBackchannelAuthorizationRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(cibaResponse);
+
+        // Act
+        var result = await _auth0CibaService.InitiateAuthenticationAsync(request);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.IsSuccessful.Should().BeTrue();
+        cibaResponse.Interval.Should().Be(result.Interval);
+        cibaResponse.ExpiresIn.Should().Be(result.ExpiresIn);
+        cibaResponse.AuthRequestId.Should().Be(result.AuthRequestId);
+    }
+
+    [Fact]
+    public async Task InitiateAuthenticationAsync_ThrowsException_OnApiError()
+    {
+        // Arrange
+        var request = new CibaInitiationRequest
+        {
+            Audience = "test-audience",
+            LoginHint = new LoginHint { Format = "test-format", Issuer = "test-issuer", Subject = "test-subject" },
+            Scope = "openid"
+        };
+
+        _mockAuthenticationApiClient
+            .Setup(client =>
+                client.ClientInitiatedBackchannelAuthorization(
+                    It.IsAny<ClientInitiatedBackchannelAuthorizationRequest>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new Exception("API error"));
+
+        // Act & Assert
+        await Assert.ThrowsAsync<Exception>(() => _auth0CibaService.InitiateAuthenticationAsync(request));
+    }
+
+    [Fact]
+    public async Task PollForTokensAsync_ReturnsCibaCompletionDetails_OnSuccessfulTokenRetrieval()
+    {
+        // Arrange
+        var initDetails = new CibaInitiationDetails
+        {
+            AuthRequestId = "test-auth-request-id",
+            Interval = 5
+        };
+
+        var tokenResponse = new ClientInitiatedBackchannelAuthorizationTokenResponse
+        {
+            AccessToken = "test-access-token",
+            IdToken = "test-id-token",
+            TokenType = "Bearer",
+            Scope = "openid",
+            ExpiresIn = 3600,
+            RefreshToken = "test-refresh-token"
+        };
+
+        _mockAuthenticationApiClient
+            .Setup(client => client.GetTokenAsync(It.IsAny<ClientInitiatedBackchannelAuthorizationTokenRequest>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(tokenResponse);
+
+        // Act
+        var result = await _auth0CibaService.PollForTokensAsync(initDetails);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.IsSuccessful.Should().BeTrue();
+        tokenResponse.AccessToken.Should().BeEquivalentTo(result.AccessToken);
+        tokenResponse.IdToken.Should().BeEquivalentTo(result.IdToken);
+        tokenResponse.TokenType.Should().BeEquivalentTo(result.TokenType);
+        tokenResponse.Scope.Should().BeEquivalentTo(result.Scope);
+        tokenResponse.ExpiresIn.Should().Be(result.ExpiresIn);
+        tokenResponse.RefreshToken.Should().BeEquivalentTo(result.RefreshToken);
+    }
+
+    [Fact]
+    public async Task PollForTokensAsync_ReturnsPendingStatus_OnAuthorizationPendingError()
+    {
+        // Arrange
+        var initDetails = new CibaInitiationDetails
+        {
+            AuthRequestId = "test-auth-request-id",
+            Interval = 1
+        };
+
+        _mockAuthenticationApiClient
+            .SetupSequence(client =>
+                client.GetTokenAsync(It.IsAny<ClientInitiatedBackchannelAuthorizationTokenRequest>(),
+                    It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new ErrorApiException(HttpStatusCode.InternalServerError, new ApiError
+                { Error = "authorization_pending", Message = "Authorization is pending" }))
+            .ReturnsAsync(new ClientInitiatedBackchannelAuthorizationTokenResponse()
+            {
+                AccessToken = "test-access-token",
+                IdToken = "test-id-token",
+                TokenType = "Bearer",
+                Scope = "openid",
+                ExpiresIn = 3600
+            });
+
+        // Act
+        var result = await _auth0CibaService.PollForTokensAsync(initDetails);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.IsSuccessful.Should().BeTrue();
+        result.AccessToken.Should().Be("test-access-token");
+    }
+
+    [Fact]
+    public async Task PollForTokensAsync_ReturnsErrorDetails_OnNonPendingError()
+    {
+        // Arrange
+        var initDetails = new CibaInitiationDetails
+        {
+            AuthRequestId = "test-auth-request-id",
+            Interval = 5
+        };
+
+        var apiError = new ApiError { Error = "invalid_request", Message = "Invalid request" };
+
+        _mockAuthenticationApiClient
+            .Setup(client => client.GetTokenAsync(It.IsAny<ClientInitiatedBackchannelAuthorizationTokenRequest>(),
+                It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new ErrorApiException(HttpStatusCode.InternalServerError, apiError));
+
+        // Act
+        var result = await _auth0CibaService.PollForTokensAsync(initDetails);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.IsSuccessful.Should().BeFalse();
+        apiError.Error.Should().BeEquivalentTo(result.Error);
+        apiError.Message.Should().BeEquivalentTo(result.ErrorMessage);
+    }
+}


### PR DESCRIPTION
### Description

- Adds `Auth0.AuthenticationApi` [package](https://www.nuget.org/packages/Auth0.AuthenticationApi) as a direct dependency.
- Developers can now use the features of `Auth0.AuthenticationApi` without adding/managing a separate reference.
- [Examples](https://github.com/auth0/auth0-aspnetcore-authentication/blob/feature/SDK-5567/EXAMPLES.md) are updated to show how to register the dependency and use the `AuthenticationApiClient`.
- Added a new `Auth0CibaService` that the developers can register as dependency. It simplifies the CIBA flows and provides a default polling mechanism that the users can opt for. It also provides flexibility for the users to have their own polling mechanism.
- [Examples](https://github.com/auth0/auth0-aspnetcore-authentication/blob/feature/SDK-5567/EXAMPLES.md) are updated to show how to register the dependency and use the `Auth0CibaService`.
 
### Internal References
- [SDK-5567](https://auth0team.atlassian.net/browse/SDK-5567)
- [Discovery](https://oktawiki.atlassian.net/wiki/spaces/DXSDK/pages/3209822410/CIBA+in+Auth0.AspNetCore.Authentication)

### Testing
- Tested the changes on the sample application as well.
- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `main`
