### PR TITLE
fix: remove duplicate trailing slash from client_assertion audience

### DIFF
--- a/src/Auth0.AspNetCore.Authentication/OpenIdConnectEventsFactory.cs
+++ b/src/Auth0.AspNetCore.Authentication/OpenIdConnectEventsFactory.cs
@@ -242,7 +242,7 @@ namespace Auth0.AspNetCore.Authentication
                         issuer = $"https://{resolvedDomain}/";
                     }
 
-                    var audience = Utils.ToAuthority(issuer) + "/";
+                    var audience = Utils.ToAuthority(issuer);
                     context.TokenEndpointRequest?.SetParameter("client_assertion",
                         new JwtTokenFactory(auth0Options.ClientAssertionSecurityKey,
                                 auth0Options.ClientAssertionSecurityKeyAlgorithm ?? SecurityAlgorithms.RsaSha256)

--- a/tests/Auth0.AspNetCore.Authentication.IntegrationTests/Auth0MiddlewareTests.cs
+++ b/tests/Auth0.AspNetCore.Authentication.IntegrationTests/Auth0MiddlewareTests.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Configuration;
 using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
+using System.IdentityModel.Tokens.Jwt;
 using System.Net.Http.Headers;
 using System.Text;
 using System.Threading.Tasks;
@@ -865,10 +866,16 @@ namespace Auth0.AspNetCore.Authentication.IntegrationTests
             var configuration = TestConfiguration.GetConfiguration();
             var domain = configuration["Auth0:Domain"];
             var clientId = configuration["Auth0:ClientId"];
+            string capturedClientAssertion = null;
             var mockHandler = new OidcMockBuilder()
                 .MockOpenIdConfig()
                 .MockJwks()
-                .MockToken(() => JwtUtils.GenerateToken(1, $"https://{domain}/", clientId, null, nonce), (me) => me.HasClientAssertion())
+                .MockToken(() => JwtUtils.GenerateToken(1, $"https://{domain}/", clientId, null, nonce), (me) =>
+                {
+                    if (!me.HasClientAssertion()) return false;
+                    capturedClientAssertion = me.GetClientAssertion();
+                    return true;
+                })
                 .Build();
 
             var provider = new RSACryptoServiceProvider();
@@ -902,6 +909,12 @@ namespace Auth0.AspNetCore.Authentication.IntegrationTests
                     var callbackResponse = (await client.SendAsync(message, setCookie.Value));
 
                     callbackResponse.Headers.Location.OriginalString.Should().Be("/");
+
+                    capturedClientAssertion.Should().NotBeNullOrEmpty();
+                    var decoded = new JwtSecurityTokenHandler().ReadJwtToken(capturedClientAssertion);
+                    decoded.Audiences.Should().ContainSingle().Which.Should().Be($"https://{domain}/");
+                    decoded.Issuer.Should().Be(clientId);
+                    decoded.Subject.Should().Be(clientId);
                 }
             }
         }

--- a/tests/Auth0.AspNetCore.Authentication.IntegrationTests/Extensions/HttpRequestMessageExtensions.cs
+++ b/tests/Auth0.AspNetCore.Authentication.IntegrationTests/Extensions/HttpRequestMessageExtensions.cs
@@ -1,4 +1,6 @@
-﻿using System.Net.Http;
+﻿using System;
+using System.Linq;
+using System.Net.Http;
 
 namespace Auth0.AspNetCore.Authentication.IntegrationTests.Extensions
 {
@@ -88,6 +90,16 @@ namespace Auth0.AspNetCore.Authentication.IntegrationTests.Extensions
         }
 
         /// <summary>
+        /// Read the URL-decoded value of `client_assertion` from the HttpRequestMessage form body.
+        /// </summary>
+        /// <param name="me">The HttpRequestMessage to inspect.</param>
+        /// <returns>The decoded `client_assertion` value, or null if not present.</returns>
+        public static string GetClientAssertion(this HttpRequestMessage me)
+        {
+            return me.GetBody("client_assertion");
+        }
+
+        /// <summary>
         /// Indicate whether or not the HttpRequestMessage contains the specified property and value, if provided.
         /// </summary>
         /// <param name="me">The HttpRequestMessage to inspect.</param>
@@ -102,6 +114,22 @@ namespace Auth0.AspNetCore.Authentication.IntegrationTests.Extensions
             }
 
             return content.Contains($"{key}=");
+        }
+
+        /// <summary>
+        /// Read the URL-decoded value of the specified form body property, if present.
+        /// </summary>
+        /// <param name="me">The HttpRequestMessage to inspect.</param>
+        /// <param name="key">The form body property name.</param>
+        /// <returns>The decoded value, or null if the property is not present.</returns>
+        private static string GetBody(this HttpRequestMessage me, string key)
+        {
+            var content = me.Content.ReadAsStringAsync().Result;
+            return content.Split('&')
+                .Select(p => p.Split(new[] { '=' }, 2))
+                .Where(kv => kv.Length == 2 && kv[0] == key)
+                .Select(kv => Uri.UnescapeDataString(kv[1]))
+                .FirstOrDefault();
         }
     }
 }


### PR DESCRIPTION
### Description

The `OnAuthorizationCodeReceived` handler builds the `aud` claim for the Private Key JWT client assertion sent to `/oauth/token`. Since v1.7.0 it has been double-appending the trailing slash:

```csharp
var audience = Utils.ToAuthority(issuer) + "/";
```

`Utils.ToAuthority` (added in #206) already normalises its input to a value ending in `/`, so the resulting audience becomes `https://{tenant}//` (two slashes). Auth0's `/oauth/token` endpoint validates that `aud` exactly matches the tenant token endpoint with a single trailing slash, so it rejects the assertion with `401 invalid_client`.

The visible symptom for affected apps (any app configured with `ClientAssertionSecurityKey`) is a callback loop: the OIDC middleware can't complete the code-for-token exchange, retries `/authorize`, Auth0's SSO cookie immediately returns a new code, and the cycle repeats. Server logs show:

```
Microsoft.AspNetCore.Authentication.OpenIdConnect.OpenIdConnectHandler
Message contains error: 'invalid_client', error_description: 'Unauthorized',
error_uri: 'error_uri is null', status code '401'.
```

The companion `TokenClient` path (used for refresh-token exchange in `TokenClient.cs:68`) already used the single-slash form `$"https://{domain}/"` and was unaffected — so the fix brings the OIDC callback path back in line with it.

The change is a one-line removal of the duplicate `+ "/"`.

### References

- Regression introduced in #206 (multiple custom domains support) released in 1.7.0.

### Testing

The existing integration test `Should_Send_ClientAssertion_To_Token_Endpoint` only asserted that a `client_assertion` form parameter was present, which is how this slipped through. It has been strengthened to:

1. Capture the assertion JWT from the token-endpoint request body via a new `HttpRequestMessage.GetClientAssertion()` test helper.
2. Decode it and assert `Audiences` contains exactly `https://{domain}/` (single trailing slash), plus that `Issuer` and `Subject` equal the configured `ClientId`.

Verified by temporarily reverting the fix — the new assertion fails with the buggy double-slash audience; restoring the fix passes.

Full integration suite: 205/205 passing locally on `net10.0`.

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `main`