### PR TITLE
feat: Adds Muti-Resource Refresh Token (MRRT) support 

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -5,6 +5,11 @@
 - [Calling an API](#calling-an-api)
   - [Configuring the refresh leeway](#configuring-the-refresh-leeway)
 - [Server-side session storage](#server-side-session-storage)
+- [Multi-Resource Refresh Tokens (MRRT)](#multi-resource-refresh-tokens-mrrt)
+  - [Requesting a token for another audience](#requesting-a-token-for-another-audience)
+  - [Configuring default scopes per audience](#configuring-default-scopes-per-audience)
+  - [Forcing a refresh](#forcing-a-refresh)
+  - [Handling refresh failures](#handling-refresh-failures)
 - [Organizations](#organizations)
 - [Extra parameters](#extra-parameters)
 - [Roles](#roles)
@@ -165,6 +170,8 @@ services
 
 A larger leeway refreshes more eagerly (fewer near-expiry tokens, more refresh calls); a smaller leeway refreshes later. The leeway only takes effect when `UseRefreshTokens` is enabled.
 
+> :information_source: To obtain access tokens for **additional** audiences or scopes on demand (without a second login), see [Multi-Resource Refresh Tokens (MRRT)](#multi-resource-refresh-tokens-mrrt).
+
 #### Detecting the absense of a refresh token
 
 In the event where the API, defined in your Auth0 dashboard, isn't configured to [allow offline access](https://auth0.com/docs/get-started/dashboard/api-settings), or the user was already logged in before the use of refresh tokens was enabled (e.g. a user logs in a few minutes before the use of refresh tokens is deployed), it might be useful to detect the absense of a refresh token in order to react accordingly (e.g. log the user out locally and force them to re-login).
@@ -275,6 +282,134 @@ public class RedisTicketStore : ITicketStore
 > :warning: **Running multiple instances:** the store must be shared across them (e.g. a distributed cache such as Redis or SQL Server). An in-memory store only works for a single instance and will cause users to appear logged out when their requests are served by a different instance. Likewise, the [Data Protection keys must be persisted and shared](https://learn.microsoft.com/en-us/aspnet/core/security/data-protection/configuration/overview) across all instances - otherwise tickets become unreadable after a key rotation, app restart, or when served by a different node.
 >
 > :warning: **Protecting the ticket:** it holds sensitive data (claims, access and refresh tokens). Encrypting the payload with `IDataProtector` as shown above means an attacker who gains read access to the cache cannot recover those tokens. Treat the cache backend itself as sensitive too: restrict access and enable encryption in transit (e.g. Redis AUTH + TLS) and at rest.
+
+## Multi-Resource Refresh Tokens (MRRT)
+
+[Multi-Resource Refresh Tokens (MRRT)](https://auth0.com/docs/secure/tokens/refresh-tokens/multi-resource-refresh-token) let a single session obtain access tokens for *additional* audiences and scopes on demand, by exchanging the session's refresh token — without forcing the user through another interactive login.
+
+A typical use case: the user logs in once, and your web app then needs to call a downstream API that expects a token for a *different* audience than the one requested at login. Instead of re-authenticating, you exchange the existing refresh token for a token scoped to that API.
+
+> :information_source: MRRT requires refresh tokens. Configure `UseRefreshTokens = true` and a `ClientSecret`, and ensure MRRT is enabled for your client/APIs in the Auth0 Dashboard. Tokens obtained for additional audiences are cached in the session alongside the login-time ("primary") token and reused until they near expiry.
+
+> :warning: **Token storage and cookie size.** Each additional audience/scope you obtain a token for adds another entry to the cached token set, which by default is serialized into the encrypted **authentication cookie** along with the rest of the session. Cookies cannot grow indefinitely — browsers cap them at around 4 KB each, and request-header limits apply on top of that. An application that fans out across several audiences can therefore accumulate enough tokens to exceed those limits and have the session rejected. If you expect to hold tokens for more than a couple of audiences, move the session **server-side** so only a small session key rides in the cookie while the token set lives in a store you control — see [Server-side session storage](#server-side-session-storage) above. The MRRT API is identical either way; only where the token set is persisted changes.
+
+### Requesting a token for another audience
+
+Use `HttpContext.GetAccessTokenAsync` with an `AccessTokenRequest` describing the `Audience` and/or `Scope` you need. The SDK first tries to satisfy the request from the session (the primary token or a previously cached additional token), and only exchanges the refresh token when no usable cached token exists. Newly obtained tokens are persisted back into the session automatically.
+
+```csharp
+[Authorize]
+public async Task<IActionResult> CallMessagesApi()
+{
+    var accessToken = await HttpContext.GetAccessTokenAsync(new AccessTokenRequest
+    {
+        Audience = "https://messages.example.com",
+        Scope = "read:messages"
+    });
+
+    if (accessToken == null)
+    {
+        // No refresh token available, or the refresh failed — see "Handling refresh failures" below.
+        return Challenge();
+    }
+
+    var request = new HttpRequestMessage(HttpMethod.Get, "https://messages.example.com/api/messages");
+    request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
+
+    var response = await _httpClient.SendAsync(request);
+    return Content(await response.Content.ReadAsStringAsync());
+}
+```
+
+The requested `Scope` is merged (order-preserving union) with the configured default scopes for the resolved audience. Omitting `Audience` falls back to the globally configured `Audience`; omitting `Scope` falls back to the configured default for that audience.
+
+> :information_source: `GetAccessTokenAsync` returns `null` rather than throwing when no refresh token is available or the refresh fails. Always check for `null` before using the token.
+
+When called with no arguments matching the primary audience/scope, `GetAccessTokenAsync` is equivalent to retrieving the login-time access token (and refreshing it when expired).
+
+### Configuring default scopes per audience
+
+You can configure default scopes for each additional audience using `ScopeByAudience`. When an audience is present in this map, its value is used as the default scope for that audience; otherwise the global `Scope` is used as the fallback.
+
+```csharp
+services
+    .AddAuth0WebAppAuthentication(options =>
+    {
+        options.Domain = Configuration["Auth0:Domain"];
+        options.ClientId = Configuration["Auth0:ClientId"];
+        options.ClientSecret = Configuration["Auth0:ClientSecret"];
+    })
+    .WithAccessToken(options =>
+    {
+        options.Audience = Configuration["Auth0:Audience"];
+        options.UseRefreshTokens = true;
+        options.ScopeByAudience = new Dictionary<string, string>
+        {
+            ["https://messages.example.com"] = "read:messages write:messages",
+            ["https://billing.example.com"]  = "read:invoices"
+        };
+    });
+```
+
+With this configured, a request for the `https://messages.example.com` audience defaults to the `read:messages write:messages` scopes, so callers can omit `Scope` for that audience:
+
+```csharp
+var accessToken = await HttpContext.GetAccessTokenAsync(new AccessTokenRequest
+{
+    Audience = "https://messages.example.com"
+});
+```
+
+### Forcing a refresh
+
+Set `ForceRefresh = true` to bypass the cache and always exchange the refresh token for a new access token. The freshly retrieved token still replaces the cached entry.
+
+```csharp
+var accessToken = await HttpContext.GetAccessTokenAsync(new AccessTokenRequest
+{
+    Audience = "https://messages.example.com",
+    Scope = "read:messages",
+    ForceRefresh = true
+});
+```
+
+### Handling refresh failures
+
+When a refresh token is present but the exchange fails, the `OnAccessTokenRefreshFailed` event fires and `GetAccessTokenAsync` returns `null`. The supplied `AccessTokenRefreshFailedContext` carries the failure details so you can distinguish a **terminal** failure (such as an `invalid_grant` for a revoked or expired refresh token, which warrants a re-login) from a **transient** one (such as a timeout or rate-limit, which may be retried).
+
+All refresh failures — token-endpoint rejections, malformed responses, and transport/misconfiguration errors — flow through this single event. For HTTP rejections, `StatusCode`, `Error`, and `ErrorDescription` are populated; for transport failures, `Exception` is populated instead.
+
+```csharp
+services
+    .AddAuth0WebAppAuthentication(options =>
+    {
+        options.Domain = Configuration["Auth0:Domain"];
+        options.ClientId = Configuration["Auth0:ClientId"];
+        options.ClientSecret = Configuration["Auth0:ClientSecret"];
+    })
+    .WithAccessToken(options =>
+    {
+        options.Audience = Configuration["Auth0:Audience"];
+        options.UseRefreshTokens = true;
+        options.Events = new Auth0WebAppWithAccessTokenEvents
+        {
+            OnAccessTokenRefreshFailed = async (context) =>
+            {
+                // A revoked or expired refresh token is terminal — force a re-login.
+                if (context.Error == "invalid_grant")
+                {
+                    await context.HttpContext.SignOutAsync(CookieAuthenticationDefaults.AuthenticationScheme);
+                    var authenticationProperties = new LogoutAuthenticationPropertiesBuilder().WithRedirectUri("/").Build();
+                    await context.HttpContext.ChallengeAsync(Auth0Constants.AuthenticationScheme, authenticationProperties);
+                }
+                // Otherwise (e.g. a timeout surfaced via context.Exception, or a 429), you may
+                // choose to log and let the caller retry.
+            }
+        };
+    });
+```
+
+> :warning: `AccessTokenRefreshFailedContext.Exception` may contain transport/diagnostic detail — log it server-side only, do not surface it to end users.
 
 ## Organizations
 

--- a/README.md
+++ b/README.md
@@ -141,6 +141,20 @@ services.AddAuth0WebAppAuthentication(options =>
 
 For detailed configuration options, caching strategies, security requirements, and more examples, see the [Multiple Custom Domain (MCD) Examples](EXAMPLES.md#multiple-custom-domain-mcd-support).
 
+## Multi-Resource Refresh Tokens (MRRT)
+
+Multi-Resource Refresh Tokens (MRRT) let a single session obtain access tokens for additional audiences and scopes on demand, by exchanging the session's refresh token — without forcing the user through another interactive login.
+
+```csharp
+var accessToken = await HttpContext.GetAccessTokenAsync(new AccessTokenRequest
+{
+    Audience = "https://messages.example.com",
+    Scope = "read:messages"
+});
+```
+
+For configuring per-audience default scopes, forcing a refresh, and handling refresh failures, see the [Multi-Resource Refresh Tokens (MRRT) Examples](EXAMPLES.md#multi-resource-refresh-tokens-mrrt).
+
 ## API reference
 Explore public API's available in auth0-aspnetcore-authentication.
 

--- a/src/Auth0.AspNetCore.Authentication/AccessTokenRefreshFailedContext.cs
+++ b/src/Auth0.AspNetCore.Authentication/AccessTokenRefreshFailedContext.cs
@@ -12,7 +12,7 @@ namespace Auth0.AspNetCore.Authentication
     /// </summary>
     public class AccessTokenRefreshFailedContext
     {
-        internal AccessTokenRefreshFailedContext(HttpContext httpContext, string? audience, string? scope, int? statusCode, string? error, string? errorDescription, Exception? exception)
+        private AccessTokenRefreshFailedContext(HttpContext httpContext, string? audience, string? scope, int? statusCode, string? error, string? errorDescription, Exception? exception)
         {
             HttpContext = httpContext;
             Audience = audience;
@@ -22,6 +22,21 @@ namespace Auth0.AspNetCore.Authentication
             ErrorDescription = errorDescription;
             Exception = exception;
         }
+
+        /// <summary>
+        /// Creates a context for a failure where the token endpoint returned a non-success
+        /// HTTP response. <see cref="Exception"/> is left <c>null</c>.
+        /// </summary>
+        internal static AccessTokenRefreshFailedContext FromHttpRejection(HttpContext httpContext, string? audience, string? scope, int? statusCode, string? error, string? errorDescription) =>
+            new AccessTokenRefreshFailedContext(httpContext, audience, scope, statusCode, error, errorDescription, exception: null);
+
+        /// <summary>
+        /// Creates a context for a failure where the refresh threw before producing an HTTP
+        /// response (for example a transport failure, timeout, or misconfiguration).
+        /// <see cref="StatusCode"/>, <see cref="Error"/>, and <see cref="ErrorDescription"/> are left <c>null</c>.
+        /// </summary>
+        internal static AccessTokenRefreshFailedContext FromException(HttpContext httpContext, string? audience, string? scope, Exception exception) =>
+            new AccessTokenRefreshFailedContext(httpContext, audience, scope, statusCode: null, error: null, errorDescription: null, exception: exception);
 
         /// <summary>
         /// The current <see cref="HttpContext"/>, allowing you to sign the user out, challenge

--- a/src/Auth0.AspNetCore.Authentication/AccessTokenRefreshFailedContext.cs
+++ b/src/Auth0.AspNetCore.Authentication/AccessTokenRefreshFailedContext.cs
@@ -1,0 +1,69 @@
+using Microsoft.AspNetCore.Http;
+using System;
+
+namespace Auth0.AspNetCore.Authentication
+{
+    /// <summary>
+    /// Provides the details of a failed access-token refresh to subscribers of
+    /// <see cref="Auth0WebAppWithAccessTokenEvents.OnAccessTokenRefreshFailed"/>, so they can
+    /// distinguish a terminal failure (such as an <c>invalid_grant</c> for a revoked or expired
+    /// refresh token, which warrants a re-login) from a transient one (such as a timeout or a
+    /// rate-limit, which may be retried).
+    /// </summary>
+    public class AccessTokenRefreshFailedContext
+    {
+        internal AccessTokenRefreshFailedContext(HttpContext httpContext, string? audience, string? scope, int? statusCode, string? error, string? errorDescription, Exception? exception)
+        {
+            HttpContext = httpContext;
+            Audience = audience;
+            Scope = scope;
+            StatusCode = statusCode;
+            Error = error;
+            ErrorDescription = errorDescription;
+            Exception = exception;
+        }
+
+        /// <summary>
+        /// The current <see cref="HttpContext"/>, allowing you to sign the user out, challenge
+        /// for re-login, or resolve services to react to the failure.
+        /// </summary>
+        public HttpContext HttpContext { get; }
+
+        /// <summary>
+        /// The audience the token was being requested for, when one was resolved.
+        /// </summary>
+        public string? Audience { get; }
+
+        /// <summary>
+        /// The scope the token was being requested for, when one was resolved.
+        /// </summary>
+        public string? Scope { get; }
+
+        /// <summary>
+        /// The HTTP status code returned by the token endpoint, when the failure was an HTTP
+        /// rejection. <c>null</c> when the request never produced a response (for example a
+        /// transport failure — see <see cref="Exception"/>).
+        /// </summary>
+        public int? StatusCode { get; }
+
+        /// <summary>
+        /// The <c>error</c> code from the token endpoint's error response (for example
+        /// <c>invalid_grant</c>), when present.
+        /// </summary>
+        public string? Error { get; }
+
+        /// <summary>
+        /// The <c>error_description</c> from the token endpoint's error response, when present.
+        /// </summary>
+        public string? ErrorDescription { get; }
+
+        /// <summary>
+        /// The exception that caused the failure, when the refresh threw rather than returning
+        /// an HTTP error (for example a transport failure, timeout, or misconfiguration).
+        /// <c>null</c> when the failure was an HTTP rejection — see <see cref="StatusCode"/>,
+        /// <see cref="Error"/>, and <see cref="ErrorDescription"/>.
+        /// May contain transport/diagnostic detail; log server-side only, do not surface to end users.
+        /// </summary>
+        public Exception? Exception { get; }
+    }
+}

--- a/src/Auth0.AspNetCore.Authentication/AccessTokenRequest.cs
+++ b/src/Auth0.AspNetCore.Authentication/AccessTokenRequest.cs
@@ -17,5 +17,12 @@ namespace Auth0.AspNetCore.Authentication
         /// default scopes for the resolved audience.
         /// </summary>
         public string? Scope { get; set; }
+
+        /// <summary>
+        /// When <c>true</c>, always exchanges the refresh token for a new access token,
+        /// ignoring any cached token. The freshly retrieved token still replaces the
+        /// cached entry. Defaults to <c>false</c>.
+        /// </summary>
+        public bool ForceRefresh { get; set; }
     }
 }

--- a/src/Auth0.AspNetCore.Authentication/AccessTokenRequest.cs
+++ b/src/Auth0.AspNetCore.Authentication/AccessTokenRequest.cs
@@ -1,0 +1,21 @@
+namespace Auth0.AspNetCore.Authentication
+{
+    /// <summary>
+    /// Describes a request for an access token, optionally targeting a specific
+    /// audience and/or scope.
+    /// </summary>
+    public class AccessTokenRequest
+    {
+        /// <summary>
+        /// The audience to request an access token for. When omitted, the audience
+        /// configured via <see cref="Auth0WebAppWithAccessTokenOptions.Audience"/> is used.
+        /// </summary>
+        public string? Audience { get; set; }
+
+        /// <summary>
+        /// The scopes to request. Merged (order-preserving union) with the configured
+        /// default scopes for the resolved audience.
+        /// </summary>
+        public string? Scope { get; set; }
+    }
+}

--- a/src/Auth0.AspNetCore.Authentication/AccessTokenResponse.cs
+++ b/src/Auth0.AspNetCore.Authentication/AccessTokenResponse.cs
@@ -30,5 +30,11 @@ namespace Auth0.AspNetCore.Authentication
         /// </summary>
         [JsonPropertyName("access_token")]
         public string AccessToken { get; set; } = null!;
+
+        /// <summary>
+        /// Space-separated scopes granted for the access token.
+        /// </summary>
+        [JsonPropertyName("scope")]
+        public string? Scope { get; set; }
     }
 }

--- a/src/Auth0.AspNetCore.Authentication/AccessTokenSet.cs
+++ b/src/Auth0.AspNetCore.Authentication/AccessTokenSet.cs
@@ -1,0 +1,48 @@
+using System.Text.Json.Serialization;
+
+namespace Auth0.AspNetCore.Authentication
+{
+    /// <summary>
+    /// Represents an additional access token retrieved for a specific audience/scope
+    /// combination, stored alongside the primary token in the session.
+    /// </summary>
+    internal class AccessTokenSet
+    {
+        /// <summary>
+        /// The access token.
+        /// </summary>
+        [JsonPropertyName("access_token")]
+        public string AccessToken { get; set; } = null!;
+
+        /// <summary>
+        /// Expiration time as a Unix timestamp (seconds).
+        /// </summary>
+        [JsonPropertyName("expires_at")]
+        public long ExpiresAt { get; set; }
+
+        /// <summary>
+        /// The audience the token was requested for.
+        /// </summary>
+        [JsonPropertyName("audience")]
+        public string Audience { get; set; } = null!;
+
+        /// <summary>
+        /// The scopes actually granted by the authorization server.
+        /// </summary>
+        [JsonPropertyName("scope")]
+        public string? Scope { get; set; }
+
+        /// <summary>
+        /// The scopes originally requested. Tracked separately from <see cref="Scope"/>
+        /// so that future requests for a subset/superset resolve to the same entry.
+        /// </summary>
+        [JsonPropertyName("requested_scope")]
+        public string? RequestedScope { get; set; }
+
+        /// <summary>
+        /// The token type (e.g. "Bearer"). Optional.
+        /// </summary>
+        [JsonPropertyName("token_type")]
+        public string? TokenType { get; set; }
+    }
+}

--- a/src/Auth0.AspNetCore.Authentication/Auth0WebAppAuthenticationBuilder.cs
+++ b/src/Auth0.AspNetCore.Authentication/Auth0WebAppAuthenticationBuilder.cs
@@ -169,6 +169,11 @@ namespace Auth0.AspNetCore.Authentication
 
             ValidateOptions(_options);
 
+            // GetAccessTokenAsync (MRRT) resolves an IHttpClientFactory to exchange the refresh
+            // token when no Backchannel is configured. Register it here so the factory is always
+            // available.
+            _services.AddHttpClient();
+
             _services.Configure(_authenticationScheme, configureOptions);
             _services.AddOptions<OpenIdConnectOptions>(_authenticationScheme)
                 .Configure(options =>

--- a/src/Auth0.AspNetCore.Authentication/Auth0WebAppWithAccessTokenEvents.cs
+++ b/src/Auth0.AspNetCore.Authentication/Auth0WebAppWithAccessTokenEvents.cs
@@ -54,5 +54,38 @@ namespace Auth0.AspNetCore.Authentication
         /// </code>
         /// </example>
         public Func<HttpContext, Task>? OnMissingRefreshToken { get; set; }
+
+        /// <summary>
+        /// Executed when an attempt to exchange the refresh token for an access token failed,
+        /// allowing you to react accordingly (e.g. force a re-login). This fires when a refresh
+        /// token was present but the token endpoint rejected the request (such as an
+        /// <c>invalid_grant</c> for a revoked or expired refresh token) or could not be reached.
+        /// The supplied <see cref="AccessTokenRefreshFailedContext"/> carries the failure details
+        /// (status code, <c>error</c>/<c>error_description</c>, or the thrown exception) so you can
+        /// distinguish a terminal failure from a transient one.
+        /// </summary>
+        /// <example>
+        /// <code>
+        /// services
+        ///   .AddAuth0WebAppAuthentication(options => {})
+        ///   .WithAccessToken(options =>
+        ///   {
+        ///       options.Events = new Auth0WebAppWithAccessTokenEvents
+        ///       {
+        ///           OnAccessTokenRefreshFailed = async (context) =>
+        ///           {
+        ///               // A revoked or expired refresh token is terminal — force a re-login.
+        ///               if (context.Error == "invalid_grant")
+        ///               {
+        ///                   await context.HttpContext.SignOutAsync(CookieAuthenticationDefaults.AuthenticationScheme);
+        ///                   var authenticationProperties = new AuthenticationPropertiesBuilder().WithRedirectUri("/").Build();
+        ///                   await context.HttpContext.ChallengeAsync(Auth0Constants.AuthenticationScheme, authenticationProperties);
+        ///               }
+        ///           }
+        ///       };
+        ///   });
+        /// </code>
+        /// </example>
+        public Func<AccessTokenRefreshFailedContext, Task>? OnAccessTokenRefreshFailed { get; set; }
     }
 }

--- a/src/Auth0.AspNetCore.Authentication/Auth0WebAppWithAccessTokenOptions.cs
+++ b/src/Auth0.AspNetCore.Authentication/Auth0WebAppWithAccessTokenOptions.cs
@@ -33,8 +33,8 @@ namespace Auth0.AspNetCore.Authentication
         /// <summary>
         /// The amount of time before an access token expires during which it is treated as
         /// already expired, so that a refresh is triggered proactively rather than the token
-        /// lapsing mid-request. Only applies when <see cref="UseRefreshTokens"/> is enabled.
-        /// Defaults to 60 seconds.
+        /// lapsing mid-request. Applies to both the primary (login-time) token and additional
+        /// audience/scope tokens retrieved on demand (MRRT). Defaults to 60 seconds.
         /// </summary>
         public TimeSpan AccessTokenExpirationLeeway { get; set; } = TimeSpan.FromSeconds(60);
 

--- a/src/Auth0.AspNetCore.Authentication/Auth0WebAppWithAccessTokenOptions.cs
+++ b/src/Auth0.AspNetCore.Authentication/Auth0WebAppWithAccessTokenOptions.cs
@@ -1,4 +1,5 @@
-﻿using System;
+using System;
+using System.Collections.Generic;
 
 namespace Auth0.AspNetCore.Authentication
 {
@@ -16,6 +17,13 @@ namespace Auth0.AspNetCore.Authentication
         /// Scopes to be used to request token(s). (e.g. "Scope1 Scope2 Scope3")
         /// </summary>
         public string? Scope { get; set; }
+
+        /// <summary>
+        /// Optional per-audience default scopes, used when requesting access tokens for
+        /// additional audiences (MRRT). When an audience is present in this map, its value
+        /// is used as the default scope for that audience; otherwise <see cref="Scope"/> is used.
+        /// </summary>
+        public IReadOnlyDictionary<string, string>? ScopeByAudience { get; set; }
 
         /// <summary>
         /// Define whether or not Refresh Tokens should be used internally when the access token is expired.

--- a/src/Auth0.AspNetCore.Authentication/AuthenticationBuilderExtensions.cs
+++ b/src/Auth0.AspNetCore.Authentication/AuthenticationBuilderExtensions.cs
@@ -251,11 +251,12 @@ namespace Auth0.AspNetCore.Authentication
         private static async Task<AccessTokenResponse?> RefreshTokens(HttpContext httpContext, Auth0WebAppOptions options, string refreshToken, HttpClient httpClient)
         {
             var tokenClient = new TokenClient(httpClient);
-            
+
             // Get the resolved domain from HttpContext if available (for multiple custom domains)
             var resolvedDomain = httpContext.GetResolvedDomain();
-            
-            return await tokenClient.Refresh(options, refreshToken, resolvedDomain);
+
+            var result = await tokenClient.Refresh(options, refreshToken, resolvedDomain);
+            return result.Response;
         }
 
         private static async Task VerifyBackchannelLogoutSupport(HttpContext context, OpenIdConnectOptions oidcOptions)

--- a/src/Auth0.AspNetCore.Authentication/HttpContextExtensions.cs
+++ b/src/Auth0.AspNetCore.Authentication/HttpContextExtensions.cs
@@ -86,11 +86,27 @@ namespace Auth0.AspNetCore.Authentication
             var tokenClient = new TokenClient(httpClient);
             var resolvedDomain = context.GetResolvedDomain();
 
-            var response = await tokenClient.Refresh(options, refreshToken, resolvedDomain, audience, mergedScope).ConfigureAwait(false);
-            if (response == null)
+            TokenRefreshResult result;
+            try
             {
+                result = await tokenClient.Refresh(options, refreshToken, resolvedDomain, audience, mergedScope).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                // Any refresh failure — transport error, malformed response, or misconfiguration —
+                // is folded into the same failure path as a token-endpoint rejection, so callers
+                // have a single failure protocol and nothing escapes this method.
+                await FireRefreshFailed(context, optionsWithAccessToken, audience, mergedScope, statusCode: null, error: null, errorDescription: null, exception: ex).ConfigureAwait(false);
                 return null;
             }
+
+            if (!result.IsSuccess)
+            {
+                await FireRefreshFailed(context, optionsWithAccessToken, audience, mergedScope, result.StatusCode, result.Error, result.ErrorDescription, exception: null).ConfigureAwait(false);
+                return null;
+            }
+
+            var response = result.Response!;
 
             // 3. Merge the new token into the session (primary slot or additional array) and persist.
             ApplyTokenResponse(properties, response, audience, mergedScope, matchesPrimaryToken);
@@ -119,6 +135,15 @@ namespace Auth0.AspNetCore.Authentication
         /// (login-time) token — the one stored in the <c>.Token.access_token</c> slot — rather
         /// than an additional MRRT audience/scope kept in the access-token sets.
         /// </summary>
+        private static async Task FireRefreshFailed(HttpContext context, Auth0WebAppWithAccessTokenOptions optionsWithAccessToken, string? audience, string? scope, int? statusCode, string? error, string? errorDescription, Exception? exception)
+        {
+            if (optionsWithAccessToken.Events?.OnAccessTokenRefreshFailed != null)
+            {
+                var failedContext = new AccessTokenRefreshFailedContext(context, audience, scope, statusCode, error, errorDescription, exception);
+                await optionsWithAccessToken.Events.OnAccessTokenRefreshFailed(failedContext).ConfigureAwait(false);
+            }
+        }
+
         private static bool MatchesPrimaryToken(string? audience, string? mergedScope, Auth0WebAppWithAccessTokenOptions options)
         {
             var matchesPrimaryAudience = audience == null || audience == options.Audience;
@@ -136,7 +161,13 @@ namespace Auth0.AspNetCore.Authentication
                 return true;
             }
 
-            var expiresAt = DateTimeOffset.Parse(expiresAtRaw);
+            // Treat an unparseable timestamp as expired so the token is re-fetched rather
+            // than throwing out of a cache check on a malformed session value.
+            if (!DateTimeOffset.TryParse(expiresAtRaw, out var expiresAt))
+            {
+                return true;
+            }
+
             return DateTimeOffset.Compare(expiresAt, DateTimeOffset.Now.AddSeconds(ExpiryLeewaySeconds)) <= 0;
         }
 
@@ -170,7 +201,16 @@ namespace Auth0.AspNetCore.Authentication
         {
             if (properties.Items.TryGetValue(AccessTokensItemKey, out var json) && !string.IsNullOrEmpty(json))
             {
-                return JsonSerializer.Deserialize<List<AccessTokenSet>>(json) ?? new List<AccessTokenSet>();
+                // Corrupted or version-skewed session data is treated as a cache miss: the
+                // token gets re-fetched, which is preferable to throwing out of a public method.
+                try
+                {
+                    return JsonSerializer.Deserialize<List<AccessTokenSet>>(json) ?? new List<AccessTokenSet>();
+                }
+                catch (JsonException)
+                {
+                    return new List<AccessTokenSet>();
+                }
             }
 
             return new List<AccessTokenSet>();

--- a/src/Auth0.AspNetCore.Authentication/HttpContextExtensions.cs
+++ b/src/Auth0.AspNetCore.Authentication/HttpContextExtensions.cs
@@ -17,7 +17,6 @@ namespace Auth0.AspNetCore.Authentication
     public static class HttpContextExtensions
     {
         internal const string AccessTokensItemKey = ".Token.access_tokens";
-        private const int ExpiryLeewaySeconds = 60;
 
         /// <summary>
         /// Retrieves an access token for the audience/scope described by <paramref name="request"/>.
@@ -55,7 +54,7 @@ namespace Auth0.AspNetCore.Authentication
                 {
                     if (properties.Items.TryGetValue(".Token.access_token", out var primaryToken) &&
                         !string.IsNullOrEmpty(primaryToken) &&
-                        !IsPrimaryExpired(properties))
+                        !IsPrimaryExpired(properties, optionsWithAccessToken.AccessTokenExpirationLeeway))
                     {
                         return primaryToken;
                     }
@@ -64,7 +63,7 @@ namespace Auth0.AspNetCore.Authentication
                 {
                     var sets = ReadAccessTokenSets(properties);
                     var match = TokenSetHelpers.FindAccessTokenSet(sets, audience!, mergedScope, ScopeMatchMode.RequestedScope);
-                    if (match != null && match.ExpiresAt > DateTimeOffset.UtcNow.AddSeconds(ExpiryLeewaySeconds).ToUnixTimeSeconds())
+                    if (match != null && match.ExpiresAt > DateTimeOffset.UtcNow.Add(optionsWithAccessToken.AccessTokenExpirationLeeway).ToUnixTimeSeconds())
                     {
                         return match.AccessToken;
                     }
@@ -154,7 +153,7 @@ namespace Auth0.AspNetCore.Authentication
             return matchesPrimaryAudience && matchesPrimaryScope;
         }
 
-        private static bool IsPrimaryExpired(AuthenticationProperties properties)
+        private static bool IsPrimaryExpired(AuthenticationProperties properties, TimeSpan leeway)
         {
             if (!properties.Items.TryGetValue(".Token.expires_at", out var expiresAtRaw) || string.IsNullOrEmpty(expiresAtRaw))
             {
@@ -168,7 +167,7 @@ namespace Auth0.AspNetCore.Authentication
                 return true;
             }
 
-            return DateTimeOffset.Compare(expiresAt, DateTimeOffset.Now.AddSeconds(ExpiryLeewaySeconds)) <= 0;
+            return DateTimeOffset.Compare(expiresAt, DateTimeOffset.Now.Add(leeway)) <= 0;
         }
 
         private static void ApplyTokenResponse(AuthenticationProperties properties, AccessTokenResponse response, string? audience, string? mergedScope, bool matchesPrimaryToken)

--- a/src/Auth0.AspNetCore.Authentication/HttpContextExtensions.cs
+++ b/src/Auth0.AspNetCore.Authentication/HttpContextExtensions.cs
@@ -47,23 +47,27 @@ namespace Auth0.AspNetCore.Authentication
             var properties = authenticateResult.Properties;
             var matchesPrimaryToken = MatchesPrimaryToken(audience, mergedScope, optionsWithAccessToken);
 
-            // 1. Try to satisfy the request from what is already stored in the session.
-            if (matchesPrimaryToken)
+            // 1. Try to satisfy the request from what is already stored in the session,
+            //    unless the caller explicitly asked to bypass the cache.
+            if (!request.ForceRefresh)
             {
-                if (properties.Items.TryGetValue(".Token.access_token", out var primaryToken) &&
-                    !string.IsNullOrEmpty(primaryToken) &&
-                    !IsPrimaryExpired(properties))
+                if (matchesPrimaryToken)
                 {
-                    return primaryToken;
+                    if (properties.Items.TryGetValue(".Token.access_token", out var primaryToken) &&
+                        !string.IsNullOrEmpty(primaryToken) &&
+                        !IsPrimaryExpired(properties))
+                    {
+                        return primaryToken;
+                    }
                 }
-            }
-            else
-            {
-                var sets = ReadAccessTokenSets(properties);
-                var match = TokenSetHelpers.FindAccessTokenSet(sets, audience!, mergedScope, ScopeMatchMode.RequestedScope);
-                if (match != null && match.ExpiresAt > DateTimeOffset.UtcNow.AddSeconds(ExpiryLeewaySeconds).ToUnixTimeSeconds())
+                else
                 {
-                    return match.AccessToken;
+                    var sets = ReadAccessTokenSets(properties);
+                    var match = TokenSetHelpers.FindAccessTokenSet(sets, audience!, mergedScope, ScopeMatchMode.RequestedScope);
+                    if (match != null && match.ExpiresAt > DateTimeOffset.UtcNow.AddSeconds(ExpiryLeewaySeconds).ToUnixTimeSeconds())
+                    {
+                        return match.AccessToken;
+                    }
                 }
             }
 

--- a/src/Auth0.AspNetCore.Authentication/HttpContextExtensions.cs
+++ b/src/Auth0.AspNetCore.Authentication/HttpContextExtensions.cs
@@ -1,20 +1,180 @@
+using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading.Tasks;
 
-namespace Auth0.AspNetCore.Authentication;
-
-internal static class HttpContextExtensions
+namespace Auth0.AspNetCore.Authentication
 {
     /// <summary>
-    /// Retrieves the resolved domain from the <see cref="HttpContext.Items"/> collection.
+    /// <see cref="HttpContext"/> extensions for retrieving access tokens, including
+    /// on-demand tokens for additional audiences/scopes (Multi-Resource Refresh Token).
     /// </summary>
-    /// <param name="httpContext">The current HTTP context.</param>
-    /// <returns>
-    /// The resolved domain as a <c>string</c> if present; otherwise, <c>null</c>.
-    /// </returns>
-    internal static string? GetResolvedDomain(this HttpContext httpContext)
+    public static class HttpContextExtensions
     {
-        return httpContext.Items.TryGetValue(Auth0Constants.ResolvedDomainKey, out var domainObj)
-            ? domainObj as string
-            : null;
+        internal const string AccessTokensItemKey = ".Token.access_tokens";
+        private const int ExpiryLeewaySeconds = 60;
+
+        /// <summary>
+        /// Retrieves an access token for the audience/scope described by <paramref name="request"/>.
+        /// Reuses a cached token from the session when one is present and not expired; otherwise
+        /// exchanges the session's refresh token for a new token and persists it.
+        /// </summary>
+        /// <param name="context">The current <see cref="HttpContext"/>.</param>
+        /// <param name="request">The audience/scope to request a token for.</param>
+        /// <param name="scheme">The Auth0 authentication scheme. Defaults to <see cref="Auth0Constants.AuthenticationScheme"/>.</param>
+        /// <returns>The access token, or <c>null</c> when no refresh token is available or the refresh failed.</returns>
+        public static async Task<string?> GetAccessTokenAsync(this HttpContext context, AccessTokenRequest request, string? scheme = null)
+        {
+            scheme ??= Auth0Constants.AuthenticationScheme;
+
+            var options = context.RequestServices.GetRequiredService<IOptionsSnapshot<Auth0WebAppOptions>>().Get(scheme);
+            var optionsWithAccessToken = context.RequestServices.GetRequiredService<IOptionsSnapshot<Auth0WebAppWithAccessTokenOptions>>().Get(scheme);
+
+            var audience = request.Audience ?? optionsWithAccessToken.Audience;
+            var mergedScope = TokenSetHelpers.MergeScopeWithDefaults(request.Scope, audience, optionsWithAccessToken.Scope, optionsWithAccessToken.ScopeByAudience);
+
+            var authenticateResult = await context.AuthenticateAsync(options.CookieAuthenticationScheme).ConfigureAwait(false);
+            if (!authenticateResult.Succeeded || authenticateResult.Properties == null)
+            {
+                return null;
+            }
+
+            var properties = authenticateResult.Properties;
+            var matchesPrimaryToken = MatchesPrimaryToken(audience, mergedScope, optionsWithAccessToken);
+
+            // 1. Try to satisfy the request from what is already stored in the session.
+            if (matchesPrimaryToken)
+            {
+                if (properties.Items.TryGetValue(".Token.access_token", out var primaryToken) &&
+                    !string.IsNullOrEmpty(primaryToken) &&
+                    !IsPrimaryExpired(properties))
+                {
+                    return primaryToken;
+                }
+            }
+            else
+            {
+                var sets = ReadAccessTokenSets(properties);
+                var match = TokenSetHelpers.FindAccessTokenSet(sets, audience!, mergedScope, ScopeMatchMode.RequestedScope);
+                if (match != null && match.ExpiresAt > DateTimeOffset.UtcNow.AddSeconds(ExpiryLeewaySeconds).ToUnixTimeSeconds())
+                {
+                    return match.AccessToken;
+                }
+            }
+
+            // 2. No usable token cached — we need the refresh token to obtain one.
+            if (!properties.Items.TryGetValue(".Token.refresh_token", out var refreshToken) || string.IsNullOrWhiteSpace(refreshToken))
+            {
+                if (optionsWithAccessToken.Events?.OnMissingRefreshToken != null)
+                {
+                    await optionsWithAccessToken.Events.OnMissingRefreshToken(context).ConfigureAwait(false);
+                }
+
+                return null;
+            }
+
+            var httpClient = options.Backchannel ?? new HttpClient();
+            var tokenClient = new TokenClient(httpClient);
+            var resolvedDomain = context.GetResolvedDomain();
+
+            var response = await tokenClient.Refresh(options, refreshToken, resolvedDomain, audience, mergedScope).ConfigureAwait(false);
+            if (response == null)
+            {
+                return null;
+            }
+
+            // 3. Merge the new token into the session (primary slot or additional array) and persist.
+            ApplyTokenResponse(properties, response, audience, mergedScope, matchesPrimaryToken);
+
+            await context.SignInAsync(options.CookieAuthenticationScheme, authenticateResult.Principal!, properties).ConfigureAwait(false);
+
+            return response.AccessToken;
+        }
+
+        /// <summary>
+        /// Retrieves the resolved domain from the <see cref="HttpContext.Items"/> collection.
+        /// </summary>
+        /// <param name="httpContext">The current HTTP context.</param>
+        /// <returns>
+        /// The resolved domain as a <c>string</c> if present; otherwise, <c>null</c>.
+        /// </returns>
+        internal static string? GetResolvedDomain(this HttpContext httpContext)
+        {
+            return httpContext.Items.TryGetValue(Auth0Constants.ResolvedDomainKey, out var domainObj)
+                ? domainObj as string
+                : null;
+        }
+
+        /// <summary>
+        /// Determines whether the requested audience/scope matches the application's primary
+        /// (login-time) token — the one stored in the <c>.Token.access_token</c> slot — rather
+        /// than an additional MRRT audience/scope kept in the access-token sets.
+        /// </summary>
+        private static bool MatchesPrimaryToken(string? audience, string? mergedScope, Auth0WebAppWithAccessTokenOptions options)
+        {
+            var matchesPrimaryAudience = audience == null || audience == options.Audience;
+
+            var primaryScope = TokenSetHelpers.GetScopeForAudience(options.Scope, options.ScopeByAudience, audience);
+            var matchesPrimaryScope = string.IsNullOrEmpty(mergedScope) || TokenSetHelpers.CompareScopes(primaryScope, mergedScope);
+
+            return matchesPrimaryAudience && matchesPrimaryScope;
+        }
+
+        private static bool IsPrimaryExpired(AuthenticationProperties properties)
+        {
+            if (!properties.Items.TryGetValue(".Token.expires_at", out var expiresAtRaw) || string.IsNullOrEmpty(expiresAtRaw))
+            {
+                return true;
+            }
+
+            var expiresAt = DateTimeOffset.Parse(expiresAtRaw);
+            return DateTimeOffset.Compare(expiresAt, DateTimeOffset.Now.AddSeconds(ExpiryLeewaySeconds)) <= 0;
+        }
+
+        private static void ApplyTokenResponse(AuthenticationProperties properties, AccessTokenResponse response, string? audience, string? mergedScope, bool matchesPrimaryToken)
+        {
+            if (matchesPrimaryToken)
+            {
+                properties.UpdateTokenValue("access_token", response.AccessToken);
+                properties.UpdateTokenValue("expires_at", DateTimeOffset.Now.AddSeconds(response.ExpiresIn).ToString("o"));
+            }
+            else
+            {
+                var sets = ReadAccessTokenSets(properties);
+                var updated = TokenSetHelpers.UpsertAccessTokenSet(sets, audience!, mergedScope, response);
+                WriteAccessTokenSets(properties, updated);
+            }
+
+            // Rotation + id_token refresh apply regardless of which slot was updated.
+            if (!string.IsNullOrEmpty(response.RefreshToken))
+            {
+                properties.UpdateTokenValue("refresh_token", response.RefreshToken);
+            }
+
+            if (!string.IsNullOrEmpty(response.IdToken))
+            {
+                properties.UpdateTokenValue("id_token", response.IdToken);
+            }
+        }
+
+        private static List<AccessTokenSet> ReadAccessTokenSets(AuthenticationProperties properties)
+        {
+            if (properties.Items.TryGetValue(AccessTokensItemKey, out var json) && !string.IsNullOrEmpty(json))
+            {
+                return JsonSerializer.Deserialize<List<AccessTokenSet>>(json) ?? new List<AccessTokenSet>();
+            }
+
+            return new List<AccessTokenSet>();
+        }
+
+        private static void WriteAccessTokenSets(AuthenticationProperties properties, List<AccessTokenSet> sets)
+        {
+            properties.Items[AccessTokensItemKey] = JsonSerializer.Serialize(sets);
+        }
     }
 }

--- a/src/Auth0.AspNetCore.Authentication/HttpContextExtensions.cs
+++ b/src/Auth0.AspNetCore.Authentication/HttpContextExtensions.cs
@@ -23,10 +23,32 @@ namespace Auth0.AspNetCore.Authentication
         /// Reuses a cached token from the session when one is present and not expired; otherwise
         /// exchanges the session's refresh token for a new token and persists it.
         /// </summary>
+        /// <remarks>
+        /// This method is not safe to call concurrently for the same session. It reads the session,
+        /// modifies the stored tokens in memory, and writes them back; concurrent calls each operate on
+        /// their own snapshot, so the last write wins and a freshly fetched token from another in-flight
+        /// call can be silently dropped. More importantly, when refresh-token rotation is enabled,
+        /// concurrent calls exchange the same refresh token: the second exchange presents an
+        /// already-rotated token, which can trigger refresh-token reuse detection and invalidate the
+        /// entire session.
+        /// <para>
+        /// To avoid this, ensure only one <see cref="GetAccessTokenAsync"/> call is in flight per session
+        /// at a time. Either don't issue parallel requests that each trigger a refresh, or plug in a
+        /// server-side session store via
+        /// <see cref="Auth0WebAppAuthenticationBuilder.WithSessionStore(Microsoft.AspNetCore.Authentication.Cookies.ITicketStore)"/>
+        /// whose <c>ITicketStore</c> serializes concurrent access per session.
+        /// </para>
+        /// </remarks>
         /// <param name="context">The current <see cref="HttpContext"/>.</param>
         /// <param name="request">The audience/scope to request a token for.</param>
         /// <param name="scheme">The Auth0 authentication scheme. Defaults to <see cref="Auth0Constants.AuthenticationScheme"/>.</param>
         /// <returns>The access token, or <c>null</c> when no refresh token is available or the refresh failed.</returns>
+        /// <exception cref="System.InvalidOperationException">
+        /// Thrown when a refresh succeeds but the new token cannot be persisted because the response has
+        /// already started. Persisting the refreshed token calls <see cref="AuthenticationHttpContextExtensions.SignInAsync(HttpContext, string?, System.Security.Claims.ClaimsPrincipal, AuthenticationProperties?)"/>,
+        /// which writes the authentication cookie; if the headers have already been sent, this throws and
+        /// the exception propagates out of this method rather than being folded into the refresh-failed path.
+        /// </exception>
         public static async Task<string?> GetAccessTokenAsync(this HttpContext context, AccessTokenRequest request, string? scheme = null)
         {
             scheme ??= Auth0Constants.AuthenticationScheme;

--- a/src/Auth0.AspNetCore.Authentication/HttpContextExtensions.cs
+++ b/src/Auth0.AspNetCore.Authentication/HttpContextExtensions.cs
@@ -81,7 +81,7 @@ namespace Auth0.AspNetCore.Authentication
                 return null;
             }
 
-            var httpClient = options.Backchannel ?? new HttpClient();
+            var httpClient = options.Backchannel ?? context.RequestServices.GetRequiredService<IHttpClientFactory>().CreateClient();
             var tokenClient = new TokenClient(httpClient);
             var resolvedDomain = context.GetResolvedDomain();
 
@@ -95,13 +95,15 @@ namespace Auth0.AspNetCore.Authentication
                 // Any refresh failure — transport error, malformed response, or misconfiguration —
                 // is folded into the same failure path as a token-endpoint rejection, so callers
                 // have a single failure protocol and nothing escapes this method.
-                await FireRefreshFailed(context, optionsWithAccessToken, audience, mergedScope, statusCode: null, error: null, errorDescription: null, exception: ex).ConfigureAwait(false);
+                await FireRefreshFailed(optionsWithAccessToken,
+                    AccessTokenRefreshFailedContext.FromException(context, audience, mergedScope, ex)).ConfigureAwait(false);
                 return null;
             }
 
             if (!result.IsSuccess)
             {
-                await FireRefreshFailed(context, optionsWithAccessToken, audience, mergedScope, result.StatusCode, result.Error, result.ErrorDescription, exception: null).ConfigureAwait(false);
+                await FireRefreshFailed(optionsWithAccessToken,
+                    AccessTokenRefreshFailedContext.FromHttpRejection(context, audience, mergedScope, result.StatusCode, result.Error, result.ErrorDescription)).ConfigureAwait(false);
                 return null;
             }
 
@@ -130,19 +132,22 @@ namespace Auth0.AspNetCore.Authentication
         }
 
         /// <summary>
-        /// Determines whether the requested audience/scope matches the application's primary
-        /// (login-time) token — the one stored in the <c>.Token.access_token</c> slot — rather
-        /// than an additional MRRT audience/scope kept in the access-token sets.
+        /// Fires the <see cref="Auth0WebAppWithAccessTokenEvents.OnAccessTokenRefreshFailed"/> event
+        /// with the details of a failed refresh, when a subscriber is configured.
         /// </summary>
-        private static async Task FireRefreshFailed(HttpContext context, Auth0WebAppWithAccessTokenOptions optionsWithAccessToken, string? audience, string? scope, int? statusCode, string? error, string? errorDescription, Exception? exception)
+        private static async Task FireRefreshFailed(Auth0WebAppWithAccessTokenOptions optionsWithAccessToken, AccessTokenRefreshFailedContext failedContext)
         {
             if (optionsWithAccessToken.Events?.OnAccessTokenRefreshFailed != null)
             {
-                var failedContext = new AccessTokenRefreshFailedContext(context, audience, scope, statusCode, error, errorDescription, exception);
                 await optionsWithAccessToken.Events.OnAccessTokenRefreshFailed(failedContext).ConfigureAwait(false);
             }
         }
 
+        /// <summary>
+        /// Determines whether the requested audience/scope matches the application's primary
+        /// (login-time) token — the one stored in the <c>.Token.access_token</c> slot — rather
+        /// than an additional MRRT audience/scope kept in the access-token sets.
+        /// </summary>
         private static bool MatchesPrimaryToken(string? audience, string? mergedScope, Auth0WebAppWithAccessTokenOptions options)
         {
             var matchesPrimaryAudience = audience == null || audience == options.Audience;

--- a/src/Auth0.AspNetCore.Authentication/TokenClient.cs
+++ b/src/Auth0.AspNetCore.Authentication/TokenClient.cs
@@ -82,9 +82,16 @@ namespace Auth0.AspNetCore.Authentication
                             "The token endpoint returned a response that could not be parsed.");
                     }
 
-                    return accessTokenResponse != null
-                        ? TokenRefreshResult.Success(accessTokenResponse)
-                        : TokenRefreshResult.Failure((int)response.StatusCode);
+                    // A 200 with no usable access_token (e.g. an empty object or a body missing
+                    // the field) deserializes to a non-null response whose AccessToken is null.
+                    // Treat that as a failure so IsSuccess only ever means "we have a usable token"
+                    // and a useless token is never persisted downstream.
+                    return !string.IsNullOrEmpty(accessTokenResponse?.AccessToken)
+                        ? TokenRefreshResult.Success(accessTokenResponse!)
+                        : TokenRefreshResult.Failure(
+                            (int)response.StatusCode,
+                            "invalid_token_response",
+                            "The token endpoint returned a response without an access token.");
                 }
             }
         }

--- a/src/Auth0.AspNetCore.Authentication/TokenClient.cs
+++ b/src/Auth0.AspNetCore.Authentication/TokenClient.cs
@@ -22,13 +22,23 @@ namespace Auth0.AspNetCore.Authentication
             _httpClient = httpClient;
         }
 
-        public async Task<AccessTokenResponse?> Refresh(Auth0WebAppOptions options, string refreshToken, string? domain = null)
+        public async Task<AccessTokenResponse?> Refresh(Auth0WebAppOptions options, string refreshToken, string? domain = null, string? audience = null, string? scope = null)
         {
             var body = new Dictionary<string, string> {
                 { "grant_type", "refresh_token" },
                 { "client_id", options.ClientId },
                 { "refresh_token", refreshToken }
             };
+
+            if (!string.IsNullOrWhiteSpace(audience))
+            {
+                body.Add("audience", audience);
+            }
+
+            if (!string.IsNullOrWhiteSpace(scope))
+            {
+                body.Add("scope", scope);
+            }
 
             // Use provided domain for dynamic resolution, fallback to options.Domain
             var tokenEndpointDomain = domain ?? options.Domain;

--- a/src/Auth0.AspNetCore.Authentication/TokenClient.cs
+++ b/src/Auth0.AspNetCore.Authentication/TokenClient.cs
@@ -22,7 +22,7 @@ namespace Auth0.AspNetCore.Authentication
             _httpClient = httpClient;
         }
 
-        public async Task<AccessTokenResponse?> Refresh(Auth0WebAppOptions options, string refreshToken, string? domain = null, string? audience = null, string? scope = null)
+        public async Task<TokenRefreshResult> Refresh(Auth0WebAppOptions options, string refreshToken, string? domain = null, string? audience = null, string? scope = null)
         {
             var body = new Dictionary<string, string> {
                 { "grant_type", "refresh_token" },
@@ -60,14 +60,70 @@ namespace Auth0.AspNetCore.Authentication
                 {
                     if (!response.IsSuccessStatusCode)
                     {
-                        return null;
+                        return await BuildFailure(response).ConfigureAwait(false);
                     }
 
                     var contentStream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
 
-                    return await JsonSerializer.DeserializeAsync<AccessTokenResponse>(contentStream, _jsonSerializerOptions).ConfigureAwait(false);
+                    AccessTokenResponse? accessTokenResponse;
+                    try
+                    {
+                        accessTokenResponse = await JsonSerializer.DeserializeAsync<AccessTokenResponse>(contentStream, _jsonSerializerOptions).ConfigureAwait(false);
+                    }
+                    catch (JsonException)
+                    {
+                        // The body is over token-bearing bytes (id_token is a JWT of user claims).
+                        // Swallow the parse error so it never surfaces as an exposed Exception on the
+                        // failure event; report a status-code-only failure with a static, payload-free
+                        // message instead.
+                        return new TokenRefreshResult
+                        {
+                            StatusCode = (int)response.StatusCode,
+                            Error = "invalid_token_response",
+                            ErrorDescription = "The token endpoint returned a response that could not be parsed."
+                        };
+                    }
+
+                    return accessTokenResponse != null
+                        ? TokenRefreshResult.Success(accessTokenResponse)
+                        : new TokenRefreshResult { StatusCode = (int)response.StatusCode };
                 }
             }
+        }
+
+        private static async Task<TokenRefreshResult> BuildFailure(HttpResponseMessage response)
+        {
+            var result = new TokenRefreshResult { StatusCode = (int)response.StatusCode };
+
+            try
+            {
+                var body = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+                if (!string.IsNullOrWhiteSpace(body))
+                {
+                    using var document = JsonDocument.Parse(body);
+                    var root = document.RootElement;
+                    if (root.ValueKind == JsonValueKind.Object)
+                    {
+                        // An "mfa_required" error also carries "mfa_token" and "mfa_requirements";
+                        // surfacing those (and completing the MFA flow) is deferred to a subsequent PR.
+                        if (root.TryGetProperty("error", out var errorElement))
+                        {
+                            result.Error = errorElement.GetString();
+                        }
+
+                        if (root.TryGetProperty("error_description", out var descriptionElement))
+                        {
+                            result.ErrorDescription = descriptionElement.GetString();
+                        }
+                    }
+                }
+            }
+            catch (Exception)
+            {
+                // A non-JSON or unreadable error body still yields a result carrying the status code.
+            }
+
+            return result;
         }
 
         private void ApplyClientAuthentication(Auth0WebAppOptions options, Dictionary<string, string> body, string domain)

--- a/src/Auth0.AspNetCore.Authentication/TokenClient.cs
+++ b/src/Auth0.AspNetCore.Authentication/TokenClient.cs
@@ -76,24 +76,23 @@ namespace Auth0.AspNetCore.Authentication
                         // Swallow the parse error so it never surfaces as an exposed Exception on the
                         // failure event; report a status-code-only failure with a static, payload-free
                         // message instead.
-                        return new TokenRefreshResult
-                        {
-                            StatusCode = (int)response.StatusCode,
-                            Error = "invalid_token_response",
-                            ErrorDescription = "The token endpoint returned a response that could not be parsed."
-                        };
+                        return TokenRefreshResult.Failure(
+                            (int)response.StatusCode,
+                            "invalid_token_response",
+                            "The token endpoint returned a response that could not be parsed.");
                     }
 
                     return accessTokenResponse != null
                         ? TokenRefreshResult.Success(accessTokenResponse)
-                        : new TokenRefreshResult { StatusCode = (int)response.StatusCode };
+                        : TokenRefreshResult.Failure((int)response.StatusCode);
                 }
             }
         }
 
         private static async Task<TokenRefreshResult> BuildFailure(HttpResponseMessage response)
         {
-            var result = new TokenRefreshResult { StatusCode = (int)response.StatusCode };
+            string? error = null;
+            string? errorDescription = null;
 
             try
             {
@@ -104,16 +103,14 @@ namespace Auth0.AspNetCore.Authentication
                     var root = document.RootElement;
                     if (root.ValueKind == JsonValueKind.Object)
                     {
-                        // An "mfa_required" error also carries "mfa_token" and "mfa_requirements";
-                        // surfacing those (and completing the MFA flow) is deferred to a subsequent PR.
                         if (root.TryGetProperty("error", out var errorElement))
                         {
-                            result.Error = errorElement.GetString();
+                            error = errorElement.GetString();
                         }
 
                         if (root.TryGetProperty("error_description", out var descriptionElement))
                         {
-                            result.ErrorDescription = descriptionElement.GetString();
+                            errorDescription = descriptionElement.GetString();
                         }
                     }
                 }
@@ -123,7 +120,7 @@ namespace Auth0.AspNetCore.Authentication
                 // A non-JSON or unreadable error body still yields a result carrying the status code.
             }
 
-            return result;
+            return TokenRefreshResult.Failure((int)response.StatusCode, error, errorDescription);
         }
 
         private void ApplyClientAuthentication(Auth0WebAppOptions options, Dictionary<string, string> body, string domain)

--- a/src/Auth0.AspNetCore.Authentication/TokenRefreshResult.cs
+++ b/src/Auth0.AspNetCore.Authentication/TokenRefreshResult.cs
@@ -1,0 +1,25 @@
+namespace Auth0.AspNetCore.Authentication
+{
+    /// <summary>
+    /// The outcome of a refresh-token exchange: either a successful <see cref="Response"/>
+    /// or, on an HTTP rejection, the status code and parsed error details from the body.
+    /// </summary>
+    internal class TokenRefreshResult
+    {
+        /// <summary>The successful token response, or <c>null</c> when the exchange failed.</summary>
+        public AccessTokenResponse? Response { get; set; }
+
+        /// <summary>The HTTP status code returned by the token endpoint when the exchange failed.</summary>
+        public int? StatusCode { get; set; }
+
+        /// <summary>The <c>error</c> code from the token endpoint's error body, when present.</summary>
+        public string? Error { get; set; }
+
+        /// <summary>The <c>error_description</c> from the token endpoint's error body, when present.</summary>
+        public string? ErrorDescription { get; set; }
+
+        public bool IsSuccess => Response != null;
+
+        public static TokenRefreshResult Success(AccessTokenResponse response) => new TokenRefreshResult { Response = response };
+    }
+}

--- a/src/Auth0.AspNetCore.Authentication/TokenRefreshResult.cs
+++ b/src/Auth0.AspNetCore.Authentication/TokenRefreshResult.cs
@@ -2,24 +2,38 @@ namespace Auth0.AspNetCore.Authentication
 {
     /// <summary>
     /// The outcome of a refresh-token exchange: either a successful <see cref="Response"/>
-    /// or, on an HTTP rejection, the status code and parsed error details from the body.
+    /// or, on a failure, the status code and parsed error details from the body. Construct
+    /// via <see cref="Success"/> or <see cref="Failure"/> so the two states stay mutually exclusive.
     /// </summary>
     internal class TokenRefreshResult
     {
+        private TokenRefreshResult()
+        {
+        }
+
         /// <summary>The successful token response, or <c>null</c> when the exchange failed.</summary>
-        public AccessTokenResponse? Response { get; set; }
+        public AccessTokenResponse? Response { get; private set; }
 
         /// <summary>The HTTP status code returned by the token endpoint when the exchange failed.</summary>
-        public int? StatusCode { get; set; }
+        public int? StatusCode { get; private set; }
 
         /// <summary>The <c>error</c> code from the token endpoint's error body, when present.</summary>
-        public string? Error { get; set; }
+        public string? Error { get; private set; }
 
         /// <summary>The <c>error_description</c> from the token endpoint's error body, when present.</summary>
-        public string? ErrorDescription { get; set; }
+        public string? ErrorDescription { get; private set; }
 
         public bool IsSuccess => Response != null;
 
-        public static TokenRefreshResult Success(AccessTokenResponse response) => new TokenRefreshResult { Response = response };
+        public static TokenRefreshResult Success(AccessTokenResponse response) =>
+            new TokenRefreshResult { Response = response };
+
+        public static TokenRefreshResult Failure(int? statusCode, string? error = null, string? errorDescription = null) =>
+            new TokenRefreshResult
+            {
+                StatusCode = statusCode,
+                Error = error,
+                ErrorDescription = errorDescription
+            };
     }
 }

--- a/src/Auth0.AspNetCore.Authentication/TokenSetHelpers.cs
+++ b/src/Auth0.AspNetCore.Authentication/TokenSetHelpers.cs
@@ -156,11 +156,14 @@ namespace Auth0.AspNetCore.Authentication
         /// <item>Else match strictly by granted scope and merge the requested scopes (union).</item>
         /// <item>Else append a new entry.</item>
         /// </list>
+        /// Expired entries are pruned first so stale tokens for combinations that are no longer
+        /// requested don't accumulate in the (cookie-serialized) set indefinitely.
         /// Returns the updated list (a new list instance).
         /// </summary>
         public static List<AccessTokenSet> UpsertAccessTokenSet(IEnumerable<AccessTokenSet>? sets, string audience, string? requestedScope, AccessTokenResponse response)
         {
-            var result = sets?.ToList() ?? new List<AccessTokenSet>();
+            var now = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+            var result = sets?.Where(set => set.ExpiresAt > now).ToList() ?? new List<AccessTokenSet>();
 
             // Case 1: we've served this request before. Refresh the token in place,
             // skipping the write when the access token is unchanged.

--- a/src/Auth0.AspNetCore.Authentication/TokenSetHelpers.cs
+++ b/src/Auth0.AspNetCore.Authentication/TokenSetHelpers.cs
@@ -1,0 +1,214 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Auth0.AspNetCore.Authentication
+{
+    /// <summary>
+    /// Selects how <see cref="TokenSetHelpers.FindAccessTokenSet"/> compares scopes.
+    /// </summary>
+    internal enum ScopeMatchMode
+    {
+        /// <summary>
+        /// Superset membership against the requested scope (falling back to the granted
+        /// scope for older entries that never recorded it). Used on the read path so a
+        /// request for "read" can be served by a cached "read write" token.
+        /// </summary>
+        RequestedScope,
+
+        /// <summary>
+        /// Strict set-equality against the granted scope. Used when deciding whether a
+        /// freshly granted token should replace an existing entry.
+        /// </summary>
+        Granted
+    }
+
+    /// <summary>
+    /// Pure helper functions for scope handling and access-token-set matching/merging.
+    /// </summary>
+    internal static class TokenSetHelpers
+    {
+        /// <summary>
+        /// Splits a space-separated scope string into individual scopes, dropping empties.
+        /// </summary>
+        public static string[] ParseScopes(string? scopes)
+        {
+            if (string.IsNullOrWhiteSpace(scopes))
+            {
+                return Array.Empty<string>();
+            }
+
+            return scopes.Trim().Split(' ').Where(s => !string.IsNullOrEmpty(s)).ToArray();
+        }
+
+        /// <summary>
+        /// Merges two scope strings into an order-preserving union (no sorting).
+        /// </summary>
+        public static string MergeScopes(string? baseScopes, string? additionalScopes)
+        {
+            var ordered = ParseScopes(baseScopes).Concat(ParseScopes(additionalScopes)).Distinct().ToList();
+            return string.Join(" ", ordered);
+        }
+
+        /// <summary>
+        /// Determines whether all <paramref name="requiredScopes"/> are present in
+        /// <paramref name="scopes"/> (set membership). When <paramref name="strict"/> is true,
+        /// the two scope sets must be exactly equal.
+        /// </summary>
+        public static bool CompareScopes(string? scopes, string? requiredScopes, bool strict = false)
+        {
+            if (scopes == requiredScopes)
+            {
+                return true;
+            }
+
+            if (string.IsNullOrEmpty(scopes) || string.IsNullOrEmpty(requiredScopes))
+            {
+                return false;
+            }
+
+            var scopesSet = new HashSet<string>(ParseScopes(scopes));
+            var requiredSet = new HashSet<string>(ParseScopes(requiredScopes));
+
+            var hasAll = requiredSet.All(scopesSet.Contains);
+
+            if (strict)
+            {
+                return hasAll && scopesSet.Count == requiredSet.Count;
+            }
+
+            return hasAll;
+        }
+
+        /// <summary>
+        /// Returns the default scope configured for an audience: the per-audience entry when
+        /// present, otherwise the global default.
+        /// </summary>
+        public static string? GetScopeForAudience(string? scope, IReadOnlyDictionary<string, string>? scopeByAudience, string? audience)
+        {
+            if (scopeByAudience != null && audience != null && scopeByAudience.TryGetValue(audience, out var audienceScope))
+            {
+                return audienceScope;
+            }
+
+            return scope;
+        }
+
+        /// <summary>
+        /// Merges the requested scope with the configured defaults for the audience.
+        /// Order-preserving union of default scopes followed by requested scopes.
+        /// </summary>
+        public static string? MergeScopeWithDefaults(string? requestScope, string? audience, string? scope, IReadOnlyDictionary<string, string>? scopeByAudience)
+        {
+            var defaultScope = GetScopeForAudience(scope, scopeByAudience, audience);
+            var merged = MergeScopes(defaultScope, requestScope);
+
+            return string.IsNullOrEmpty(merged) ? null : merged;
+        }
+
+        /// <summary>
+        /// Finds the best matching <see cref="AccessTokenSet"/> for an audience and scope:
+        /// an exact match is preferred, otherwise the smallest superset.
+        /// </summary>
+        /// <param name="matchMode">
+        /// <see cref="ScopeMatchMode.RequestedScope"/> compares against the requested scope
+        /// (falling back to granted); <see cref="ScopeMatchMode.Granted"/> compares strictly
+        /// against the granted scope.
+        /// </param>
+        public static AccessTokenSet? FindAccessTokenSet(IEnumerable<AccessTokenSet>? sets, string audience, string? scope, ScopeMatchMode matchMode = ScopeMatchMode.RequestedScope)
+        {
+            if (sets == null)
+            {
+                return null;
+            }
+
+            // Audience must match exactly; scope comparison depends on the mode:
+            //  - Granted: strict set-equality against the granted scope (used when deciding
+            //    whether a freshly granted token should replace an existing entry).
+            //  - RequestedScope (default): superset membership against the requested scope,
+            //    falling back to granted for older entries that never recorded it (used on the
+            //    read path, so a request for "read" can be served by a cached "read write" token).
+            var strict = matchMode == ScopeMatchMode.Granted;
+            var matches = sets.Where(set =>
+                set.Audience == audience &&
+                CompareScopes(
+                    strict ? set.Scope : (set.RequestedScope ?? set.Scope),
+                    scope,
+                    strict))
+                .ToList();
+
+            if (matches.Count == 0)
+            {
+                return null;
+            }
+
+            // When several tokens qualify, prefer the least-scoped one (smallest superset) so we
+            // never hand back a more privileged token than the request needs.
+            return matches
+                .OrderBy(set => new HashSet<string>(ParseScopes(set.Scope)).Count)
+                .First();
+        }
+
+        /// <summary>
+        /// Applies a freshly retrieved token to the additional-token collection:
+        /// <list type="number">
+        /// <item>Match by requested scope; if found, replace when the access token changed.</item>
+        /// <item>Else match strictly by granted scope and merge the requested scopes (union).</item>
+        /// <item>Else append a new entry.</item>
+        /// </list>
+        /// Returns the updated list (a new list instance).
+        /// </summary>
+        public static List<AccessTokenSet> UpsertAccessTokenSet(IEnumerable<AccessTokenSet>? sets, string audience, string? requestedScope, AccessTokenResponse response)
+        {
+            var result = sets?.ToList() ?? new List<AccessTokenSet>();
+
+            // Case 1: we've served this request before. Refresh the token in place,
+            // skipping the write when the access token is unchanged.
+            var sameRequest = FindAccessTokenSet(result, audience, requestedScope, ScopeMatchMode.RequestedScope);
+            if (sameRequest != null)
+            {
+                if (sameRequest.AccessToken != response.AccessToken)
+                {
+                    Replace(result, sameRequest, Build(audience, requestedScope, response));
+                }
+
+                return result;
+            }
+
+            // Case 2: a different request resolved to a token we already hold (Auth0
+            // granted the same scope set). Reuse that entry and widen its RequestedScope
+            // so both requests now resolve here.
+            var sameGrant = FindAccessTokenSet(result, audience, response.Scope, ScopeMatchMode.Granted);
+            if (sameGrant != null)
+            {
+                var mergedRequested = MergeScopes(sameGrant.RequestedScope, requestedScope);
+                Replace(result, sameGrant, Build(audience, mergedRequested, response));
+
+                return result;
+            }
+
+            // Case 3: a brand-new audience/scope combination.
+            result.Add(Build(audience, requestedScope, response));
+
+            return result;
+        }
+
+        private static void Replace(List<AccessTokenSet> sets, AccessTokenSet existing, AccessTokenSet updated)
+        {
+            var index = sets.IndexOf(existing);
+            sets[index] = updated;
+        }
+
+        private static AccessTokenSet Build(string audience, string? requestedScope, AccessTokenResponse response)
+        {
+            return new AccessTokenSet
+            {
+                AccessToken = response.AccessToken,
+                ExpiresAt = DateTimeOffset.UtcNow.ToUnixTimeSeconds() + response.ExpiresIn,
+                Audience = audience,
+                Scope = response.Scope,
+                RequestedScope = string.IsNullOrEmpty(requestedScope) ? null : requestedScope
+            };
+        }
+    }
+}

--- a/tests/Auth0.AspNetCore.Authentication.IntegrationTests/HttpContextExtensionsTests.cs
+++ b/tests/Auth0.AspNetCore.Authentication.IntegrationTests/HttpContextExtensionsTests.cs
@@ -180,6 +180,45 @@ namespace Auth0.AspNetCore.Authentication.IntegrationTests
         }
 
         [Fact]
+        public async Task GetAccessTokenAsync_WhenRefreshReturnsTokenlessBody_FiresRefreshFailedEventAndDoesNotPersist()
+        {
+            // 200 OK with no access_token: must be treated as a failure, not a success that
+            // clobbers the cached primary token with null.
+            var handler = CreateRawTokenHandler("{}");
+            var properties = new AuthenticationProperties();
+            properties.Items[".Token.access_token"] = "cached";
+            properties.Items[".Token.expires_at"] = DateTimeOffset.Now.AddHours(1).ToString("o");
+            properties.Items[".Token.refresh_token"] = "rt";
+
+            AccessTokenRefreshFailedContext? captured = null;
+            var context = BuildContext(handler.Object, properties, out var authService, opts =>
+            {
+                opts.Events = new Auth0WebAppWithAccessTokenEvents
+                {
+                    OnAccessTokenRefreshFailed = ctx =>
+                    {
+                        captured = ctx;
+                        return Task.CompletedTask;
+                    }
+                };
+            });
+
+            var result = await context.GetAccessTokenAsync(
+                new AccessTokenRequest { Audience = PrimaryAudience, ForceRefresh = true });
+
+            result.Should().BeNull();
+            captured.Should().NotBeNull();
+            captured!.StatusCode.Should().Be((int)HttpStatusCode.OK);
+            captured.Error.Should().Be("invalid_token_response");
+            captured.ErrorDescription.Should().Be("The token endpoint returned a response without an access token.");
+            // The session must be left untouched — no SignInAsync, so the stale token is preserved.
+            authService.Verify(s => s.SignInAsync(
+                It.IsAny<HttpContext>(), It.IsAny<string>(),
+                It.IsAny<ClaimsPrincipal>(), It.IsAny<AuthenticationProperties>()), Times.Never());
+            properties.Items[".Token.access_token"].Should().Be("cached");
+        }
+
+        [Fact]
         public async Task GetAccessTokenAsync_WhenTransportFails_FiresRefreshFailedEventAndReturnsNull()
         {
             var handler = new Mock<HttpMessageHandler>();

--- a/tests/Auth0.AspNetCore.Authentication.IntegrationTests/HttpContextExtensionsTests.cs
+++ b/tests/Auth0.AspNetCore.Authentication.IntegrationTests/HttpContextExtensionsTests.cs
@@ -102,6 +102,140 @@ namespace Auth0.AspNetCore.Authentication.IntegrationTests
                 ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>());
         }
 
+        [Fact]
+        public async Task GetAccessTokenAsync_WithCorruptedAccessTokenSets_TreatsAsCacheMissAndRefreshes()
+        {
+            var handler = CreateTokenHandler("fresh");
+            var properties = new AuthenticationProperties();
+            properties.Items[".Token.access_token"] = "primary";
+            properties.Items[".Token.expires_at"] = DateTimeOffset.Now.AddHours(1).ToString("o");
+            properties.Items[".Token.refresh_token"] = "rt";
+            // Corrupted/version-skewed additional-token store.
+            properties.Items[".Token.access_tokens"] = "{ this is not valid json";
+
+            var context = BuildContext(handler.Object, properties, out _);
+
+            var result = await context.GetAccessTokenAsync(
+                new AccessTokenRequest { Audience = "https://other-api" });
+
+            // Corruption is swallowed: the request falls through to a refresh rather than throwing.
+            result.Should().Be("fresh");
+        }
+
+        [Fact]
+        public async Task GetAccessTokenAsync_WithMalformedPrimaryExpiry_TreatsAsExpiredAndRefreshes()
+        {
+            var handler = CreateTokenHandler("fresh");
+            var properties = new AuthenticationProperties();
+            properties.Items[".Token.access_token"] = "cached";
+            properties.Items[".Token.expires_at"] = "not-a-date";
+            properties.Items[".Token.refresh_token"] = "rt";
+
+            var context = BuildContext(handler.Object, properties, out _);
+
+            var result = await context.GetAccessTokenAsync(
+                new AccessTokenRequest { Audience = PrimaryAudience });
+
+            result.Should().Be("fresh");
+            handler.Protected().Verify("SendAsync", Times.Once(),
+                ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>());
+        }
+
+        [Fact]
+        public async Task GetAccessTokenAsync_WhenRefreshRejected_FiresRefreshFailedEventAndReturnsNull()
+        {
+            var handler = CreateFailingHandler(HttpStatusCode.BadRequest,
+                "{\"error\":\"invalid_grant\",\"error_description\":\"refresh token revoked\"}");
+            var properties = new AuthenticationProperties();
+            properties.Items[".Token.access_token"] = "cached";
+            properties.Items[".Token.expires_at"] = DateTimeOffset.Now.AddHours(1).ToString("o");
+            properties.Items[".Token.refresh_token"] = "rt";
+
+            AccessTokenRefreshFailedContext? captured = null;
+            var context = BuildContext(handler.Object, properties, out _, opts =>
+            {
+                opts.Events = new Auth0WebAppWithAccessTokenEvents
+                {
+                    OnAccessTokenRefreshFailed = ctx =>
+                    {
+                        captured = ctx;
+                        return Task.CompletedTask;
+                    }
+                };
+            });
+
+            var result = await context.GetAccessTokenAsync(
+                new AccessTokenRequest { Audience = PrimaryAudience, ForceRefresh = true });
+
+            result.Should().BeNull();
+            captured.Should().NotBeNull();
+            captured!.StatusCode.Should().Be((int)HttpStatusCode.BadRequest);
+            captured.Error.Should().Be("invalid_grant");
+            captured.ErrorDescription.Should().Be("refresh token revoked");
+            captured.Exception.Should().BeNull();
+            captured.Audience.Should().Be(PrimaryAudience);
+            captured.HttpContext.Should().BeSameAs(context);
+        }
+
+        [Fact]
+        public async Task GetAccessTokenAsync_WhenTransportFails_FiresRefreshFailedEventAndReturnsNull()
+        {
+            var handler = new Mock<HttpMessageHandler>();
+            handler
+                .Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>())
+                .ThrowsAsync(new HttpRequestException("network down"));
+
+            var properties = new AuthenticationProperties();
+            properties.Items[".Token.access_token"] = "cached";
+            properties.Items[".Token.expires_at"] = DateTimeOffset.Now.AddHours(1).ToString("o");
+            properties.Items[".Token.refresh_token"] = "rt";
+
+            AccessTokenRefreshFailedContext? captured = null;
+            var context = BuildContext(handler.Object, properties, out _, opts =>
+            {
+                opts.Events = new Auth0WebAppWithAccessTokenEvents
+                {
+                    OnAccessTokenRefreshFailed = ctx =>
+                    {
+                        captured = ctx;
+                        return Task.CompletedTask;
+                    }
+                };
+            });
+
+            // A transport failure must not propagate out of the public method.
+            var result = await context.GetAccessTokenAsync(
+                new AccessTokenRequest { Audience = PrimaryAudience, ForceRefresh = true });
+
+            result.Should().BeNull();
+            captured.Should().NotBeNull();
+            // Transport failures surface as the thrown exception, with no HTTP status/error detail.
+            captured!.Exception.Should().BeOfType<HttpRequestException>();
+            captured.StatusCode.Should().BeNull();
+            captured.Error.Should().BeNull();
+        }
+
+        private static Mock<HttpMessageHandler> CreateFailingHandler(HttpStatusCode statusCode, string body)
+        {
+            var handler = new Mock<HttpMessageHandler>();
+            handler
+                .Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>())
+                .ReturnsAsync(new HttpResponseMessage
+                {
+                    StatusCode = statusCode,
+                    Content = new StringContent(body)
+                });
+            return handler;
+        }
+
         private static Mock<HttpMessageHandler> CreateTokenHandler(string accessToken)
         {
             var handler = new Mock<HttpMessageHandler>();

--- a/tests/Auth0.AspNetCore.Authentication.IntegrationTests/HttpContextExtensionsTests.cs
+++ b/tests/Auth0.AspNetCore.Authentication.IntegrationTests/HttpContextExtensionsTests.cs
@@ -6,9 +6,11 @@ using Microsoft.Extensions.Options;
 using Moq;
 using Moq.Protected;
 using System;
+using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
 using System.Security.Claims;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
@@ -219,6 +221,206 @@ namespace Auth0.AspNetCore.Authentication.IntegrationTests
             captured.Error.Should().BeNull();
         }
 
+        [Fact]
+        public async Task GetAccessTokenAsync_AdditionalAudienceCached_ReturnsCachedTokenWithoutCallingBackchannel()
+        {
+            var handler = CreateTokenHandler("fresh");
+            var properties = new AuthenticationProperties();
+            properties.Items[".Token.access_token"] = "primary";
+            properties.Items[".Token.expires_at"] = DateTimeOffset.Now.AddHours(1).ToString("o");
+            properties.Items[".Token.refresh_token"] = "rt";
+            properties.Items[".Token.access_tokens"] = SerializeSets(
+                new AccessTokenSet
+                {
+                    Audience = "https://other-api",
+                    AccessToken = "cached-other",
+                    Scope = "read:other",
+                    RequestedScope = "read:other",
+                    ExpiresAt = DateTimeOffset.UtcNow.AddHours(1).ToUnixTimeSeconds()
+                });
+
+            var context = BuildContext(handler.Object, properties, out var authService);
+
+            var result = await context.GetAccessTokenAsync(
+                new AccessTokenRequest { Audience = "https://other-api", Scope = "read:other" });
+
+            result.Should().Be("cached-other");
+            handler.Protected().Verify("SendAsync", Times.Never(),
+                ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>());
+            authService.Verify(s => s.SignInAsync(
+                It.IsAny<HttpContext>(), It.IsAny<string>(),
+                It.IsAny<ClaimsPrincipal>(), It.IsAny<AuthenticationProperties>()), Times.Never());
+        }
+
+        [Fact]
+        public async Task GetAccessTokenAsync_AdditionalAudienceCached_PrefersSmallestSuperset()
+        {
+            var handler = CreateTokenHandler("fresh");
+            var properties = new AuthenticationProperties();
+            properties.Items[".Token.access_token"] = "primary";
+            properties.Items[".Token.expires_at"] = DateTimeOffset.Now.AddHours(1).ToString("o");
+            properties.Items[".Token.refresh_token"] = "rt";
+            properties.Items[".Token.access_tokens"] = SerializeSets(
+                new AccessTokenSet
+                {
+                    Audience = "https://other-api",
+                    AccessToken = "broad",
+                    Scope = "read write",
+                    RequestedScope = "read write",
+                    ExpiresAt = DateTimeOffset.UtcNow.AddHours(1).ToUnixTimeSeconds()
+                },
+                new AccessTokenSet
+                {
+                    Audience = "https://other-api",
+                    AccessToken = "narrow",
+                    Scope = "read",
+                    RequestedScope = "read",
+                    ExpiresAt = DateTimeOffset.UtcNow.AddHours(1).ToUnixTimeSeconds()
+                });
+
+            var context = BuildContext(handler.Object, properties, out _);
+
+            var result = await context.GetAccessTokenAsync(
+                new AccessTokenRequest { Audience = "https://other-api", Scope = "read" });
+
+            // Both tokens satisfy "read", but the least-scoped one must be returned.
+            result.Should().Be("narrow");
+            handler.Protected().Verify("SendAsync", Times.Never(),
+                ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>());
+        }
+
+        [Fact]
+        public async Task GetAccessTokenAsync_AdditionalAudienceWithinLeeway_TreatsAsExpiredAndRefreshes()
+        {
+            var handler = CreateTokenHandler("fresh");
+            var properties = new AuthenticationProperties();
+            properties.Items[".Token.access_token"] = "primary";
+            properties.Items[".Token.expires_at"] = DateTimeOffset.Now.AddHours(1).ToString("o");
+            properties.Items[".Token.refresh_token"] = "rt";
+            // Token still valid on the wall clock (expires in 30s) but inside the 60s leeway window.
+            properties.Items[".Token.access_tokens"] = SerializeSets(
+                new AccessTokenSet
+                {
+                    Audience = "https://other-api",
+                    AccessToken = "almost-expired",
+                    Scope = "read:other",
+                    RequestedScope = "read:other",
+                    ExpiresAt = DateTimeOffset.UtcNow.AddSeconds(30).ToUnixTimeSeconds()
+                });
+
+            var context = BuildContext(handler.Object, properties, out _);
+
+            var result = await context.GetAccessTokenAsync(
+                new AccessTokenRequest { Audience = "https://other-api", Scope = "read:other" });
+
+            result.Should().Be("fresh");
+            handler.Protected().Verify("SendAsync", Times.Once(),
+                ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>());
+        }
+
+        [Fact]
+        public async Task GetAccessTokenAsync_OnRefresh_PersistsRotatedRefreshToken()
+        {
+            var handler = CreateRawTokenHandler(
+                "{\"access_token\":\"fresh\",\"token_type\":\"Bearer\",\"expires_in\":86400,\"refresh_token\":\"rotated-rt\"}");
+            var properties = new AuthenticationProperties();
+            properties.Items[".Token.access_token"] = "cached";
+            properties.Items[".Token.expires_at"] = DateTimeOffset.Now.AddHours(1).ToString("o");
+            properties.Items[".Token.refresh_token"] = "rt";
+
+            AuthenticationProperties? persisted = null;
+            var context = BuildContext(handler.Object, properties, out var authService);
+            authService
+                .Setup(s => s.SignInAsync(It.IsAny<HttpContext>(), It.IsAny<string>(),
+                    It.IsAny<ClaimsPrincipal>(), It.IsAny<AuthenticationProperties>()))
+                .Callback<HttpContext, string, ClaimsPrincipal, AuthenticationProperties>(
+                    (_, _, _, p) => persisted = p)
+                .Returns(Task.CompletedTask);
+
+            var result = await context.GetAccessTokenAsync(
+                new AccessTokenRequest { Audience = PrimaryAudience, ForceRefresh = true });
+
+            result.Should().Be("fresh");
+            persisted.Should().NotBeNull();
+            persisted!.Items[".Token.refresh_token"].Should().Be("rotated-rt");
+        }
+
+        [Fact]
+        public async Task GetAccessTokenAsync_OnAdditionalAudienceRefresh_PersistsRotatedIdToken()
+        {
+            var handler = CreateRawTokenHandler(
+                "{\"access_token\":\"fresh\",\"token_type\":\"Bearer\",\"expires_in\":86400,\"id_token\":\"rotated-id\"}");
+            var properties = new AuthenticationProperties();
+            properties.Items[".Token.access_token"] = "primary";
+            properties.Items[".Token.expires_at"] = DateTimeOffset.Now.AddHours(1).ToString("o");
+            properties.Items[".Token.id_token"] = "old-id";
+            properties.Items[".Token.refresh_token"] = "rt";
+
+            AuthenticationProperties? persisted = null;
+            var context = BuildContext(handler.Object, properties, out var authService);
+            authService
+                .Setup(s => s.SignInAsync(It.IsAny<HttpContext>(), It.IsAny<string>(),
+                    It.IsAny<ClaimsPrincipal>(), It.IsAny<AuthenticationProperties>()))
+                .Callback<HttpContext, string, ClaimsPrincipal, AuthenticationProperties>(
+                    (_, _, _, p) => persisted = p)
+                .Returns(Task.CompletedTask);
+
+            // A non-primary audience goes through the additional-token path; id_token refresh
+            // must still be persisted regardless of which slot was updated.
+            var result = await context.GetAccessTokenAsync(
+                new AccessTokenRequest { Audience = "https://other-api", Scope = "read:other" });
+
+            result.Should().Be("fresh");
+            persisted.Should().NotBeNull();
+            persisted!.Items[".Token.id_token"].Should().Be("rotated-id");
+        }
+
+        [Fact]
+        public async Task GetAccessTokenAsync_WithScopeByAudience_AppliesPerAudienceDefaultScope()
+        {
+            var capturedBody = string.Empty;
+            var handler = new Mock<HttpMessageHandler>();
+            handler
+                .Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>())
+                .Callback<HttpRequestMessage, CancellationToken>((req, _) =>
+                {
+                    if (req.Content != null)
+                        capturedBody = req.Content.ReadAsStringAsync().Result;
+                })
+                .ReturnsAsync(new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = new StringContent(
+                        "{\"access_token\":\"fresh\",\"token_type\":\"Bearer\",\"expires_in\":86400,\"scope\":\"read:orders\"}")
+                });
+
+            var properties = new AuthenticationProperties();
+            properties.Items[".Token.access_token"] = "primary";
+            properties.Items[".Token.expires_at"] = DateTimeOffset.Now.AddHours(1).ToString("o");
+            properties.Items[".Token.refresh_token"] = "rt";
+
+            var context = BuildContext(handler.Object, properties, out _, opts =>
+            {
+                opts.ScopeByAudience = new Dictionary<string, string> { ["https://orders"] = "read:orders" };
+            });
+
+            // No explicit scope on the request — the per-audience default must flow into the exchange.
+            var result = await context.GetAccessTokenAsync(
+                new AccessTokenRequest { Audience = "https://orders" });
+
+            result.Should().Be("fresh");
+            capturedBody.Should().Contain("scope=read%3Aorders");
+        }
+
+        private static string SerializeSets(params AccessTokenSet[] sets)
+        {
+            return JsonSerializer.Serialize(new List<AccessTokenSet>(sets));
+        }
+
         private static Mock<HttpMessageHandler> CreateFailingHandler(HttpStatusCode statusCode, string body)
         {
             var handler = new Mock<HttpMessageHandler>();
@@ -250,6 +452,23 @@ namespace Auth0.AspNetCore.Authentication.IntegrationTests
                     StatusCode = HttpStatusCode.OK,
                     Content = new StringContent(
                         $"{{\"access_token\":\"{accessToken}\",\"token_type\":\"Bearer\",\"expires_in\":86400}}")
+                });
+            return handler;
+        }
+
+        private static Mock<HttpMessageHandler> CreateRawTokenHandler(string body)
+        {
+            var handler = new Mock<HttpMessageHandler>();
+            handler
+                .Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>())
+                .ReturnsAsync(new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = new StringContent(body)
                 });
             return handler;
         }

