### PR TITLE
chore(deps): Bump dependencies

### DIFF
--- a/src/Auth0.AspNetCore.Authentication/Auth0.AspNetCore.Authentication.csproj
+++ b/src/Auth0.AspNetCore.Authentication/Auth0.AspNetCore.Authentication.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="8.18.0" />
+    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="8.19.1" />
     <PackageReference Include="System.Text.Encodings.Web" Version="10.0.8" />
   </ItemGroup>
 

--- a/src/Auth0.AspNetCore.Authentication/Auth0.AspNetCore.Authentication.csproj
+++ b/src/Auth0.AspNetCore.Authentication/Auth0.AspNetCore.Authentication.csproj
@@ -13,7 +13,7 @@
   
   <ItemGroup>
     <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="8.19.1" />
-    <PackageReference Include="System.Text.Encodings.Web" Version="10.0.8" />
+    <PackageReference Include="System.Text.Encodings.Web" Version="10.0.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Auth0.AspNetCore.Authentication.IntegrationTests/Auth0.AspNetCore.Authentication.IntegrationTests.csproj
+++ b/tests/Auth0.AspNetCore.Authentication.IntegrationTests/Auth0.AspNetCore.Authentication.IntegrationTests.csproj
@@ -27,7 +27,7 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="7.2.2" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.9" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.ViewFeatures" Version="2.3.10" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.ViewFeatures" Version="2.3.11" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit" Version="2.9.3" />

--- a/tests/Auth0.AspNetCore.Authentication.IntegrationTests/Auth0.AspNetCore.Authentication.IntegrationTests.csproj
+++ b/tests/Auth0.AspNetCore.Authentication.IntegrationTests/Auth0.AspNetCore.Authentication.IntegrationTests.csproj
@@ -26,7 +26,7 @@
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="7.2.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.8" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.9" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.ViewFeatures" Version="2.3.10" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageReference Include="Moq" Version="4.20.72" />


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

Combines the open Dependabot dependency bumps into a single PR so they can be reviewed and merged at once, rather than as four separate PRs. The commits were cherry-picked from the individual Dependabot branches; conflicts arising from packages declared in the same `ItemGroup` were resolved to keep every target version. There are no source code changes — only package version bumps in the project files.

- Bump `Microsoft.IdentityModel.Protocols.OpenIdConnect` from 8.18.0 to 8.19.1
- Bump `Microsoft.AspNetCore.Mvc.Testing` from 10.0.8 to 10.0.9
- Bump `Microsoft.AspNetCore.Mvc.ViewFeatures` from 2.3.10 to 2.3.11
- Bump `System.Text.Encodings.Web` from 10.0.8 to 10.0.9

### References

Supersedes the individual Dependabot PRs:

- #240 (Microsoft.IdentityModel.Protocols.OpenIdConnect)
- #242 (Microsoft.AspNetCore.Mvc.Testing)
- #243 (Microsoft.AspNetCore.Mvc.ViewFeatures)
- #244 (System.Text.Encodings.Web)

### Testing

These are dependency version bumps with no behavioral code changes. 

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `main`