### PR TITLE
fix: Wires OnValidatePrincipal to the configured cookie scheme

### DIFF
--- a/src/Auth0.AspNetCore.Authentication/AuthenticationBuilderExtensions.cs
+++ b/src/Auth0.AspNetCore.Authentication/AuthenticationBuilderExtensions.cs
@@ -69,7 +69,7 @@ namespace Auth0.AspNetCore.Authentication
             builder.Services.Configure(authenticationScheme, configureOptions);
             builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<IPostConfigureOptions<OpenIdConnectOptions>, Auth0OpenIdConnectPostConfigureOptions>());
 
-            builder.Services.AddOptions<CookieAuthenticationOptions>(CookieAuthenticationDefaults.AuthenticationScheme)
+            builder.Services.AddOptions<CookieAuthenticationOptions>(auth0Options.CookieAuthenticationScheme)
                 .Configure(options =>
                 {
                     options.Events.OnValidatePrincipal = Utils.ProxyEvent(CreateOnValidatePrincipal(authenticationScheme), options.Events.OnValidatePrincipal);

--- a/tests/Auth0.AspNetCore.Authentication.IntegrationTests/Auth0MiddlewareTests.cs
+++ b/tests/Auth0.AspNetCore.Authentication.IntegrationTests/Auth0MiddlewareTests.cs
@@ -1142,6 +1142,62 @@ namespace Auth0.AspNetCore.Authentication.IntegrationTests
         }
 
         [Fact]
+        public async void Should_Refresh_Access_Token_When_Expired_Using_Custom_Cookie_Scheme()
+        {
+            var nonce = "";
+            var cookieScheme = "Test_Cookie_Scheme";
+            var configuration = TestConfiguration.GetConfiguration();
+            var domain = configuration["Auth0:Domain"];
+            var clientId = configuration["Auth0:ClientId"];
+
+            var mockHandler = new OidcMockBuilder()
+                .MockOpenIdConfig()
+                .MockJwks()
+                .MockToken(() => JwtUtils.GenerateToken(1, $"https://{domain}/", clientId, null, nonce, DateTime.UtcNow.AddSeconds(20)), (me) => me.HasGrantType("authorization_code"), 20)
+                .MockToken(() => JwtUtils.GenerateToken(1, $"https://{domain}/", clientId, null, null, DateTime.UtcNow.AddSeconds(20)), (me) => me.HasGrantType("refresh_token") && me.HasClientSecret(), 20)
+                .Build();
+            using (var server = TestServerBuilder.CreateServer(opts =>
+            {
+                opts.ClientSecret = "123";
+                opts.Backchannel = new HttpClient(mockHandler.Object);
+                opts.CookieAuthenticationScheme = cookieScheme;
+            }, opts =>
+            {
+                opts.Audience = "123";
+                opts.UseRefreshTokens = true;
+            }, false, true))
+            {
+
+                using (var client = server.CreateClient())
+                {
+                    var loginResponse = (await client.SendAsync($"{TestServerBuilder.Host}/{TestServerBuilder.Login}"));
+                    var setCookie = Assert.Single(loginResponse.Headers, h => h.Key == "Set-Cookie");
+
+                    var queryParameters = UriUtils.GetQueryParams(loginResponse.Headers.Location);
+
+                    // Keep track of the nonce/state as we need to:
+                    // - Send it to the `/oauth/token` endpoint
+                    nonce = queryParameters["nonce"];
+                    var state = queryParameters["state"];
+
+                    var message = new HttpRequestMessage(HttpMethod.Get, $"{TestServerBuilder.Host}/{TestServerBuilder.Callback}?state={state}&nonce={nonce}&code=123");
+
+                    // Pass along the Set-Cookies to ensure `Nonce` and `Correlation` cookies are set.
+                    var callbackResponse = (await client.SendAsync(message, setCookie.Value));
+
+                    callbackResponse.Headers.Location.OriginalString.Should().Be("/");
+
+                    // Authenticate against the custom cookie scheme so OnValidatePrincipal fires on the
+                    // handler the SDK actually registered. If the refresh hook were wired to the default
+                    // "Cookies" scheme, the refresh_token grant would never be called and Verify() fails.
+                    var response = await client.SendAsync($"{TestServerBuilder.Host}/{TestServerBuilder.Process}?scheme={cookieScheme}", callbackResponse.Headers.GetValues("Set-Cookie"));
+
+                    mockHandler.Verify();
+                }
+            }
+        }
+
+        [Fact]
         public async void Should_Refresh_Access_Token_When_Expired_Using_Client_Assertion()
         {
             var nonce = "";

--- a/tests/Auth0.AspNetCore.Authentication.IntegrationTests/Infrastructure/TestServerBuilder.cs
+++ b/tests/Auth0.AspNetCore.Authentication.IntegrationTests/Infrastructure/TestServerBuilder.cs
@@ -57,10 +57,13 @@ namespace Auth0.AspNetCore.Authentication.IntegrationTests.Infrastructure
 
                                if (req.Path == new PathString("/process"))
                                 {
-                                    var ticket = await context.AuthenticateAsync("Cookies");
+                                    var cookieScheme = req.Query.TryGetValue("scheme", out var schemeValue)
+                                        ? schemeValue.ToString()
+                                        : CookieAuthenticationDefaults.AuthenticationScheme;
+                                    var ticket = await context.AuthenticateAsync(cookieScheme);
                                     await res.WriteAsync(JsonSerializer.Serialize(new
                                     {
-                                        RefreshToken = await context.GetTokenAsync("refresh_token")
+                                        RefreshToken = await context.GetTokenAsync(cookieScheme, "refresh_token")
                                     }));
                                 }
                                 else


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

When a custom `CookieAuthenticationScheme` is configured via `Auth0WebAppOptions`, the access-token refresh hook (`OnValidatePrincipal`) was never invoked, so expired access tokens were not refreshed even when `UseRefreshTokens` was enabled.

The root cause was a scheme mismatch in `AddAuth0WebAppAuthentication`: the `CookieAuthenticationOptions` carrying the `OnValidatePrincipal` handler were always registered against the default `CookieAuthenticationDefaults.AuthenticationScheme` ("Cookies"), rather than against the scheme the SDK actually registers and uses (`auth0Options.CookieAuthenticationScheme`). As a result, when a user configured a custom cookie scheme, the handler was attached to a scheme that was never exercised, and the refresh logic silently never ran.

The fix registers the cookie options against `auth0Options.CookieAuthenticationScheme` so `OnValidatePrincipal` is wired to the configured scheme. When the default scheme is used, behavior is unchanged.

### References

### Testing
- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `main`