--- a/tests/Auth0.AspNetCore.Authentication.IntegrationTests/HttpContextExtensionsTests.cs
+++ b/tests/Auth0.AspNetCore.Authentication.IntegrationTests/HttpContextExtensionsTests.cs
@@ -1,0 +1,172 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Moq;
+using Moq.Protected;
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Security.Claims;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Auth0.AspNetCore.Authentication.IntegrationTests
+{
+    public class HttpContextExtensionsTests
+    {
+        private const string CookieScheme = "Cookies";
+        private const string Domain = "test.auth0.com";
+        private const string PrimaryAudience = "https://api";
+
+        [Fact]
+        public async Task GetAccessTokenAsync_WithoutForceRefresh_ReturnsCachedTokenWithoutCallingBackchannel()
+        {
+            var handler = CreateTokenHandler("fresh");
+            var properties = new AuthenticationProperties();
+            properties.Items[".Token.access_token"] = "cached";
+            properties.Items[".Token.expires_at"] = DateTimeOffset.Now.AddHours(1).ToString("o");
+            properties.Items[".Token.refresh_token"] = "rt";
+
+            var context = BuildContext(handler.Object, properties, out var authService);
+
+            var result = await context.GetAccessTokenAsync(
+                new AccessTokenRequest { Audience = PrimaryAudience, ForceRefresh = false });
+
+            result.Should().Be("cached");
+            handler.Protected().Verify("SendAsync", Times.Never(),
+                ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>());
+            authService.Verify(s => s.SignInAsync(
+                It.IsAny<HttpContext>(), It.IsAny<string>(),
+                It.IsAny<ClaimsPrincipal>(), It.IsAny<AuthenticationProperties>()), Times.Never());
+        }
+
+        [Fact]
+        public async Task GetAccessTokenAsync_WithForceRefresh_BypassesCacheAndPersistsNewToken()
+        {
+            var handler = CreateTokenHandler("fresh");
+            var properties = new AuthenticationProperties();
+            properties.Items[".Token.access_token"] = "cached";
+            properties.Items[".Token.expires_at"] = DateTimeOffset.Now.AddHours(1).ToString("o");
+            properties.Items[".Token.refresh_token"] = "rt";
+
+            AuthenticationProperties? persisted = null;
+            var context = BuildContext(handler.Object, properties, out var authService);
+            authService
+                .Setup(s => s.SignInAsync(It.IsAny<HttpContext>(), It.IsAny<string>(),
+                    It.IsAny<ClaimsPrincipal>(), It.IsAny<AuthenticationProperties>()))
+                .Callback<HttpContext, string, ClaimsPrincipal, AuthenticationProperties>(
+                    (_, _, _, p) => persisted = p)
+                .Returns(Task.CompletedTask);
+
+            var result = await context.GetAccessTokenAsync(
+                new AccessTokenRequest { Audience = PrimaryAudience, ForceRefresh = true });
+
+            result.Should().Be("fresh");
+            handler.Protected().Verify("SendAsync", Times.Once(),
+                ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>());
+            persisted.Should().NotBeNull();
+            persisted!.Items[".Token.access_token"].Should().Be("fresh");
+        }
+
+        [Fact]
+        public async Task GetAccessTokenAsync_WithForceRefresh_NoRefreshToken_FiresEventAndReturnsNull()
+        {
+            var handler = CreateTokenHandler("fresh");
+            var properties = new AuthenticationProperties();
+            properties.Items[".Token.access_token"] = "cached";
+            properties.Items[".Token.expires_at"] = DateTimeOffset.Now.AddHours(1).ToString("o");
+            // No refresh token stored.
+
+            var missingRefreshTokenFired = false;
+            var context = BuildContext(handler.Object, properties, out _, withAccessTokenOptions =>
+            {
+                withAccessTokenOptions.Events = new Auth0WebAppWithAccessTokenEvents
+                {
+                    OnMissingRefreshToken = _ =>
+                    {
+                        missingRefreshTokenFired = true;
+                        return Task.CompletedTask;
+                    }
+                };
+            });
+
+            var result = await context.GetAccessTokenAsync(
+                new AccessTokenRequest { Audience = PrimaryAudience, ForceRefresh = true });
+
+            result.Should().BeNull();
+            missingRefreshTokenFired.Should().BeTrue();
+            handler.Protected().Verify("SendAsync", Times.Never(),
+                ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>());
+        }
+
+        private static Mock<HttpMessageHandler> CreateTokenHandler(string accessToken)
+        {
+            var handler = new Mock<HttpMessageHandler>();
+            handler
+                .Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>())
+                .ReturnsAsync(new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = new StringContent(
+                        $"{{\"access_token\":\"{accessToken}\",\"token_type\":\"Bearer\",\"expires_in\":86400}}")
+                });
+            return handler;
+        }
+
+        private static HttpContext BuildContext(
+            HttpMessageHandler backchannelHandler,
+            AuthenticationProperties properties,
+            out Mock<IAuthenticationService> authService,
+            Action<Auth0WebAppWithAccessTokenOptions>? configureWithAccessToken = null)
+        {
+            var webAppOptions = new Auth0WebAppOptions
+            {
+                Domain = Domain,
+                ClientId = "cid",
+                ClientSecret = "secret",
+                Backchannel = new HttpClient(backchannelHandler),
+                CookieAuthenticationScheme = CookieScheme
+            };
+
+            var withAccessTokenOptions = new Auth0WebAppWithAccessTokenOptions
+            {
+                Audience = PrimaryAudience
+            };
+            configureWithAccessToken?.Invoke(withAccessTokenOptions);
+
+            var principal = new ClaimsPrincipal(new ClaimsIdentity("Cookies"));
+            var ticket = new AuthenticationTicket(principal, properties, CookieScheme);
+
+            authService = new Mock<IAuthenticationService>();
+            authService
+                .Setup(s => s.AuthenticateAsync(It.IsAny<HttpContext>(), CookieScheme))
+                .ReturnsAsync(AuthenticateResult.Success(ticket));
+            authService
+                .Setup(s => s.SignInAsync(It.IsAny<HttpContext>(), It.IsAny<string>(),
+                    It.IsAny<ClaimsPrincipal>(), It.IsAny<AuthenticationProperties>()))
+                .Returns(Task.CompletedTask);
+
+            var webAppSnapshot = new Mock<IOptionsSnapshot<Auth0WebAppOptions>>();
+            webAppSnapshot.Setup(s => s.Get(It.IsAny<string>())).Returns(webAppOptions);
+            var withAccessTokenSnapshot = new Mock<IOptionsSnapshot<Auth0WebAppWithAccessTokenOptions>>();
+            withAccessTokenSnapshot.Setup(s => s.Get(It.IsAny<string>())).Returns(withAccessTokenOptions);
+
+            var services = new ServiceCollection();
+            services.AddSingleton(authService.Object);
+            services.AddSingleton(webAppSnapshot.Object);
+            services.AddSingleton(withAccessTokenSnapshot.Object);
+
+            return new DefaultHttpContext
+            {
+                RequestServices = services.BuildServiceProvider()
+            };
+        }
+    }
+}

