### PR TITLE
Remove refresh_token from cookie instead of setting to NULL

### DIFF
--- a/src/Auth0.AspNetCore.Authentication/AuthenticationBuilderExtensions.cs
+++ b/src/Auth0.AspNetCore.Authentication/AuthenticationBuilderExtensions.cs
@@ -210,7 +210,8 @@ namespace Auth0.AspNetCore.Authentication
                             }
                             else
                             {
-                                context.Properties.UpdateTokenValue("refresh_token", null!);
+                                // Remove the refresh token when refresh fails to ensure OnMissingRefreshToken is called on subsequent requests
+                                context.Properties.Items.Remove(".Token.refresh_token");
                             }
 
                             context.ShouldRenew = true;


### PR DESCRIPTION
### Description

This PR improves the handling of refresh token failures in the Auth0 ASP.NET Core Authentication library.

#### Fix 
- When a refresh token fails to refresh, the code now removes the refresh token from the authentication properties to ensure that the `OnMissingRefreshToken` event is triggered on subsequent requests. 
- A new integration test has been added to verify that `OnMissingRefreshToken` is called after a refresh token failure and subsequent request.

### References

 - [SDK-7171](https://auth0team.atlassian.net/browse/SDK-7171)
 - #191 

### Testing

- `Should_Call_OnMissingRefreshToken_After_Refresh_Fails` test added to simluate simulate a scenarios where refresh fails.

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `main`

[SDK-7171]: https://auth0team.atlassian.net/browse/SDK-7171?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

**Note :** This fix is based on the issue raised by [janruo](https://github.com/janruo) in #191 . The fix will be attributed to [@janruo](https://github.com/janruo) during release.