--- a/tests/Auth0.AspNetCore.Authentication.IntegrationTests/TokenClientTests.cs
+++ b/tests/Auth0.AspNetCore.Authentication.IntegrationTests/TokenClientTests.cs
@@ -258,6 +258,98 @@ namespace Auth0.AspNetCore.Authentication.IntegrationTests
         }
 
         [Fact]
+        public async Task Refresh_WithEmptyJsonObjectBody_ReturnsFailureWithoutThrowing()
+        {
+            var mockHandler = new Mock<HttpMessageHandler>();
+            mockHandler
+                .Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>()
+                )
+                .ReturnsAsync(new HttpResponseMessage()
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = new StringContent("{}")
+                });
+
+            var client = new TokenClient(new HttpClient(mockHandler.Object));
+            var result = await client.Refresh(
+                new Auth0WebAppOptions { Domain = "default.auth0.com", ClientId = "cid", ClientSecret = "secret" },
+                "refresh_123"
+            );
+
+            // A 200 with no access_token deserializes to a non-null object whose AccessToken is null;
+            // that must be reported as a failure rather than a success carrying an empty token.
+            result.IsSuccess.Should().BeFalse();
+            result.Response.Should().BeNull();
+            result.StatusCode.Should().Be((int)HttpStatusCode.OK);
+            result.Error.Should().Be("invalid_token_response");
+            result.ErrorDescription.Should().Be("The token endpoint returned a response without an access token.");
+        }
+
+        [Fact]
+        public async Task Refresh_WithBodyMissingAccessToken_ReturnsFailureWithoutThrowing()
+        {
+            var mockHandler = new Mock<HttpMessageHandler>();
+            mockHandler
+                .Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>()
+                )
+                .ReturnsAsync(new HttpResponseMessage()
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = new StringContent("{\"token_type\":\"Bearer\",\"expires_in\":86400}")
+                });
+
+            var client = new TokenClient(new HttpClient(mockHandler.Object));
+            var result = await client.Refresh(
+                new Auth0WebAppOptions { Domain = "default.auth0.com", ClientId = "cid", ClientSecret = "secret" },
+                "refresh_123"
+            );
+
+            result.IsSuccess.Should().BeFalse();
+            result.Response.Should().BeNull();
+            result.StatusCode.Should().Be((int)HttpStatusCode.OK);
+            result.Error.Should().Be("invalid_token_response");
+            result.ErrorDescription.Should().Be("The token endpoint returned a response without an access token.");
+        }
+
+        [Fact]
+        public async Task Refresh_WithEmptyAccessToken_ReturnsFailureWithoutThrowing()
+        {
+            var mockHandler = new Mock<HttpMessageHandler>();
+            mockHandler
+                .Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>()
+                )
+                .ReturnsAsync(new HttpResponseMessage()
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = new StringContent("{\"access_token\":\"\",\"token_type\":\"Bearer\",\"expires_in\":86400}")
+                });
+
+            var client = new TokenClient(new HttpClient(mockHandler.Object));
+            var result = await client.Refresh(
+                new Auth0WebAppOptions { Domain = "default.auth0.com", ClientId = "cid", ClientSecret = "secret" },
+                "refresh_123"
+            );
+
+            result.IsSuccess.Should().BeFalse();
+            result.Response.Should().BeNull();
+            result.StatusCode.Should().Be((int)HttpStatusCode.OK);
+            result.Error.Should().Be("invalid_token_response");
+            result.ErrorDescription.Should().Be("The token endpoint returned a response without an access token.");
+        }
+
+        [Fact]
         public async Task Refresh_WithNullDomain_ThrowsInvalidOperationException()
         {
             var mockHandler = new Mock<HttpMessageHandler>();

--- a/tests/Auth0.AspNetCore.Authentication.IntegrationTests/TokenClientTests.cs
+++ b/tests/Auth0.AspNetCore.Authentication.IntegrationTests/TokenClientTests.cs
@@ -128,6 +128,79 @@ namespace Auth0.AspNetCore.Authentication.IntegrationTests
         }
 
         [Fact]
+        public async Task Refresh_WithAudienceAndScope_IncludesThemInBody()
+        {
+            var capturedBody = string.Empty;
+
+            var mockHandler = new Mock<HttpMessageHandler>();
+            mockHandler
+                .Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>()
+                )
+                .Callback<HttpRequestMessage, CancellationToken>((req, _) =>
+                {
+                    if (req.Content != null)
+                        capturedBody = req.Content.ReadAsStringAsync().Result;
+                })
+                .ReturnsAsync(new HttpResponseMessage()
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = new StringContent("{\"access_token\":\"new_token\",\"token_type\":\"Bearer\",\"expires_in\":86400,\"scope\":\"read:orders\"}")
+                });
+
+            var client = new TokenClient(new HttpClient(mockHandler.Object));
+            var result = await client.Refresh(
+                new Auth0WebAppOptions { Domain = "default.auth0.com", ClientId = "cid", ClientSecret = "secret" },
+                "refresh_123",
+                null,
+                "api://orders",
+                "read:orders"
+            );
+
+            result.Should().NotBeNull();
+            result?.Scope.Should().Be("read:orders");
+            capturedBody.Should().Contain("audience=api%3A%2F%2Forders");
+            capturedBody.Should().Contain("scope=read%3Aorders");
+        }
+
+        [Fact]
+        public async Task Refresh_WithoutAudienceAndScope_OmitsThemFromBody()
+        {
+            var capturedBody = string.Empty;
+
+            var mockHandler = new Mock<HttpMessageHandler>();
+            mockHandler
+                .Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>()
+                )
+                .Callback<HttpRequestMessage, CancellationToken>((req, _) =>
+                {
+                    if (req.Content != null)
+                        capturedBody = req.Content.ReadAsStringAsync().Result;
+                })
+                .ReturnsAsync(new HttpResponseMessage()
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = new StringContent("{\"access_token\":\"new_token\",\"token_type\":\"Bearer\",\"expires_in\":86400}")
+                });
+
+            var client = new TokenClient(new HttpClient(mockHandler.Object));
+            await client.Refresh(
+                new Auth0WebAppOptions { Domain = "default.auth0.com", ClientId = "cid", ClientSecret = "secret" },
+                "refresh_123"
+            );
+
+            capturedBody.Should().NotContain("audience=");
+            capturedBody.Should().NotContain("scope=");
+        }
+
+        [Fact]
         public async Task Refresh_WithNullDomain_ThrowsInvalidOperationException()
         {
             var mockHandler = new Mock<HttpMessageHandler>();

--- a/tests/Auth0.AspNetCore.Authentication.IntegrationTests/TokenClientTests.cs
+++ b/tests/Auth0.AspNetCore.Authentication.IntegrationTests/TokenClientTests.cs
@@ -32,7 +32,34 @@ namespace Auth0.AspNetCore.Authentication.IntegrationTests
             var client = new TokenClient(new HttpClient(mockHandler.Object));
             var result = await client.Refresh(new Auth0WebAppOptions { Domain = "local.auth0.com", ClientId = "cid", ClientSecret = "secret" }, "123");
 
-            result.Should().BeNull();
+            result.IsSuccess.Should().BeFalse();
+            result.Response.Should().BeNull();
+        }
+
+        [Fact]
+        public async Task Returns_Failure_With_Error_Details_When_Rejected()
+        {
+            var mockHandler = new Mock<HttpMessageHandler>();
+            mockHandler
+              .Protected()
+                  .Setup<Task<HttpResponseMessage>>(
+                     "SendAsync",
+                     ItExpr.IsAny<HttpRequestMessage>(),
+                     ItExpr.IsAny<CancellationToken>()
+                  )
+                  .ReturnsAsync(new HttpResponseMessage()
+                  {
+                      StatusCode = HttpStatusCode.Forbidden,
+                      Content = new StringContent("{\"error\":\"invalid_grant\",\"error_description\":\"token revoked\"}")
+                  });
+
+            var client = new TokenClient(new HttpClient(mockHandler.Object));
+            var result = await client.Refresh(new Auth0WebAppOptions { Domain = "local.auth0.com", ClientId = "cid", ClientSecret = "secret" }, "123");
+
+            result.IsSuccess.Should().BeFalse();
+            result.StatusCode.Should().Be((int)HttpStatusCode.Forbidden);
+            result.Error.Should().Be("invalid_grant");
+            result.ErrorDescription.Should().Be("token revoked");
         }
 
         [Fact]
@@ -76,8 +103,8 @@ namespace Auth0.AspNetCore.Authentication.IntegrationTests
                 customDomain  // Pass custom domain
             );
 
-            result.Should().NotBeNull();
-            result?.AccessToken.Should().Be("new_token");
+            result.IsSuccess.Should().BeTrue();
+            result.Response?.AccessToken.Should().Be("new_token");
             requestedDomain.Should().Be(customDomain);
         }
 
@@ -122,8 +149,8 @@ namespace Auth0.AspNetCore.Authentication.IntegrationTests
                 // No custom domain passed, should use default
             );
 
-            result.Should().NotBeNull();
-            result?.AccessToken.Should().Be("new_token");
+            result.IsSuccess.Should().BeTrue();
+            result.Response?.AccessToken.Should().Be("new_token");
             requestedDomain.Should().Be(defaultDomain);
         }
 
@@ -160,8 +187,8 @@ namespace Auth0.AspNetCore.Authentication.IntegrationTests
                 "read:orders"
             );
 
-            result.Should().NotBeNull();
-            result?.Scope.Should().Be("read:orders");
+            result.IsSuccess.Should().BeTrue();
+            result.Response?.Scope.Should().Be("read:orders");
             capturedBody.Should().Contain("audience=api%3A%2F%2Forders");
             capturedBody.Should().Contain("scope=read%3Aorders");
         }
@@ -198,6 +225,36 @@ namespace Auth0.AspNetCore.Authentication.IntegrationTests
 
             capturedBody.Should().NotContain("audience=");
             capturedBody.Should().NotContain("scope=");
+        }
+
+        [Fact]
+        public async Task Refresh_WithMalformedSuccessBody_ReturnsFailureWithoutThrowing()
+        {
+            var mockHandler = new Mock<HttpMessageHandler>();
+            mockHandler
+                .Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>()
+                )
+                .ReturnsAsync(new HttpResponseMessage()
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = new StringContent("{ this is not valid json")
+                });
+
+            var client = new TokenClient(new HttpClient(mockHandler.Object));
+            var result = await client.Refresh(
+                new Auth0WebAppOptions { Domain = "default.auth0.com", ClientId = "cid", ClientSecret = "secret" },
+                "refresh_123"
+            );
+
+            result.IsSuccess.Should().BeFalse();
+            result.Response.Should().BeNull();
+            result.StatusCode.Should().Be((int)HttpStatusCode.OK);
+            result.Error.Should().Be("invalid_token_response");
+            result.ErrorDescription.Should().Be("The token endpoint returned a response that could not be parsed.");
         }
 
         [Fact]

--- a/tests/Auth0.AspNetCore.Authentication.IntegrationTests/TokenSetHelpersTests.cs
+++ b/tests/Auth0.AspNetCore.Authentication.IntegrationTests/TokenSetHelpersTests.cs
@@ -1,0 +1,139 @@
+using FluentAssertions;
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Auth0.AspNetCore.Authentication.IntegrationTests
+{
+    public class TokenSetHelpersTests
+    {
+        [Theory]
+        [InlineData(null, new string[0])]
+        [InlineData("", new string[0])]
+        [InlineData("   ", new string[0])]
+        [InlineData("a", new[] { "a" })]
+        [InlineData("a b c", new[] { "a", "b", "c" })]
+        [InlineData("  a   b  ", new[] { "a", "b" })]
+        public void ParseScopes_SplitsAndFilters(string? input, string[] expected)
+        {
+            TokenSetHelpers.ParseScopes(input).Should().Equal(expected);
+        }
+
+        [Fact]
+        public void MergeScopes_IsOrderPreservingUnion_NotSorted()
+        {
+            // default scopes first, request scopes appended, dedup, original order kept
+            TokenSetHelpers.MergeScopes("c b", "b a").Should().Be("c b a");
+        }
+
+        [Fact]
+        public void MergeScopes_HandlesNulls()
+        {
+            TokenSetHelpers.MergeScopes(null, "a b").Should().Be("a b");
+            TokenSetHelpers.MergeScopes("a b", null).Should().Be("a b");
+            TokenSetHelpers.MergeScopes(null, null).Should().Be("");
+        }
+
+        [Fact]
+        public void CompareScopes_NonStrict_IsSupersetMembership()
+        {
+            TokenSetHelpers.CompareScopes("a b c", "a b").Should().BeTrue();
+            TokenSetHelpers.CompareScopes("a b", "a b c").Should().BeFalse();
+        }
+
+        [Fact]
+        public void CompareScopes_Strict_RequiresEqualSets()
+        {
+            TokenSetHelpers.CompareScopes("a b", "b a", strict: true).Should().BeTrue();
+            TokenSetHelpers.CompareScopes("a b c", "a b", strict: true).Should().BeFalse();
+        }
+
+        [Fact]
+        public void GetScopeForAudience_PrefersPerAudienceMap()
+        {
+            var map = new Dictionary<string, string> { ["api://orders"] = "read:orders" };
+            TokenSetHelpers.GetScopeForAudience("default", map, "api://orders").Should().Be("read:orders");
+            TokenSetHelpers.GetScopeForAudience("default", map, "api://other").Should().Be("default");
+            TokenSetHelpers.GetScopeForAudience("default", null, "api://orders").Should().Be("default");
+        }
+
+        [Fact]
+        public void MergeScopeWithDefaults_UnionsDefaultsWithRequest()
+        {
+            var map = new Dictionary<string, string> { ["api://orders"] = "read:orders" };
+            TokenSetHelpers.MergeScopeWithDefaults("write:orders", "api://orders", "openid", map)
+                .Should().Be("read:orders write:orders");
+        }
+
+        [Fact]
+        public void MergeScopeWithDefaults_ReturnsNullWhenEmpty()
+        {
+            TokenSetHelpers.MergeScopeWithDefaults(null, "api://x", null, null).Should().BeNull();
+        }
+
+        [Fact]
+        public void FindAccessTokenSet_PrefersExactThenSmallestSuperset()
+        {
+            var sets = new List<AccessTokenSet>
+            {
+                new AccessTokenSet { Audience = "api", AccessToken = "big", Scope = "a b c", RequestedScope = "a b c" },
+                new AccessTokenSet { Audience = "api", AccessToken = "small", Scope = "a b", RequestedScope = "a b" },
+            };
+
+            // smallest superset for "a"
+            TokenSetHelpers.FindAccessTokenSet(sets, "api", "a", ScopeMatchMode.RequestedScope)!.AccessToken.Should().Be("small");
+            // exact match
+            TokenSetHelpers.FindAccessTokenSet(sets, "api", "a b c", ScopeMatchMode.RequestedScope)!.AccessToken.Should().Be("big");
+            // no match for different audience
+            TokenSetHelpers.FindAccessTokenSet(sets, "other", "a", ScopeMatchMode.RequestedScope).Should().BeNull();
+        }
+
+        [Fact]
+        public void UpsertAccessTokenSet_AppendsNewEntry()
+        {
+            var response = new AccessTokenResponse { AccessToken = "tok", ExpiresIn = 3600, Scope = "read:x" };
+            var result = TokenSetHelpers.UpsertAccessTokenSet(null, "api", "read:x", response);
+
+            result.Should().HaveCount(1);
+            result[0].AccessToken.Should().Be("tok");
+            result[0].Audience.Should().Be("api");
+            result[0].Scope.Should().Be("read:x");
+            result[0].RequestedScope.Should().Be("read:x");
+            result[0].ExpiresAt.Should().BeGreaterThan(DateTimeOffset.UtcNow.ToUnixTimeSeconds());
+        }
+
+        [Fact]
+        public void UpsertAccessTokenSet_ReplacesExistingByRequestedScope()
+        {
+            var existing = new List<AccessTokenSet>
+            {
+                new AccessTokenSet { Audience = "api", AccessToken = "old", Scope = "a", RequestedScope = "a" }
+            };
+            var response = new AccessTokenResponse { AccessToken = "new", ExpiresIn = 3600, Scope = "a" };
+
+            var result = TokenSetHelpers.UpsertAccessTokenSet(existing, "api", "a", response);
+
+            result.Should().HaveCount(1);
+            result[0].AccessToken.Should().Be("new");
+        }
+
+        [Fact]
+        public void UpsertAccessTokenSet_MergesRequestedScopeWhenGrantedScopeMatches()
+        {
+            // cached entry: granted "a", requested "a b". New request "a c" -> granted "a".
+            // Should merge requestedScope to "a b c" on the same entry rather than append.
+            var existing = new List<AccessTokenSet>
+            {
+                new AccessTokenSet { Audience = "api", AccessToken = "old", Scope = "a", RequestedScope = "a b" }
+            };
+            var response = new AccessTokenResponse { AccessToken = "new", ExpiresIn = 3600, Scope = "a" };
+
+            var result = TokenSetHelpers.UpsertAccessTokenSet(existing, "api", "a c", response);
+
+            result.Should().HaveCount(1);
+            result[0].RequestedScope.Should().Be("a b c");
+            result[0].Scope.Should().Be("a");
+            result[0].AccessToken.Should().Be("new");
+        }
+    }
+}

--- a/tests/Auth0.AspNetCore.Authentication.IntegrationTests/TokenSetHelpersTests.cs
+++ b/tests/Auth0.AspNetCore.Authentication.IntegrationTests/TokenSetHelpersTests.cs
@@ -118,6 +118,21 @@ namespace Auth0.AspNetCore.Authentication.IntegrationTests
         }
 
         [Fact]
+        public void UpsertAccessTokenSet_UnchangedAccessToken_LeavesEntryIntact()
+        {
+            // Same request, same access token returned: the entry must be left in place
+            // (same instance) rather than replaced.
+            var existing = new AccessTokenSet { Audience = "api", AccessToken = "tok", Scope = "a", RequestedScope = "a" };
+            var sets = new List<AccessTokenSet> { existing };
+            var response = new AccessTokenResponse { AccessToken = "tok", ExpiresIn = 3600, Scope = "a" };
+
+            var result = TokenSetHelpers.UpsertAccessTokenSet(sets, "api", "a", response);
+
+            result.Should().HaveCount(1);
+            result[0].Should().BeSameAs(existing);
+        }
+
+        [Fact]
         public void UpsertAccessTokenSet_MergesRequestedScopeWhenGrantedScopeMatches()
         {
             // cached entry: granted "a", requested "a b". New request "a c" -> granted "a".

--- a/tests/Auth0.AspNetCore.Authentication.IntegrationTests/TokenSetHelpersTests.cs
+++ b/tests/Auth0.AspNetCore.Authentication.IntegrationTests/TokenSetHelpersTests.cs
@@ -107,7 +107,7 @@ namespace Auth0.AspNetCore.Authentication.IntegrationTests
         {
             var existing = new List<AccessTokenSet>
             {
-                new AccessTokenSet { Audience = "api", AccessToken = "old", Scope = "a", RequestedScope = "a" }
+                new AccessTokenSet { Audience = "api", AccessToken = "old", Scope = "a", RequestedScope = "a", ExpiresAt = DateTimeOffset.UtcNow.AddHours(1).ToUnixTimeSeconds() }
             };
             var response = new AccessTokenResponse { AccessToken = "new", ExpiresIn = 3600, Scope = "a" };
 
@@ -122,7 +122,7 @@ namespace Auth0.AspNetCore.Authentication.IntegrationTests
         {
             // Same request, same access token returned: the entry must be left in place
             // (same instance) rather than replaced.
-            var existing = new AccessTokenSet { Audience = "api", AccessToken = "tok", Scope = "a", RequestedScope = "a" };
+            var existing = new AccessTokenSet { Audience = "api", AccessToken = "tok", Scope = "a", RequestedScope = "a", ExpiresAt = DateTimeOffset.UtcNow.AddHours(1).ToUnixTimeSeconds() };
             var sets = new List<AccessTokenSet> { existing };
             var response = new AccessTokenResponse { AccessToken = "tok", ExpiresIn = 3600, Scope = "a" };
 
@@ -133,13 +133,72 @@ namespace Auth0.AspNetCore.Authentication.IntegrationTests
         }
 
         [Fact]
+        public void UpsertAccessTokenSet_PrunesExpiredEntriesForOtherCombinations()
+        {
+            var now = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+            var existing = new List<AccessTokenSet>
+            {
+                // Expired entry for a combination that is no longer being requested.
+                new AccessTokenSet { Audience = "api", AccessToken = "stale", Scope = "read", RequestedScope = "read", ExpiresAt = now - 60 },
+                // Still-valid entry for a different combination.
+                new AccessTokenSet { Audience = "api", AccessToken = "live", Scope = "write", RequestedScope = "write", ExpiresAt = now + 3600 }
+            };
+            var response = new AccessTokenResponse { AccessToken = "fresh", ExpiresIn = 3600, Scope = "manage" };
+
+            var result = TokenSetHelpers.UpsertAccessTokenSet(existing, "api", "manage", response);
+
+            // The dead "read" entry is dropped; the live "write" entry and the new "manage" entry remain.
+            result.Should().HaveCount(2);
+            result.Should().NotContain(set => set.AccessToken == "stale");
+            result.Should().Contain(set => set.AccessToken == "live");
+            result.Should().Contain(set => set.AccessToken == "fresh");
+        }
+
+        [Fact]
+        public void UpsertAccessTokenSet_KeepsUnexpiredEntries()
+        {
+            var now = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+            var existing = new List<AccessTokenSet>
+            {
+                new AccessTokenSet { Audience = "api", AccessToken = "other", Scope = "read", RequestedScope = "read", ExpiresAt = now + 3600 }
+            };
+            var response = new AccessTokenResponse { AccessToken = "fresh", ExpiresIn = 3600, Scope = "write" };
+
+            var result = TokenSetHelpers.UpsertAccessTokenSet(existing, "api", "write", response);
+
+            result.Should().HaveCount(2);
+            result.Should().Contain(set => set.AccessToken == "other");
+            result.Should().Contain(set => set.AccessToken == "fresh");
+        }
+
+        [Fact]
+        public void UpsertAccessTokenSet_ExpiredUpsertTarget_IsRefreshedNotDropped()
+        {
+            // The entry being upserted is itself expired. Pruning must not lose the combination:
+            // it should end up present with the freshly fetched token.
+            var now = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+            var existing = new List<AccessTokenSet>
+            {
+                new AccessTokenSet { Audience = "api", AccessToken = "old", Scope = "a", RequestedScope = "a", ExpiresAt = now - 60 }
+            };
+            var response = new AccessTokenResponse { AccessToken = "new", ExpiresIn = 3600, Scope = "a" };
+
+            var result = TokenSetHelpers.UpsertAccessTokenSet(existing, "api", "a", response);
+
+            result.Should().HaveCount(1);
+            result[0].AccessToken.Should().Be("new");
+            result[0].RequestedScope.Should().Be("a");
+            result[0].ExpiresAt.Should().BeGreaterThan(now);
+        }
+
+        [Fact]
         public void UpsertAccessTokenSet_MergesRequestedScopeWhenGrantedScopeMatches()
         {
             // cached entry: granted "a", requested "a b". New request "a c" -> granted "a".
             // Should merge requestedScope to "a b c" on the same entry rather than append.
             var existing = new List<AccessTokenSet>
             {
-                new AccessTokenSet { Audience = "api", AccessToken = "old", Scope = "a", RequestedScope = "a b" }
+                new AccessTokenSet { Audience = "api", AccessToken = "old", Scope = "a", RequestedScope = "a b", ExpiresAt = DateTimeOffset.UtcNow.AddHours(1).ToUnixTimeSeconds() }
             };
             var response = new AccessTokenResponse { AccessToken = "new", ExpiresIn = 3600, Scope = "a" };
 


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

Adds support for **Multi-Resource Refresh Tokens (MRRT)**, allowing an application to obtain access tokens for additional audiences and scopes on demand by exchanging the session's refresh token — without forcing the user through another interactive login.

- **`HttpContext.GetAccessTokenAsync(AccessTokenRequest, scheme?)`** — a new public extension that returns an access token for a requested `Audience` and/or `Scope`. It first tries to satisfy the request from the session (the login-time "primary" token slot, or a cached additional-token set), and only exchanges the refresh token when no usable cached token exists. Newly obtained tokens are persisted back into the session (via `SignInAsync`), and refresh-token rotation and `id_token` refresh are honored regardless of which slot was updated.
- **`AccessTokenRequest`** — describes the desired `Audience`, `Scope`, and a `ForceRefresh` flag. Requested scopes are merged (order-preserving union) with the configured defaults for the resolved audience. `ForceRefresh = true` bypasses the cache and always exchanges the refresh token, while still replacing the cached entry.
- **Per-audience default scopes** — `Auth0WebAppWithAccessTokenOptions.ScopeByAudience` lets you configure default scopes per audience; when an audience isn't present in the map, the configured `Scope` is used as the fallback.
- **Additional-token storage** — additional audience/scope tokens are stored as a serialized set (`AccessTokenSet`) in the auth-cookie session, kept separate from the primary login token.
- **Failure handling** — a new `OnAccessTokenRefreshFailed` event surfaces refresh failures through `AccessTokenRefreshFailedContext`, which carries the `Audience`/`Scope`, the token endpoint `StatusCode`/`Error`/`ErrorDescription` for HTTP rejections, and the `Exception` for transport/misconfiguration failures. This lets callers distinguish a terminal failure (e.g. `invalid_grant` for a revoked refresh token, warranting re-login) from a transient one (e.g. timeout/rate-limit, which may be retried). All refresh failures — transport errors, malformed responses, or token-endpoint rejections — are folded into this single failure path; `GetAccessTokenAsync` returns `null` rather than throwing.
- `TokenClient.Refresh` now returns a `TokenRefreshResult` that captures success/failure detail instead of throwing on non-success responses.
- Cached-token reuse applies the configurable `AccessTokenExpirationLeeway` (default 60 seconds) to both the primary and additional tokens, so a refresh is triggered proactively rather than a token lapsing mid-request. Corrupted/version-skewed session data or unparseable timestamps are treated as a cache miss so the token is re-fetched rather than throwing out of a public method.
- These changes are additive; existing access-token behavior is unchanged.

### References

### Testing

Unit/integration test coverage was added for the new functionality.

Existing tests continue to pass.

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `main`
