### PR TITLE
feat: Add MFA exception handling support in MRRT flow

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -10,6 +10,7 @@
   - [Configuring default scopes per audience](#configuring-default-scopes-per-audience)
   - [Forcing a refresh](#forcing-a-refresh)
   - [Handling refresh failures](#handling-refresh-failures)
+  - [Handling MFA during token exchange (mfa_required)](#handling-mfa-during-token-exchange-mfa_required)
 - [Organizations](#organizations)
 - [Extra parameters](#extra-parameters)
 - [Roles](#roles)
@@ -410,6 +411,124 @@ services
 ```
 
 > :warning: `AccessTokenRefreshFailedContext.Exception` may contain transport/diagnostic detail — log it server-side only, do not surface it to end users.
+
+### Handling MFA during token exchange (`mfa_required`)
+
+When an access-token exchange (for example a Multi-Resource Refresh Token request via
+`HttpContext.GetAccessTokenAsync`) returns an `mfa_required` error, the SDK throws an
+`MfaRequiredException`. You drive the MFA challenge/verify flow with `IAuthenticationApiClient`
+and decide what to do with the resulting tokens.
+
+`ex.MfaToken` is an **opaque, encrypted token with a 5-minute lifetime** — the raw `mfa_token`
+never leaves the SDK. Pass it back to the `IAuthenticationApiClient` methods unchanged; do not
+inspect, parse, or store it long-term. `ex.MfaRequirements` describes the challenge types the
+user can satisfy (for example `otp` or `oob`).
+
+#### Register the client
+
+```csharp
+services
+    .AddAuth0WebAppAuthentication(options =>
+    {
+        options.Domain = Configuration["Auth0:Domain"];
+        options.ClientId = Configuration["Auth0:ClientId"];
+        options.ClientSecret = Configuration["Auth0:ClientSecret"];
+    })
+    .WithAccessToken(options =>
+    {
+        options.UseRefreshTokens = true;
+    })
+    .WithAuthenticationApiClient();
+```
+
+#### Catch `mfa_required`, challenge, and verify
+
+```csharp
+public class ResourceController : Controller
+{
+    private readonly IAuthenticationApiClient _authClient;
+
+    public ResourceController(IAuthenticationApiClient authClient) => _authClient = authClient;
+
+    public async Task<IActionResult> CallApi()
+    {
+        try
+        {
+            var accessToken = await HttpContext.GetAccessTokenAsync(
+                new AccessTokenRequest { Audience = "https://my-second-api" });
+            // ... use accessToken ...
+            return Ok();
+        }
+        catch (MfaRequiredException ex)
+        {
+            // ex.MfaToken is an opaque, encrypted token valid for 5 minutes.
+            // Inspect ex.MfaRequirements to discover which challenge types are available.
+            var canUseOtp = ex.MfaRequirements?.Challenge?
+                .Any(c => c.Type == "otp") ?? false;
+
+            // Trigger a challenge (e.g. send an OTP / push). authenticatorId is optional.
+            var challenge = await _authClient.MfaChallengeAsync(new MfaChallengeRequest
+            {
+                MfaToken = ex.MfaToken,
+                ChallengeType = "otp"
+            });
+
+            // Store ex.MfaToken (and challenge.OobCode if using OOB) for the verify step,
+            // then prompt the user for their code. The token expires 5 minutes after issue.
+            TempData["mfa_token"] = ex.MfaToken;
+            return RedirectToAction("EnterCode");
+        }
+    }
+
+    [HttpPost]
+    public async Task<IActionResult> EnterCode(string otp)
+    {
+        var mfaToken = (string)TempData["mfa_token"]!;
+
+        try
+        {
+            var tokens = await _authClient.GetTokenAsync(new MfaOtpTokenRequest
+            {
+                MfaToken = mfaToken,
+                Otp = otp
+            });
+
+            // tokens.AccessToken is now valid for the requested audience.
+            // Persisting these tokens into the session is your responsibility — see below.
+            return Ok();
+        }
+        catch (MfaTokenExpiredException)
+        {
+            // The 5-minute window elapsed — restart the flow to obtain a fresh token.
+            return RedirectToAction("CallApi");
+        }
+        catch (MfaTokenInvalidException)
+        {
+            // The token was tampered with or malformed — restart the flow.
+            return RedirectToAction("CallApi");
+        }
+    }
+}
+```
+
+> :information_source: The SDK returns the MFA-grant tokens to you; it does not write them back
+> into the authentication session automatically. If you want subsequent
+> `GetAccessTokenAsync` calls to reuse them, persist them yourself — for example by updating
+> the authentication properties and calling `HttpContext.SignInAsync(...)` with the updated
+> principal.
+
+A bad code (rejected by Auth0) surfaces as an `ErrorApiException` (with `StatusCode` and
+`ApiError`), the base type of `MfaRequiredException`. A token that has passed its 5-minute
+lifetime throws `MfaTokenExpiredException`; a tampered or malformed token throws
+`MfaTokenInvalidException`. Both derive from `ErrorApiException`.
+
+> :warning: **Multi-instance deployments:** the encrypted `mfa_token` is protected with the
+> application's ASP.NET Core Data Protection key ring. If your app runs on more than one
+> instance, the key ring must be persisted and shared (for example with
+> `PersistKeysToFileSystem` plus a `ProtectKeysWith*` provider, or a shared key store);
+> otherwise a token encrypted on one instance cannot be decrypted on another within the
+> 5-minute window. This is the **same requirement** as the authentication cookie that already
+> carries these tokens.
 
 ## Organizations
 

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -11,6 +11,7 @@
   - [Forcing a refresh](#forcing-a-refresh)
   - [Handling refresh failures](#handling-refresh-failures)
   - [Handling MFA during token exchange (mfa_required)](#handling-mfa-during-token-exchange-mfa_required)
+    - [Completing an out-of-band (OOB) challenge with polling](#completing-an-out-of-band-oob-challenge-with-polling)
 - [Organizations](#organizations)
 - [Extra parameters](#extra-parameters)
 - [Roles](#roles)
@@ -424,6 +425,12 @@ never leaves the SDK. Pass it back to the `IAuthenticationApiClient` methods unc
 inspect, parse, or store it long-term. `ex.MfaRequirements` describes the challenge types the
 user can satisfy (for example `otp` or `oob`).
 
+> :information_source: `MfaRequiredException` is raised by `GetAccessTokenAsync` whenever the
+> exchange returns `mfa_required`, regardless of whether you called `WithAuthenticationApiClient()`.
+> You still need `WithAuthenticationApiClient()` to register the `IAuthenticationApiClient` that
+> *completes* the challenge — so register it whenever your tenant may return `mfa_required` on a
+> refresh, otherwise you can catch the exception but have no client to drive the verify step.
+
 #### Register the client
 
 ```csharp
@@ -521,6 +528,76 @@ A bad code (rejected by Auth0) surfaces as an `ErrorApiException` (with `StatusC
 `ApiError`), the base type of `MfaRequiredException`. A token that has passed its 5-minute
 lifetime throws `MfaTokenExpiredException`; a tampered or malformed token throws
 `MfaTokenInvalidException`. Both derive from `ErrorApiException`.
+
+#### Completing an out-of-band (OOB) challenge with polling
+
+Out-of-band factors (push notifications, SMS) are **asynchronous**: after you trigger the
+challenge you must poll the token endpoint until the user approves it. Unlike the OTP grant, the
+OOB grant does **not** throw while the user has not yet responded — Auth0 replies with
+`authorization_pending` (or `slow_down` if you are polling too fast), and the SDK surfaces those
+on `MfaOobTokenResponse.Error` so you can keep polling. A populated `AccessToken` (with
+`Error == null`) means the challenge succeeded. Any genuine failure (for example an expired
+`oob_code`) still throws `ErrorApiException`, just like the OTP grant.
+
+```csharp
+public async Task<IActionResult> StartOob()
+{
+    var mfaToken = (string)TempData["mfa_token"]!;
+
+    // Trigger the push/SMS. The returned oob_code identifies this challenge.
+    var challenge = await _authClient.MfaChallengeAsync(new MfaChallengeRequest
+    {
+        MfaToken = mfaToken,
+        ChallengeType = "oob"
+    });
+
+    TempData["mfa_token"] = mfaToken;          // still needed for the verify step
+    TempData["oob_code"] = challenge.OobCode;
+    return RedirectToAction("PollOob");
+}
+
+[HttpPost]
+public async Task<IActionResult> PollOob()
+{
+    var mfaToken = (string)TempData["mfa_token"]!;
+    var oobCode = (string)TempData["oob_code"]!;
+
+    try
+    {
+        var response = await _authClient.GetTokenAsync(new MfaOobTokenRequest
+        {
+            MfaToken = mfaToken,
+            OobCode = oobCode
+            // BindingCode = "1234"   // only when the challenge's binding_method requires it
+        });
+
+        if (response.Error == "authorization_pending" || response.Error == "slow_down")
+        {
+            // Not approved yet. Keep mfaToken/oobCode and poll again shortly. Back off a little
+            // on slow_down. Remember the mfa_token's overall 5-minute lifetime still applies.
+            TempData["mfa_token"] = mfaToken;
+            TempData["oob_code"] = oobCode;
+            return RedirectToAction("PollOob");
+        }
+
+        // response.Error is null here: the user approved and response.AccessToken is valid for
+        // the requested audience. Persisting it into the session is your responsibility.
+        return Ok();
+    }
+    catch (MfaTokenExpiredException)
+    {
+        // The 5-minute window elapsed — restart the flow to obtain a fresh token.
+        return RedirectToAction("CallApi");
+    }
+    // A genuine rejection (e.g. invalid/expired oob_code) throws ErrorApiException.
+}
+```
+
+> :information_source: The `mfa_token` blob is encrypted and **self-expires 5 minutes after the
+> original `mfa_required`** — not after the challenge is triggered. Since OOB approval is
+> user-paced, treat that window as your real polling budget: if it lapses, the next
+> `GetTokenAsync` throws `MfaTokenExpiredException` before any network call, and you must restart
+> from `GetAccessTokenAsync` to mint a fresh token.
 
 > :warning: **Multi-instance deployments:** the encrypted `mfa_token` is protected with the
 > application's ASP.NET Core Data Protection key ring. If your app runs on more than one

--- a/src/Auth0.AspNetCore.Authentication/Auth0.AspNetCore.Authentication.csproj
+++ b/src/Auth0.AspNetCore.Authentication/Auth0.AspNetCore.Authentication.csproj
@@ -17,6 +17,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="Auth0.AspNetCore.Authentication.IntegrationTests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <None Remove="BackchannelLogout\" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Auth0.AspNetCore.Authentication/Auth0WebAppAuthenticationBuilder.cs
+++ b/src/Auth0.AspNetCore.Authentication/Auth0WebAppAuthenticationBuilder.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
+using Microsoft.AspNetCore.DataProtection;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Options;
@@ -8,6 +9,8 @@ using System;
 using System.Threading.Tasks;
 using Auth0.AspNetCore.Authentication.BackchannelLogout;
 using Auth0.AspNetCore.Authentication.CustomDomains;
+using Auth0.AspNetCore.Authentication.AuthenticationApi;
+using System.Net.Http;
 using Microsoft.AspNetCore.Hosting;
 
 namespace Auth0.AspNetCore.Authentication
@@ -60,11 +63,37 @@ namespace Auth0.AspNetCore.Authentication
         /// <returns>An instance of <see cref="Auth0WebAppAuthenticationBuilder"/></returns>
         public Auth0WebAppAuthenticationBuilder WithBackchannelLogout()
         {
-            _services.AddTransient<BackchannelLogoutHandler>(sp => 
+            _services.AddTransient<BackchannelLogoutHandler>(sp =>
                 new BackchannelLogoutHandler(
-                    sp.GetRequiredService<ILogoutTokenHandler>(), 
+                    sp.GetRequiredService<ILogoutTokenHandler>(),
                     _authenticationScheme));
             _services.AddTransient<ILogoutTokenHandler, DefaultLogoutTokenHandler>();
+            return this;
+        }
+
+        /// <summary>
+        /// Registers an <see cref="IAuthenticationApiClient"/> for calling Auth0 Authentication API
+        /// MFA endpoints (for example, to recover from an <c>mfa_required</c> error). The client
+        /// authenticates using the <see cref="Auth0WebAppOptions.ClientId"/> and client credentials
+        /// configured on the SDK.
+        /// </summary>
+        /// <returns>An instance of <see cref="Auth0WebAppAuthenticationBuilder"/>.</returns>
+        public Auth0WebAppAuthenticationBuilder WithAuthenticationApiClient()
+        {
+            _services.AddHttpClient();
+            _services.TryAddSingleton<IMfaTokenProtector>(sp =>
+                new MfaTokenProtector(sp.GetRequiredService<IDataProtectionProvider>()));
+            _services.AddTransient<IAuthenticationApiClient>(sp =>
+            {
+                var backchannel = _options.Backchannel;
+                var httpClient = backchannel ?? sp.GetRequiredService<IHttpClientFactory>().CreateClient();
+                return new AuthenticationApiClient(
+                    httpClient,
+                    new Uri($"https://{_options.Domain}"),
+                    _options,
+                    sp.GetRequiredService<IMfaTokenProtector>(),
+                    ownsHttpClient: backchannel == null);
+            });
             return this;
         }
 

--- a/src/Auth0.AspNetCore.Authentication/Auth0WebAppAuthenticationBuilder.cs
+++ b/src/Auth0.AspNetCore.Authentication/Auth0WebAppAuthenticationBuilder.cs
@@ -203,6 +203,16 @@ namespace Auth0.AspNetCore.Authentication
             // available.
             _services.AddHttpClient();
 
+            // GetAccessTokenAsync encrypts the mfa_token into the MfaRequiredException blob on the
+            // mfa_required path. That path is reachable whenever refresh tokens are in use, even
+            // without WithAuthenticationApiClient(), so the protector must be registered here too —
+            // otherwise the mfa_required response would surface as an opaque DI resolution failure
+            // instead of the typed exception. TryAddSingleton keeps WithAuthenticationApiClient()'s
+            // own registration idempotent. Depends only on IDataProtectionProvider, which ASP.NET
+            // Core registers by default.
+            _services.TryAddSingleton<IMfaTokenProtector>(sp =>
+                new MfaTokenProtector(sp.GetRequiredService<IDataProtectionProvider>()));
+
             _services.Configure(_authenticationScheme, configureOptions);
             _services.AddOptions<OpenIdConnectOptions>(_authenticationScheme)
                 .Configure(options =>

--- a/src/Auth0.AspNetCore.Authentication/AuthenticationApi/AuthenticationApiClient.cs
+++ b/src/Auth0.AspNetCore.Authentication/AuthenticationApi/AuthenticationApiClient.cs
@@ -26,6 +26,13 @@ public class AuthenticationApiClient : IAuthenticationApiClient
     private const string MfaOobGrantType = "http://auth0.com/oauth/grant-type/mfa-oob";
     private const string MfaRecoveryCodeGrantType = "http://auth0.com/oauth/grant-type/mfa-recovery-code";
 
+    // OOB push/SMS verification is asynchronous: until the user approves, Auth0 answers the token
+    // request with HTTP 400 and one of these error codes. They are not failures — they signal the
+    // caller should keep polling — so the OOB grant surfaces them on MfaOobTokenResponse rather
+    // than throwing.
+    private const string AuthorizationPendingError = "authorization_pending";
+    private const string SlowDownError = "slow_down";
+
     private readonly HttpClient _httpClient;
     private readonly Auth0WebAppOptions _options;
     private readonly string _domain;
@@ -96,7 +103,7 @@ public class AuthenticationApiClient : IAuthenticationApiClient
     }
 
     /// <inheritdoc />
-    public Task<MfaOobTokenResponse> GetTokenAsync(MfaOobTokenRequest request, CancellationToken cancellationToken = default)
+    public async Task<MfaOobTokenResponse> GetTokenAsync(MfaOobTokenRequest request, CancellationToken cancellationToken = default)
     {
         if (request == null) throw new ArgumentNullException(nameof(request));
 
@@ -113,7 +120,34 @@ public class AuthenticationApiClient : IAuthenticationApiClient
         AddBoundAudienceScope(body, mfaContext);
         ApplyClientAuthentication(body);
 
-        return PostFormAsync<MfaOobTokenResponse>("oauth/token", body, cancellationToken);
+        var content = new FormUrlEncodedContent(body.Select(p => new KeyValuePair<string?, string?>(p.Key, p.Value)));
+        using var message = new HttpRequestMessage(HttpMethod.Post, BuildUri("oauth/token")) { Content = content };
+        using var response = await _httpClient.SendAsync(message, cancellationToken).ConfigureAwait(false);
+
+        // authorization_pending / slow_down arrive as HTTP 400 while the user has not yet approved
+        // the push/SMS. Surface them on the response so callers can poll, rather than throwing —
+        // any other non-2xx is a genuine failure and is thrown like the other grants.
+        var payload = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+        if (!response.IsSuccessStatusCode && !IsOobPending(payload))
+        {
+            throw new ErrorApiException(response.StatusCode, ApiError.Parse(payload));
+        }
+
+        return JsonSerializer.Deserialize<MfaOobTokenResponse>(payload, SerializerOptions)!;
+    }
+
+    // True when the body is an OOB token error that means "not yet — keep polling".
+    private static bool IsOobPending(string payload)
+    {
+        try
+        {
+            var error = JsonSerializer.Deserialize<MfaOobTokenResponse>(payload, SerializerOptions)?.Error;
+            return error == AuthorizationPendingError || error == SlowDownError;
+        }
+        catch (JsonException)
+        {
+            return false;
+        }
     }
 
     /// <inheritdoc />

--- a/src/Auth0.AspNetCore.Authentication/AuthenticationApi/AuthenticationApiClient.cs
+++ b/src/Auth0.AspNetCore.Authentication/AuthenticationApi/AuthenticationApiClient.cs
@@ -1,0 +1,254 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Auth0.AspNetCore.Authentication.AuthenticationApi.Models;
+using Auth0.AspNetCore.Authentication.Exceptions;
+using Microsoft.IdentityModel.Tokens;
+
+namespace Auth0.AspNetCore.Authentication.AuthenticationApi;
+
+/// <inheritdoc cref="IAuthenticationApiClient"/>
+/// <remarks>
+/// Implemented over System.Text.Json with no dependency on the <c>Auth0.AuthenticationApi</c>
+/// package (which is Newtonsoft-based). When that package is later integrated, the body of this
+/// class becomes a mapping adapter onto it; the public contract (interface + Models) stays the
+/// same, so consumers are unaffected.
+/// </remarks>
+public class AuthenticationApiClient : IAuthenticationApiClient
+{
+    private const string MfaOtpGrantType = "http://auth0.com/oauth/grant-type/mfa-otp";
+    private const string MfaOobGrantType = "http://auth0.com/oauth/grant-type/mfa-oob";
+    private const string MfaRecoveryCodeGrantType = "http://auth0.com/oauth/grant-type/mfa-recovery-code";
+
+    private readonly HttpClient _httpClient;
+    private readonly Auth0WebAppOptions _options;
+    private readonly string _domain;
+    private readonly bool _ownsHttpClient;
+    private readonly IMfaTokenProtector _mfaTokenProtector;
+
+    private static readonly JsonSerializerOptions SerializerOptions = new JsonSerializerOptions
+    {
+        DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull
+    };
+
+    /// <summary>Creates a client targeting <paramref name="baseUri"/>, authenticating with <paramref name="options"/>'s client credentials.</summary>
+    /// <param name="httpClient">The <see cref="HttpClient"/> to use for requests.</param>
+    /// <param name="baseUri">The base URI for API requests.</param>
+    /// <param name="options">The authentication options.</param>
+    /// <param name="mfaTokenProtector">The protector for decrypting MFA token blobs.</param>
+    /// <param name="ownsHttpClient">When <c>true</c> (the default), the supplied <see cref="HttpClient"/> is disposed when this client is disposed. Pass <c>false</c> when the <see cref="HttpClient"/> is owned by the caller (for example a shared backchannel client).</param>
+    internal AuthenticationApiClient(HttpClient httpClient, Uri baseUri, Auth0WebAppOptions options, IMfaTokenProtector mfaTokenProtector, bool ownsHttpClient = true)
+    {
+        _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+        BaseUri = baseUri ?? throw new ArgumentNullException(nameof(baseUri));
+        _options = options ?? throw new ArgumentNullException(nameof(options));
+        _mfaTokenProtector = mfaTokenProtector ?? throw new ArgumentNullException(nameof(mfaTokenProtector));
+        _domain = baseUri.Host;
+        _ownsHttpClient = ownsHttpClient;
+    }
+
+    /// <inheritdoc />
+    public Uri BaseUri { get; }
+
+    /// <inheritdoc />
+    public Task<MfaChallengeResponse> MfaChallengeAsync(MfaChallengeRequest request, CancellationToken cancellationToken = default)
+    {
+        if (request == null) throw new ArgumentNullException(nameof(request));
+
+        var mfaContext = _mfaTokenProtector.Unprotect(request.MfaToken);
+
+        var body = new Dictionary<string, string>
+        {
+            { "mfa_token", mfaContext.MfaToken },
+            { "client_id", _options.ClientId }
+        };
+        if (!string.IsNullOrWhiteSpace(request.ChallengeType)) body.Add("challenge_type", request.ChallengeType!);
+        if (!string.IsNullOrWhiteSpace(request.AuthenticatorId)) body.Add("authenticator_id", request.AuthenticatorId!);
+        ApplyClientAuthentication(body);
+
+        return PostFormAsync<MfaChallengeResponse>("mfa/challenge", body, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public Task<MfaOtpTokenResponse> GetTokenAsync(MfaOtpTokenRequest request, CancellationToken cancellationToken = default)
+    {
+        if (request == null) throw new ArgumentNullException(nameof(request));
+
+        var mfaContext = _mfaTokenProtector.Unprotect(request.MfaToken);
+
+        var body = new Dictionary<string, string>
+        {
+            { "grant_type", MfaOtpGrantType },
+            { "client_id", _options.ClientId },
+            { "mfa_token", mfaContext.MfaToken },
+            { "otp", request.Otp }
+        };
+        AddBoundAudienceScope(body, mfaContext);
+        ApplyClientAuthentication(body);
+
+        return PostFormAsync<MfaOtpTokenResponse>("oauth/token", body, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public Task<MfaOobTokenResponse> GetTokenAsync(MfaOobTokenRequest request, CancellationToken cancellationToken = default)
+    {
+        if (request == null) throw new ArgumentNullException(nameof(request));
+
+        var mfaContext = _mfaTokenProtector.Unprotect(request.MfaToken);
+
+        var body = new Dictionary<string, string>
+        {
+            { "grant_type", MfaOobGrantType },
+            { "client_id", _options.ClientId },
+            { "mfa_token", mfaContext.MfaToken },
+            { "oob_code", request.OobCode }
+        };
+        if (!string.IsNullOrWhiteSpace(request.BindingCode)) body.Add("binding_code", request.BindingCode!);
+        AddBoundAudienceScope(body, mfaContext);
+        ApplyClientAuthentication(body);
+
+        return PostFormAsync<MfaOobTokenResponse>("oauth/token", body, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public Task<MfaRecoveryCodeResponse> GetTokenAsync(MfaRecoveryCodeRequest request, CancellationToken cancellationToken = default)
+    {
+        if (request == null) throw new ArgumentNullException(nameof(request));
+
+        var mfaContext = _mfaTokenProtector.Unprotect(request.MfaToken);
+
+        var body = new Dictionary<string, string>
+        {
+            { "grant_type", MfaRecoveryCodeGrantType },
+            { "client_id", _options.ClientId },
+            { "mfa_token", mfaContext.MfaToken },
+            { "recovery_code", request.RecoveryCode }
+        };
+        AddBoundAudienceScope(body, mfaContext);
+        ApplyClientAuthentication(body);
+
+        return PostFormAsync<MfaRecoveryCodeResponse>("oauth/token", body, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<AssociateMfaAuthenticatorResponse> AssociateMfaAuthenticatorAsync(AssociateMfaAuthenticatorRequest request, CancellationToken cancellationToken = default)
+    {
+        if (request == null) throw new ArgumentNullException(nameof(request));
+
+        var bearer = ResolveAssociateToken(request.Token);
+
+        using var message = new HttpRequestMessage(HttpMethod.Post, BuildUri("mfa/associate"))
+        {
+            Content = new StringContent(JsonSerializer.Serialize(request, SerializerOptions), Encoding.UTF8, "application/json")
+        };
+        message.Headers.Authorization = new AuthenticationHeaderValue("Bearer", bearer);
+
+        return await SendAsync<AssociateMfaAuthenticatorResponse>(message, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task<IList<Authenticator>> ListMfaAuthenticatorsAsync(string accessToken, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(accessToken)) throw new ArgumentNullException(nameof(accessToken));
+
+        using var message = new HttpRequestMessage(HttpMethod.Get, BuildUri("mfa/authenticators"));
+        message.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
+
+        return await SendAsync<IList<Authenticator>>(message, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task DeleteMfaAuthenticatorAsync(DeleteMfaAuthenticatorRequest request, CancellationToken cancellationToken = default)
+    {
+        if (request == null) throw new ArgumentNullException(nameof(request));
+
+        using var message = new HttpRequestMessage(HttpMethod.Delete, BuildUri($"mfa/authenticators/{Uri.EscapeDataString(request.AuthenticatorId)}"));
+        message.Headers.Authorization = new AuthenticationHeaderValue("Bearer", request.AccessToken);
+
+        using var response = await _httpClient.SendAsync(message, cancellationToken).ConfigureAwait(false);
+        await EnsureSuccessAsync(response).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        if (_ownsHttpClient)
+        {
+            _httpClient.Dispose();
+        }
+        GC.SuppressFinalize(this);
+    }
+
+    private async Task<T> PostFormAsync<T>(string path, Dictionary<string, string> body, CancellationToken cancellationToken)
+    {
+        var content = new FormUrlEncodedContent(body.Select(p => new KeyValuePair<string?, string?>(p.Key, p.Value)));
+        using var message = new HttpRequestMessage(HttpMethod.Post, BuildUri(path)) { Content = content };
+        return await SendAsync<T>(message, cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task<T> SendAsync<T>(HttpRequestMessage message, CancellationToken cancellationToken)
+    {
+        using var response = await _httpClient.SendAsync(message, cancellationToken).ConfigureAwait(false);
+        await EnsureSuccessAsync(response).ConfigureAwait(false);
+
+        var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+        var result = await JsonSerializer.DeserializeAsync<T>(stream, SerializerOptions, cancellationToken).ConfigureAwait(false);
+        return result!;
+    }
+
+    private static async Task EnsureSuccessAsync(HttpResponseMessage response)
+    {
+        if (!response.IsSuccessStatusCode)
+        {
+            throw await ErrorApiException.CreateAsync(response).ConfigureAwait(false);
+        }
+    }
+
+    private Uri BuildUri(string path) => new Uri($"https://{_domain}/{path}");
+
+    // The grant calls replay the audience/scope bound into the blob so the new token targets the
+    // same resource the original refresh did.
+    private static void AddBoundAudienceScope(Dictionary<string, string> body, MfaTokenContext context)
+    {
+        if (!string.IsNullOrWhiteSpace(context.Audience)) body["audience"] = context.Audience!;
+        if (!string.IsNullOrWhiteSpace(context.Scope)) body["scope"] = context.Scope!;
+    }
+
+    // Token may be one of our encrypted mfa_token blobs OR a raw access token (enroll scope).
+    // A blob we can decrypt yields the raw mfa_token; a value that isn't one of our blobs
+    // (MfaTokenInvalidException) is an access token, used as-is. An expired blob is a genuine
+    // error and is allowed to propagate.
+    private string ResolveAssociateToken(string token)
+    {
+        try
+        {
+            return _mfaTokenProtector.Unprotect(token).MfaToken;
+        }
+        catch (MfaTokenInvalidException)
+        {
+            return token;
+        }
+    }
+
+    private void ApplyClientAuthentication(Dictionary<string, string> body)
+    {
+        if (_options.ClientAssertionSecurityKey != null)
+        {
+            body.Add("client_assertion", new JwtTokenFactory(
+                    _options.ClientAssertionSecurityKey,
+                    _options.ClientAssertionSecurityKeyAlgorithm ?? SecurityAlgorithms.RsaSha256)
+                .GenerateToken(_options.ClientId, $"https://{_domain}/", _options.ClientId));
+            body.Add("client_assertion_type", "urn:ietf:params:oauth:client-assertion-type:jwt-bearer");
+        }
+        else if (!string.IsNullOrEmpty(_options.ClientSecret))
+        {
+            body.Add("client_secret", _options.ClientSecret!);
+        }
+    }
+}

--- a/src/Auth0.AspNetCore.Authentication/AuthenticationApi/IAuthenticationApiClient.cs
+++ b/src/Auth0.AspNetCore.Authentication/AuthenticationApi/IAuthenticationApiClient.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Auth0.AspNetCore.Authentication.AuthenticationApi.Models;
+
+namespace Auth0.AspNetCore.Authentication.AuthenticationApi;
+
+/// <summary>
+/// A client for the subset of Auth0 Authentication API endpoints needed to recover from an
+/// <c>mfa_required</c> error: triggering an MFA challenge, completing MFA via the OTP / OOB /
+/// recovery-code grants, and managing authenticators.
+/// </summary>
+/// <remarks>
+/// This is implemented over System.Text.Json within this SDK. The interface name, registration
+/// (<see cref="Auth0WebAppAuthenticationBuilder.WithAuthenticationApiClient"/>) and method
+/// shapes intentionally mirror the planned <c>Auth0.AuthenticationApi</c> integration so that a
+/// future swap to that package is invisible to consumers. The request/response types in
+/// <c>Auth0.AspNetCore.Authentication.AuthenticationApi.Models</c> are this SDK's own and form a
+/// permanent public contract.
+/// </remarks>
+public interface IAuthenticationApiClient : IDisposable
+{
+    /// <summary>The base URI of the Auth0 Authentication API (e.g. <c>https://your-domain.auth0.com</c>).</summary>
+    Uri BaseUri { get; }
+
+    /// <summary>Triggers an MFA challenge (OTP, SMS, voice, or push) for an <c>mfa_token</c>.</summary>
+    Task<MfaChallengeResponse> MfaChallengeAsync(MfaChallengeRequest request, CancellationToken cancellationToken = default);
+
+    /// <summary>Completes MFA using a one-time password (OTP) code.</summary>
+    Task<MfaOtpTokenResponse> GetTokenAsync(MfaOtpTokenRequest request, CancellationToken cancellationToken = default);
+
+    /// <summary>Completes MFA using an out-of-band (OOB) code.</summary>
+    Task<MfaOobTokenResponse> GetTokenAsync(MfaOobTokenRequest request, CancellationToken cancellationToken = default);
+
+    /// <summary>Completes MFA using a recovery code.</summary>
+    Task<MfaRecoveryCodeResponse> GetTokenAsync(MfaRecoveryCodeRequest request, CancellationToken cancellationToken = default);
+
+    /// <summary>Associates (enrolls) a new MFA authenticator.</summary>
+    Task<AssociateMfaAuthenticatorResponse> AssociateMfaAuthenticatorAsync(AssociateMfaAuthenticatorRequest request, CancellationToken cancellationToken = default);
+
+    /// <summary>Lists the MFA authenticators associated with the user identified by the access token.</summary>
+    Task<IList<Authenticator>> ListMfaAuthenticatorsAsync(string accessToken, CancellationToken cancellationToken = default);
+
+    /// <summary>Deletes an associated MFA authenticator by ID.</summary>
+    Task DeleteMfaAuthenticatorAsync(DeleteMfaAuthenticatorRequest request, CancellationToken cancellationToken = default);
+}

--- a/src/Auth0.AspNetCore.Authentication/AuthenticationApi/MfaTokenContext.cs
+++ b/src/Auth0.AspNetCore.Authentication/AuthenticationApi/MfaTokenContext.cs
@@ -1,0 +1,32 @@
+using System.Text.Json.Serialization;
+using Auth0.AspNetCore.Authentication.AuthenticationApi.Models;
+
+namespace Auth0.AspNetCore.Authentication.AuthenticationApi;
+
+/// <summary>
+/// The internal payload that is JSON-serialized and encrypted into the opaque blob exposed as
+/// <see cref="MfaRequiredException.MfaToken"/>. Binds the raw <c>mfa_token</c> to the
+/// audience/scope of the originating request and carries its own expiry.
+/// </summary>
+internal sealed class MfaTokenContext
+{
+    /// <summary>The raw <c>mfa_token</c> issued by Auth0. Never leaves the SDK in plaintext.</summary>
+    [JsonPropertyName("mfa_token")]
+    public string MfaToken { get; set; } = null!;
+
+    /// <summary>The audience the original refresh targeted, replayed on the MFA grant.</summary>
+    [JsonPropertyName("audience")]
+    public string? Audience { get; set; }
+
+    /// <summary>The merged scope the original refresh targeted, replayed on the MFA grant.</summary>
+    [JsonPropertyName("scope")]
+    public string? Scope { get; set; }
+
+    /// <summary>The available MFA requirements parsed from the error body.</summary>
+    [JsonPropertyName("mfa_requirements")]
+    public MfaRequirements? MfaRequirements { get; set; }
+
+    /// <summary>Unix-seconds expiry. Enforced on unprotect to give a 5-minute lifetime.</summary>
+    [JsonPropertyName("exp")]
+    public long ExpiresAtUnix { get; set; }
+}

--- a/src/Auth0.AspNetCore.Authentication/AuthenticationApi/MfaTokenProtector.cs
+++ b/src/Auth0.AspNetCore.Authentication/AuthenticationApi/MfaTokenProtector.cs
@@ -1,0 +1,93 @@
+using System;
+using System.Security.Cryptography;
+using System.Text.Json;
+using Microsoft.AspNetCore.DataProtection;
+
+namespace Auth0.AspNetCore.Authentication.AuthenticationApi;
+
+/// <summary>
+/// Encrypts the <see cref="MfaTokenContext"/> into the opaque blob handed to the application,
+/// and decrypts it back inside the SDK when completing the MFA flow.
+/// </summary>
+internal interface IMfaTokenProtector
+{
+    /// <summary>Encrypts <paramref name="context"/> into an opaque, integrity-protected blob.</summary>
+    string Protect(MfaTokenContext context);
+
+    /// <summary>
+    /// Decrypts a blob produced by <see cref="Protect"/>.
+    /// </summary>
+    /// <exception cref="MfaTokenExpiredException">The blob's 5-minute lifetime has passed.</exception>
+    /// <exception cref="MfaTokenInvalidException">The blob was tampered with, malformed, or protected with a different key.</exception>
+    MfaTokenContext Unprotect(string protectedToken);
+}
+
+/// <inheritdoc />
+internal sealed class MfaTokenProtector : IMfaTokenProtector
+{
+    // Versioned so the wire format can change later without ambiguity.
+    private const string ProtectorPurpose = "Auth0.AspNetCore.Authentication.MfaToken.v1";
+    private static readonly TimeSpan Lifetime = TimeSpan.FromMinutes(5);
+
+    private readonly IDataProtector _protector;
+
+    public MfaTokenProtector(IDataProtectionProvider dataProtectionProvider)
+    {
+        if (dataProtectionProvider == null) throw new ArgumentNullException(nameof(dataProtectionProvider));
+        _protector = dataProtectionProvider.CreateProtector(ProtectorPurpose);
+    }
+
+    public string Protect(MfaTokenContext context)
+    {
+        if (context == null) throw new ArgumentNullException(nameof(context));
+
+        if (context.ExpiresAtUnix <= 0)
+        {
+            context.ExpiresAtUnix = DateTimeOffset.UtcNow.Add(Lifetime).ToUnixTimeSeconds();
+        }
+
+        var json = JsonSerializer.Serialize(context);
+        return _protector.Protect(json);
+    }
+
+    public MfaTokenContext Unprotect(string protectedToken)
+    {
+        if (string.IsNullOrEmpty(protectedToken)) throw new MfaTokenInvalidException();
+
+        string json;
+        try
+        {
+            json = _protector.Unprotect(protectedToken);
+        }
+        catch (CryptographicException)
+        {
+            throw new MfaTokenInvalidException();
+        }
+        catch (FormatException)
+        {
+            throw new MfaTokenInvalidException();
+        }
+
+        MfaTokenContext? context;
+        try
+        {
+            context = JsonSerializer.Deserialize<MfaTokenContext>(json);
+        }
+        catch (JsonException)
+        {
+            throw new MfaTokenInvalidException();
+        }
+
+        if (context == null || string.IsNullOrEmpty(context.MfaToken))
+        {
+            throw new MfaTokenInvalidException();
+        }
+
+        if (context.ExpiresAtUnix <= DateTimeOffset.UtcNow.ToUnixTimeSeconds())
+        {
+            throw new MfaTokenExpiredException();
+        }
+
+        return context;
+    }
+}

--- a/src/Auth0.AspNetCore.Authentication/AuthenticationApi/Models/AssociateMfaAuthenticatorRequest.cs
+++ b/src/Auth0.AspNetCore.Authentication/AuthenticationApi/Models/AssociateMfaAuthenticatorRequest.cs
@@ -1,0 +1,28 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace Auth0.AspNetCore.Authentication.AuthenticationApi.Models;
+
+/// <summary>Request to associate (enroll) a new MFA authenticator.</summary>
+public class AssociateMfaAuthenticatorRequest
+{
+    /// <summary>
+    /// The bearer token to authorize enrollment: an access token with the <c>enroll</c> scope,
+    /// or the <c>mfa_token</c> from an <c>mfa_required</c> error when the user has no active
+    /// authenticators. Sent as an <c>Authorization</c> header, not in the body.
+    /// </summary>
+    [JsonIgnore]
+    public string Token { get; set; } = null!;
+
+    /// <summary>The authenticator types supported by the client (e.g. <c>otp</c>, <c>oob</c>).</summary>
+    [JsonPropertyName("authenticator_types")]
+    public string[]? AuthenticatorTypes { get; set; }
+
+    /// <summary>The OOB channels supported by the client. Required if <c>authenticator_types</c> includes <c>oob</c>.</summary>
+    [JsonPropertyName("oob_channels")]
+    public List<string>? OobChannels { get; set; }
+
+    /// <summary>The phone number for SMS or Voice. Required if <c>oob_channels</c> includes <c>sms</c> or <c>voice</c>.</summary>
+    [JsonPropertyName("phone_number")]
+    public string? PhoneNumber { get; set; }
+}

--- a/src/Auth0.AspNetCore.Authentication/AuthenticationApi/Models/AssociateMfaAuthenticatorResponse.cs
+++ b/src/Auth0.AspNetCore.Authentication/AuthenticationApi/Models/AssociateMfaAuthenticatorResponse.cs
@@ -1,0 +1,36 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace Auth0.AspNetCore.Authentication.AuthenticationApi.Models;
+
+/// <summary>The response to associating (enrolling) a new MFA authenticator.</summary>
+public class AssociateMfaAuthenticatorResponse
+{
+    /// <summary>The code used for out-of-band authentication.</summary>
+    [JsonPropertyName("oob_code")]
+    public string? OobCode { get; set; }
+
+    /// <summary>The binding method used.</summary>
+    [JsonPropertyName("binding_method")]
+    public string? BindingMethod { get; set; }
+
+    /// <summary>The type of authenticator added.</summary>
+    [JsonPropertyName("authenticator_type")]
+    public string? AuthenticatorType { get; set; }
+
+    /// <summary>The OOB channel used.</summary>
+    [JsonPropertyName("oob_channel")]
+    public string? OobChannel { get; set; }
+
+    /// <summary>The recovery codes generated for the user.</summary>
+    [JsonPropertyName("recovery_codes")]
+    public List<string>? RecoveryCodes { get; set; }
+
+    /// <summary>The URI to generate a QR code for the authenticator.</summary>
+    [JsonPropertyName("barcode_uri")]
+    public string? BarcodeUri { get; set; }
+
+    /// <summary>The secret to use for the OTP.</summary>
+    [JsonPropertyName("secret")]
+    public string? Secret { get; set; }
+}

--- a/src/Auth0.AspNetCore.Authentication/AuthenticationApi/Models/Authenticator.cs
+++ b/src/Auth0.AspNetCore.Authentication/AuthenticationApi/Models/Authenticator.cs
@@ -1,0 +1,27 @@
+using System.Text.Json.Serialization;
+
+namespace Auth0.AspNetCore.Authentication.AuthenticationApi.Models;
+
+/// <summary>An MFA authenticator associated with a user.</summary>
+public class Authenticator
+{
+    /// <summary>The authenticator ID.</summary>
+    [JsonPropertyName("id")]
+    public string? Id { get; set; }
+
+    /// <summary>The authenticator type (e.g. <c>otp</c>, <c>oob</c>, <c>recovery-code</c>).</summary>
+    [JsonPropertyName("authenticator_type")]
+    public string? AuthenticatorType { get; set; }
+
+    /// <summary>The OOB channel, when applicable.</summary>
+    [JsonPropertyName("oob_channel")]
+    public string? OobChannel { get; set; }
+
+    /// <summary>The authenticator name.</summary>
+    [JsonPropertyName("name")]
+    public string? Name { get; set; }
+
+    /// <summary>Whether the authenticator is active.</summary>
+    [JsonPropertyName("active")]
+    public bool Active { get; set; }
+}

--- a/src/Auth0.AspNetCore.Authentication/AuthenticationApi/Models/DeleteMfaAuthenticatorRequest.cs
+++ b/src/Auth0.AspNetCore.Authentication/AuthenticationApi/Models/DeleteMfaAuthenticatorRequest.cs
@@ -1,0 +1,11 @@
+namespace Auth0.AspNetCore.Authentication.AuthenticationApi.Models;
+
+/// <summary>Request to delete an associated MFA authenticator.</summary>
+public class DeleteMfaAuthenticatorRequest
+{
+    /// <summary>An access token with scope <c>remove:authenticators</c> and the MFA audience.</summary>
+    public string AccessToken { get; set; } = null!;
+
+    /// <summary>The ID of the authenticator to delete.</summary>
+    public string AuthenticatorId { get; set; } = null!;
+}

--- a/src/Auth0.AspNetCore.Authentication/AuthenticationApi/Models/MfaChallengeRequest.cs
+++ b/src/Auth0.AspNetCore.Authentication/AuthenticationApi/Models/MfaChallengeRequest.cs
@@ -1,0 +1,17 @@
+namespace Auth0.AspNetCore.Authentication.AuthenticationApi.Models;
+
+/// <summary>
+/// Request to trigger an MFA challenge for the authenticator(s) associated with an
+/// <c>mfa_token</c> received from an <c>mfa_required</c> error.
+/// </summary>
+public class MfaChallengeRequest
+{
+    /// <summary>The <c>mfa_token</c> received from the <c>mfa_required</c> error.</summary>
+    public string MfaToken { get; set; } = null!;
+
+    /// <summary>A whitespace-separated list of challenge types accepted by your application.</summary>
+    public string? ChallengeType { get; set; }
+
+    /// <summary>The ID of the authenticator to challenge.</summary>
+    public string? AuthenticatorId { get; set; }
+}

--- a/src/Auth0.AspNetCore.Authentication/AuthenticationApi/Models/MfaChallengeResponse.cs
+++ b/src/Auth0.AspNetCore.Authentication/AuthenticationApi/Models/MfaChallengeResponse.cs
@@ -1,0 +1,19 @@
+using System.Text.Json.Serialization;
+
+namespace Auth0.AspNetCore.Authentication.AuthenticationApi.Models;
+
+/// <summary>The response to an MFA challenge request.</summary>
+public class MfaChallengeResponse
+{
+    /// <summary>The type of challenge issued.</summary>
+    [JsonPropertyName("challenge_type")]
+    public string? ChallengeType { get; set; }
+
+    /// <summary>The code for an out-of-band challenge, when applicable.</summary>
+    [JsonPropertyName("oob_code")]
+    public string? OobCode { get; set; }
+
+    /// <summary>The binding method, when applicable.</summary>
+    [JsonPropertyName("binding_method")]
+    public string? BindingMethod { get; set; }
+}

--- a/src/Auth0.AspNetCore.Authentication/AuthenticationApi/Models/MfaOobTokenRequest.cs
+++ b/src/Auth0.AspNetCore.Authentication/AuthenticationApi/Models/MfaOobTokenRequest.cs
@@ -1,0 +1,14 @@
+namespace Auth0.AspNetCore.Authentication.AuthenticationApi.Models;
+
+/// <summary>Request to complete MFA using an out-of-band (OOB) code.</summary>
+public class MfaOobTokenRequest
+{
+    /// <summary>The <c>mfa_token</c> received from the <c>mfa_required</c> error.</summary>
+    public string MfaToken { get; set; } = null!;
+
+    /// <summary>The <c>oob_code</c> received from the challenge request.</summary>
+    public string OobCode { get; set; } = null!;
+
+    /// <summary>A code used to bind the side channel with the main authentication channel.</summary>
+    public string? BindingCode { get; set; }
+}

--- a/src/Auth0.AspNetCore.Authentication/AuthenticationApi/Models/MfaOobTokenResponse.cs
+++ b/src/Auth0.AspNetCore.Authentication/AuthenticationApi/Models/MfaOobTokenResponse.cs
@@ -2,18 +2,29 @@ using System.Text.Json.Serialization;
 
 namespace Auth0.AspNetCore.Authentication.AuthenticationApi.Models;
 
-/// <summary>The token response from completing MFA with an OOB code.</summary>
+/// <summary>
+/// The token response from completing MFA with an OOB code.
+/// <para>
+/// OOB verification (push/SMS) is asynchronous: while the user has not yet approved the request,
+/// Auth0 answers with <c>authorization_pending</c> or <c>slow_down</c>. Those are surfaced on
+/// <see cref="Error"/>/<see cref="ErrorDescription"/> (with <see cref="TokenBase.AccessToken"/> null)
+/// so the caller can poll; any other failure throws an
+/// <see cref="Exceptions.ErrorApiException"/>. On success the token fields are populated and
+/// <see cref="Error"/> is null.
+/// </para>
+/// </summary>
 public class MfaOobTokenResponse : TokenBase
 {
     /// <summary>The lifetime in seconds of the access token.</summary>
     [JsonPropertyName("expires_in")]
     public int ExpiresIn { get; set; }
 
-    /// <summary>The error code returned when the OOB exchange has not yet succeeded (e.g. <c>authorization_pending</c>).</summary>
+    /// <summary>The error code returned while the OOB exchange has not yet succeeded
+    /// (<c>authorization_pending</c> or <c>slow_down</c>); <c>null</c> on success.</summary>
     [JsonPropertyName("error")]
     public string? Error { get; set; }
 
-    /// <summary>The description of the error.</summary>
+    /// <summary>The human-readable description accompanying <see cref="Error"/>; <c>null</c> on success.</summary>
     [JsonPropertyName("error_description")]
     public string? ErrorDescription { get; set; }
 }

--- a/src/Auth0.AspNetCore.Authentication/AuthenticationApi/Models/MfaOobTokenResponse.cs
+++ b/src/Auth0.AspNetCore.Authentication/AuthenticationApi/Models/MfaOobTokenResponse.cs
@@ -1,0 +1,19 @@
+using System.Text.Json.Serialization;
+
+namespace Auth0.AspNetCore.Authentication.AuthenticationApi.Models;
+
+/// <summary>The token response from completing MFA with an OOB code.</summary>
+public class MfaOobTokenResponse : TokenBase
+{
+    /// <summary>The lifetime in seconds of the access token.</summary>
+    [JsonPropertyName("expires_in")]
+    public int ExpiresIn { get; set; }
+
+    /// <summary>The error code returned when the OOB exchange has not yet succeeded (e.g. <c>authorization_pending</c>).</summary>
+    [JsonPropertyName("error")]
+    public string? Error { get; set; }
+
+    /// <summary>The description of the error.</summary>
+    [JsonPropertyName("error_description")]
+    public string? ErrorDescription { get; set; }
+}

--- a/src/Auth0.AspNetCore.Authentication/AuthenticationApi/Models/MfaOtpTokenRequest.cs
+++ b/src/Auth0.AspNetCore.Authentication/AuthenticationApi/Models/MfaOtpTokenRequest.cs
@@ -1,0 +1,11 @@
+namespace Auth0.AspNetCore.Authentication.AuthenticationApi.Models;
+
+/// <summary>Request to complete MFA using a one-time password (OTP).</summary>
+public class MfaOtpTokenRequest
+{
+    /// <summary>The <c>mfa_token</c> received from the <c>mfa_required</c> error.</summary>
+    public string MfaToken { get; set; } = null!;
+
+    /// <summary>The OTP code provided by the user.</summary>
+    public string Otp { get; set; } = null!;
+}

--- a/src/Auth0.AspNetCore.Authentication/AuthenticationApi/Models/MfaOtpTokenResponse.cs
+++ b/src/Auth0.AspNetCore.Authentication/AuthenticationApi/Models/MfaOtpTokenResponse.cs
@@ -1,0 +1,11 @@
+using System.Text.Json.Serialization;
+
+namespace Auth0.AspNetCore.Authentication.AuthenticationApi.Models;
+
+/// <summary>The token response from completing MFA with an OTP code.</summary>
+public class MfaOtpTokenResponse : TokenBase
+{
+    /// <summary>The lifetime in seconds of the access token.</summary>
+    [JsonPropertyName("expires_in")]
+    public int ExpiresIn { get; set; }
+}

--- a/src/Auth0.AspNetCore.Authentication/AuthenticationApi/Models/MfaRecoveryCodeRequest.cs
+++ b/src/Auth0.AspNetCore.Authentication/AuthenticationApi/Models/MfaRecoveryCodeRequest.cs
@@ -1,0 +1,11 @@
+namespace Auth0.AspNetCore.Authentication.AuthenticationApi.Models;
+
+/// <summary>Request to complete MFA using a recovery code.</summary>
+public class MfaRecoveryCodeRequest
+{
+    /// <summary>The <c>mfa_token</c> received from the <c>mfa_required</c> error.</summary>
+    public string MfaToken { get; set; } = null!;
+
+    /// <summary>The recovery code provided by the user.</summary>
+    public string RecoveryCode { get; set; } = null!;
+}

--- a/src/Auth0.AspNetCore.Authentication/AuthenticationApi/Models/MfaRecoveryCodeResponse.cs
+++ b/src/Auth0.AspNetCore.Authentication/AuthenticationApi/Models/MfaRecoveryCodeResponse.cs
@@ -1,0 +1,15 @@
+using System.Text.Json.Serialization;
+
+namespace Auth0.AspNetCore.Authentication.AuthenticationApi.Models;
+
+/// <summary>The token response from completing MFA with a recovery code.</summary>
+public class MfaRecoveryCodeResponse : TokenBase
+{
+    /// <summary>The lifetime in seconds of the access token.</summary>
+    [JsonPropertyName("expires_in")]
+    public int ExpiresIn { get; set; }
+
+    /// <summary>A new recovery code to store securely, replacing the one just used.</summary>
+    [JsonPropertyName("recovery_code")]
+    public string? RecoveryCode { get; set; }
+}

--- a/src/Auth0.AspNetCore.Authentication/AuthenticationApi/Models/MfaRequirements.cs
+++ b/src/Auth0.AspNetCore.Authentication/AuthenticationApi/Models/MfaRequirements.cs
@@ -1,0 +1,32 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace Auth0.AspNetCore.Authentication.AuthenticationApi.Models;
+
+/// <summary>
+/// The factors/challenge types Auth0 reports as available in an <c>mfa_required</c> error,
+/// surfaced via <see cref="MfaRequiredException.MfaRequirements"/>. Tolerant of missing or
+/// unknown fields — Auth0's shape can evolve.
+/// </summary>
+public class MfaRequirements
+{
+    /// <summary>The challenges the user can satisfy to complete MFA.</summary>
+    [JsonPropertyName("challenge")]
+    public IList<MfaChallengeRequirement>? Challenge { get; set; }
+}
+
+/// <summary>A single available MFA challenge option.</summary>
+public class MfaChallengeRequirement
+{
+    /// <summary>The challenge type, e.g. <c>otp</c> or <c>oob</c>.</summary>
+    [JsonPropertyName("type")]
+    public string? Type { get; set; }
+
+    /// <summary>For an <c>oob</c> challenge, the available out-of-band channels (e.g. <c>sms</c>, <c>voice</c>).</summary>
+    [JsonPropertyName("oob_channels")]
+    public IList<string>? OobChannels { get; set; }
+
+    /// <summary>The authenticator this challenge targets, when reported.</summary>
+    [JsonPropertyName("authenticator_id")]
+    public string? AuthenticatorId { get; set; }
+}

--- a/src/Auth0.AspNetCore.Authentication/AuthenticationApi/Models/TokenBase.cs
+++ b/src/Auth0.AspNetCore.Authentication/AuthenticationApi/Models/TokenBase.cs
@@ -1,0 +1,17 @@
+using System.Text.Json.Serialization;
+
+namespace Auth0.AspNetCore.Authentication.AuthenticationApi.Models;
+
+/// <summary>
+/// Base class for token responses returned by the Auth0 Authentication API.
+/// </summary>
+public abstract class TokenBase
+{
+    /// <summary>The access token.</summary>
+    [JsonPropertyName("access_token")]
+    public string? AccessToken { get; set; }
+
+    /// <summary>The type of token (typically <c>Bearer</c>).</summary>
+    [JsonPropertyName("token_type")]
+    public string? TokenType { get; set; }
+}

--- a/src/Auth0.AspNetCore.Authentication/HttpContextExtensions.cs
+++ b/src/Auth0.AspNetCore.Authentication/HttpContextExtensions.cs
@@ -4,9 +4,12 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using System;
 using System.Collections.Generic;
+using System.Net;
 using System.Net.Http;
 using System.Text.Json;
 using System.Threading.Tasks;
+using Auth0.AspNetCore.Authentication.AuthenticationApi;
+using Auth0.AspNetCore.Authentication.AuthenticationApi.Models;
 
 namespace Auth0.AspNetCore.Authentication
 {
@@ -124,6 +127,31 @@ namespace Auth0.AspNetCore.Authentication
 
             if (!result.IsSuccess)
             {
+                // mfa_required is a recoverable challenge, not a terminal/transient refresh failure:
+                // surface it as a typed exception so the caller can drive
+                // the MFA flow. 
+                // A mfa_required response with no mfa_token is malformed and cannot drive the flow, so it falls
+                // through to the refresh-failed path rather than yielding a blob that can never
+                // be unprotected.
+                if (result.Error == "mfa_required" && !string.IsNullOrEmpty(result.MfaToken))
+                {
+                    var protector = context.RequestServices.GetRequiredService<IMfaTokenProtector>();
+                    var mfaContext = new MfaTokenContext
+                    {
+                        MfaToken = result.MfaToken!,
+                        Audience = audience,
+                        Scope = mergedScope,
+                        MfaRequirements = result.MfaRequirements
+                    };
+                    var blob = protector.Protect(mfaContext);
+
+                    throw new MfaRequiredException(
+                        blob,
+                        result.MfaRequirements,
+                        (HttpStatusCode)(result.StatusCode ?? (int)HttpStatusCode.Forbidden),
+                        new Exceptions.ApiError { Error = result.Error, Message = result.ErrorDescription ?? string.Empty });
+                }
+
                 await FireRefreshFailed(optionsWithAccessToken,
                     AccessTokenRefreshFailedContext.FromHttpRejection(context, audience, mergedScope, result.StatusCode, result.Error, result.ErrorDescription)).ConfigureAwait(false);
                 return null;

--- a/src/Auth0.AspNetCore.Authentication/HttpContextExtensions.cs
+++ b/src/Auth0.AspNetCore.Authentication/HttpContextExtensions.cs
@@ -46,6 +46,14 @@ namespace Auth0.AspNetCore.Authentication
         /// <param name="request">The audience/scope to request a token for.</param>
         /// <param name="scheme">The Auth0 authentication scheme. Defaults to <see cref="Auth0Constants.AuthenticationScheme"/>.</param>
         /// <returns>The access token, or <c>null</c> when no refresh token is available or the refresh failed.</returns>
+        /// <exception cref="MfaRequiredException">
+        /// Thrown when the token exchange returns an <c>mfa_required</c> error carrying an <c>mfa_token</c>.
+        /// This is a recoverable challenge rather than a terminal failure: drive the MFA challenge/verify
+        /// flow with <see cref="AuthenticationApi.IAuthenticationApiClient"/> (registered via
+        /// <see cref="Auth0WebAppAuthenticationBuilder.WithAuthenticationApiClient"/>) using the
+        /// <see cref="MfaRequiredException.MfaToken"/> blob. A malformed <c>mfa_required</c> response with no
+        /// <c>mfa_token</c> is folded into the refresh-failed path instead.
+        /// </exception>
         /// <exception cref="System.InvalidOperationException">
         /// Thrown when a refresh succeeds but the new token cannot be persisted because the response has
         /// already started. Persisting the refreshed token calls <see cref="AuthenticationHttpContextExtensions.SignInAsync(HttpContext, string?, System.Security.Claims.ClaimsPrincipal, AuthenticationProperties?)"/>,

--- a/src/Auth0.AspNetCore.Authentication/MfaRequiredException.cs
+++ b/src/Auth0.AspNetCore.Authentication/MfaRequiredException.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Net;
+using System.Runtime.Serialization;
+using Auth0.AspNetCore.Authentication.AuthenticationApi.Models;
+using Auth0.AspNetCore.Authentication.Exceptions;
+
+namespace Auth0.AspNetCore.Authentication
+{
+    /// <summary>
+    /// Thrown by <see cref="HttpContextExtensions.GetAccessTokenAsync"/> when a token exchange
+    /// returns an <c>mfa_required</c> error. Carries the <see cref="MfaToken"/> needed to drive
+    /// the MFA challenge/verify flow via <see cref="AuthenticationApi.IAuthenticationApiClient"/>.
+    /// </summary>
+    [Serializable]
+    public class MfaRequiredException : ErrorApiException
+    {
+        /// <summary>
+        /// Creates an <see cref="MfaRequiredException"/> carrying the encrypted <c>mfa_token</c> blob
+        /// and the status code / error details from the failed exchange.
+        /// </summary>
+        public MfaRequiredException(string? mfaToken, HttpStatusCode statusCode, ApiError? apiError = null)
+            : this(mfaToken, null, statusCode, apiError)
+        {
+        }
+
+        /// <summary>
+        /// Creates an <see cref="MfaRequiredException"/> carrying the encrypted <c>mfa_token</c> blob,
+        /// the available <paramref name="mfaRequirements"/>, and the status code / error details.
+        /// </summary>
+        public MfaRequiredException(string? mfaToken, MfaRequirements? mfaRequirements, HttpStatusCode statusCode, ApiError? apiError = null)
+            : base(statusCode, apiError)
+        {
+            MfaToken = mfaToken;
+            MfaRequirements = mfaRequirements;
+        }
+
+        /// <summary>The encrypted, integrity-protected, self-expiring <c>mfa_token</c> blob. Opaque to the
+        /// application: pass it back to <see cref="AuthenticationApi.IAuthenticationApiClient"/>
+        /// methods, which decrypt it internally. Valid for 5 minutes.</summary>
+        public string? MfaToken { get; }
+
+        /// <summary>The MFA factors/challenge types Auth0 reported as available, when present.</summary>
+        public MfaRequirements? MfaRequirements { get; }
+
+        /// <inheritdoc />
+        protected MfaRequiredException(SerializationInfo serializationInfo, StreamingContext streamingContext)
+            : base(serializationInfo, streamingContext)
+        {
+            MfaToken = serializationInfo.GetString(nameof(MfaToken));
+        }
+
+        /// <inheritdoc />
+        public override void GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+            // MfaRequirements is intentionally not serialized: the type is not [Serializable] and
+            // the recoverable MFA flow runs within a single request.
+            base.GetObjectData(info, context);
+            info.AddValue(nameof(MfaToken), MfaToken);
+        }
+    }
+}

--- a/src/Auth0.AspNetCore.Authentication/MfaTokenExpiredException.cs
+++ b/src/Auth0.AspNetCore.Authentication/MfaTokenExpiredException.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Net;
+using System.Runtime.Serialization;
+using Auth0.AspNetCore.Authentication.Exceptions;
+
+namespace Auth0.AspNetCore.Authentication
+{
+    /// <summary>
+    /// Thrown when an encrypted <c>mfa_token</c> blob (see <see cref="MfaRequiredException.MfaToken"/>)
+    /// has passed its 5-minute lifetime. The MFA flow must be restarted to obtain a fresh token.
+    /// </summary>
+    [Serializable]
+    public class MfaTokenExpiredException : ErrorApiException
+    {
+        private static ApiError DefaultError => new ApiError
+        {
+            Error = "mfa_token_expired",
+            Message = "The MFA token has expired. Restart the MFA flow to obtain a new one."
+        };
+
+        /// <summary>Creates an <see cref="MfaTokenExpiredException"/> with a default error payload.</summary>
+        public MfaTokenExpiredException()
+            : base(HttpStatusCode.Unauthorized, DefaultError)
+        {
+        }
+
+        /// <inheritdoc />
+        protected MfaTokenExpiredException(SerializationInfo serializationInfo, StreamingContext streamingContext)
+            : base(serializationInfo, streamingContext)
+        {
+        }
+    }
+}

--- a/src/Auth0.AspNetCore.Authentication/MfaTokenInvalidException.cs
+++ b/src/Auth0.AspNetCore.Authentication/MfaTokenInvalidException.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Net;
+using System.Runtime.Serialization;
+using Auth0.AspNetCore.Authentication.Exceptions;
+
+namespace Auth0.AspNetCore.Authentication
+{
+    /// <summary>
+    /// Thrown when an <c>mfa_token</c> value cannot be decrypted as a blob produced by this SDK —
+    /// it was tampered with, malformed, or protected with a different key. The MFA flow must be
+    /// restarted.
+    /// </summary>
+    [Serializable]
+    public class MfaTokenInvalidException : ErrorApiException
+    {
+        private static ApiError DefaultError => new ApiError
+        {
+            Error = "mfa_token_invalid",
+            Message = "The MFA token is invalid or could not be decrypted."
+        };
+
+        /// <summary>Creates an <see cref="MfaTokenInvalidException"/> with a default error payload.</summary>
+        public MfaTokenInvalidException()
+            : base(HttpStatusCode.Unauthorized, DefaultError)
+        {
+        }
+
+        /// <inheritdoc />
+        protected MfaTokenInvalidException(SerializationInfo serializationInfo, StreamingContext streamingContext)
+            : base(serializationInfo, streamingContext)
+        {
+        }
+    }
+}

--- a/src/Auth0.AspNetCore.Authentication/TokenClient.cs
+++ b/src/Auth0.AspNetCore.Authentication/TokenClient.cs
@@ -1,4 +1,5 @@
 ﻿using Auth0.AspNetCore.Authentication;
+using Auth0.AspNetCore.Authentication.AuthenticationApi.Models;
 using Microsoft.IdentityModel.Tokens;
 using System;
 using System.Collections.Generic;
@@ -100,6 +101,8 @@ namespace Auth0.AspNetCore.Authentication
         {
             string? error = null;
             string? errorDescription = null;
+            string? mfaToken = null;
+            MfaRequirements? mfaRequirements = null;
 
             try
             {
@@ -119,6 +122,24 @@ namespace Auth0.AspNetCore.Authentication
                         {
                             errorDescription = descriptionElement.GetString();
                         }
+
+                        if (root.TryGetProperty("mfa_token", out var mfaTokenElement))
+                        {
+                            mfaToken = mfaTokenElement.GetString();
+                        }
+
+                        if (root.TryGetProperty("mfa_requirements", out var mfaRequirementsElement) &&
+                            mfaRequirementsElement.ValueKind == JsonValueKind.Object)
+                        {
+                            try
+                            {
+                                mfaRequirements = mfaRequirementsElement.Deserialize<MfaRequirements>();
+                            }
+                            catch (JsonException)
+                            {
+                                // Best-effort: a shape we can't map is simply omitted.
+                            }
+                        }
                     }
                 }
             }
@@ -127,7 +148,7 @@ namespace Auth0.AspNetCore.Authentication
                 // A non-JSON or unreadable error body still yields a result carrying the status code.
             }
 
-            return TokenRefreshResult.Failure((int)response.StatusCode, error, errorDescription);
+            return TokenRefreshResult.Failure((int)response.StatusCode, error, errorDescription, mfaToken, mfaRequirements);
         }
 
         private void ApplyClientAuthentication(Auth0WebAppOptions options, Dictionary<string, string> body, string domain)

--- a/src/Auth0.AspNetCore.Authentication/TokenRefreshResult.cs
+++ b/src/Auth0.AspNetCore.Authentication/TokenRefreshResult.cs
@@ -1,3 +1,5 @@
+using Auth0.AspNetCore.Authentication.AuthenticationApi.Models;
+
 namespace Auth0.AspNetCore.Authentication
 {
     /// <summary>
@@ -23,17 +25,25 @@ namespace Auth0.AspNetCore.Authentication
         /// <summary>The <c>error_description</c> from the token endpoint's error body, when present.</summary>
         public string? ErrorDescription { get; private set; }
 
+        /// <summary>The <c>mfa_token</c> from an <c>mfa_required</c> error body, when present.</summary>
+        public string? MfaToken { get; private set; }
+
+        /// <summary>The <c>mfa_requirements</c> from an <c>mfa_required</c> error body, when present.</summary>
+        public MfaRequirements? MfaRequirements { get; private set; }
+
         public bool IsSuccess => Response != null;
 
         public static TokenRefreshResult Success(AccessTokenResponse response) =>
             new TokenRefreshResult { Response = response };
 
-        public static TokenRefreshResult Failure(int? statusCode, string? error = null, string? errorDescription = null) =>
+        public static TokenRefreshResult Failure(int? statusCode, string? error = null, string? errorDescription = null, string? mfaToken = null, MfaRequirements? mfaRequirements = null) =>
             new TokenRefreshResult
             {
                 StatusCode = statusCode,
                 Error = error,
-                ErrorDescription = errorDescription
+                ErrorDescription = errorDescription,
+                MfaToken = mfaToken,
+                MfaRequirements = mfaRequirements
             };
     }
 }

--- a/tests/Auth0.AspNetCore.Authentication.IntegrationTests/AuthenticationApi/AuthenticationApiClientTests.cs
+++ b/tests/Auth0.AspNetCore.Authentication.IntegrationTests/AuthenticationApi/AuthenticationApiClientTests.cs
@@ -123,6 +123,61 @@ namespace Auth0.AspNetCore.Authentication.IntegrationTests.AuthenticationApi
             capturedBody.Should().Contain("binding_code=999");
         }
 
+        [Theory]
+        [InlineData("authorization_pending")]
+        [InlineData("slow_down")]
+        public async Task GetTokenAsync_Oob_Pending_DoesNotThrow_And_PopulatesError(string errorCode)
+        {
+            // While the user has not yet approved the OOB push/SMS, Auth0 replies HTTP 400 with a
+            // pending error. The OOB grant must surface that on the response so callers can poll,
+            // not throw.
+            var handler = Handler(new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.BadRequest,
+                Content = new StringContent($"{{\"error\":\"{errorCode}\",\"error_description\":\"still waiting\"}}")
+            }, (_, _) => { });
+            var client = Client(handler);
+
+            var result = await client.GetTokenAsync(new MfaOobTokenRequest { MfaToken = Blob("mt"), OobCode = "oc" });
+
+            result.Error.Should().Be(errorCode);
+            result.ErrorDescription.Should().Be("still waiting");
+            result.AccessToken.Should().BeNull();
+        }
+
+        [Fact]
+        public async Task GetTokenAsync_Oob_Success_PopulatesToken_And_NoError()
+        {
+            var handler = Handler(Ok("{\"access_token\":\"at\",\"token_type\":\"Bearer\",\"expires_in\":3600}"),
+                (_, _) => { });
+            var client = Client(handler);
+
+            var result = await client.GetTokenAsync(new MfaOobTokenRequest { MfaToken = Blob("mt"), OobCode = "oc" });
+
+            result.AccessToken.Should().Be("at");
+            result.ExpiresIn.Should().Be(3600);
+            result.Error.Should().BeNull();
+        }
+
+        [Fact]
+        public async Task GetTokenAsync_Oob_GenuineError_Throws_ErrorApiException()
+        {
+            // A non-pending failure (e.g. invalid_grant) is a real error and must still throw,
+            // exactly like the OTP/recovery grants.
+            var handler = Handler(new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.Forbidden,
+                Content = new StringContent("{\"error\":\"invalid_grant\",\"error_description\":\"Invalid oob_code.\"}")
+            }, (_, _) => { });
+            var client = Client(handler);
+
+            var act = async () => await client.GetTokenAsync(new MfaOobTokenRequest { MfaToken = Blob("mt"), OobCode = "oc" });
+
+            var ex = await act.Should().ThrowAsync<ErrorApiException>();
+            ex.And.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+            ex.And.ApiError!.Error.Should().Be("invalid_grant");
+        }
+
         [Fact]
         public async Task GetTokenAsync_RecoveryCode_Posts_RecoveryGrant()
         {
@@ -336,6 +391,27 @@ namespace Auth0.AspNetCore.Authentication.IntegrationTests.AuthenticationApi
 
             client.Should().NotBeNull();
             client!.BaseUri.Should().Be(new Uri("https://test.auth0.com"));
+        }
+
+        [Fact]
+        public void WithAccessToken_Registers_MfaTokenProtector_WithoutAuthenticationApiClient()
+        {
+            // GetAccessTokenAsync resolves IMfaTokenProtector on the mfa_required path. Because MRRT
+            // refresh is supported without WithAuthenticationApiClient(), the base WithAccessToken
+            // path must register the protector too — otherwise mfa_required surfaces as an opaque DI
+            // failure instead of the typed MfaRequiredException.
+            var services = new Microsoft.Extensions.DependencyInjection.ServiceCollection();
+            Microsoft.Extensions.DependencyInjection.DataProtectionServiceCollectionExtensions.AddDataProtection(services);
+            var options = new Auth0WebAppOptions { Domain = "test.auth0.com", ClientId = "cid", ClientSecret = "secret" };
+            var builder = new Auth0WebAppAuthenticationBuilder(services, options);
+
+            builder.WithAccessToken(o => o.UseRefreshTokens = true);
+
+            var provider = Microsoft.Extensions.DependencyInjection.ServiceCollectionContainerBuilderExtensions.BuildServiceProvider(services);
+            var protector = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions
+                .GetService<IMfaTokenProtector>(provider);
+
+            protector.Should().NotBeNull();
         }
     }
 }

--- a/tests/Auth0.AspNetCore.Authentication.IntegrationTests/AuthenticationApi/AuthenticationApiClientTests.cs
+++ b/tests/Auth0.AspNetCore.Authentication.IntegrationTests/AuthenticationApi/AuthenticationApiClientTests.cs
@@ -1,0 +1,341 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Auth0.AspNetCore.Authentication.AuthenticationApi;
+using Auth0.AspNetCore.Authentication.AuthenticationApi.Models;
+using Auth0.AspNetCore.Authentication.Exceptions;
+using FluentAssertions;
+using Microsoft.AspNetCore.DataProtection;
+using Moq;
+using Moq.Protected;
+using Xunit;
+
+namespace Auth0.AspNetCore.Authentication.IntegrationTests.AuthenticationApi
+{
+    public class AuthenticationApiClientTests
+    {
+        private const string Domain = "test.auth0.com";
+
+        private static readonly IMfaTokenProtector Protector =
+            new MfaTokenProtector(new EphemeralDataProtectionProvider());
+
+        private static string Blob(string rawToken, string? audience = null, string? scope = null) =>
+            Protector.Protect(new MfaTokenContext
+            {
+                MfaToken = rawToken,
+                Audience = audience,
+                Scope = scope,
+                ExpiresAtUnix = DateTimeOffset.UtcNow.AddMinutes(5).ToUnixTimeSeconds()
+            });
+
+        private static Auth0WebAppOptions Options() =>
+            new Auth0WebAppOptions { Domain = Domain, ClientId = "cid", ClientSecret = "secret" };
+
+        // Captures the outgoing request and returns a canned response.
+        private static Mock<HttpMessageHandler> Handler(HttpResponseMessage response, Action<HttpRequestMessage, string> capture)
+        {
+            var handler = new Mock<HttpMessageHandler>();
+            handler
+                .Protected()
+                .Setup<Task<HttpResponseMessage>>("SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+                .Returns<HttpRequestMessage, CancellationToken>(async (req, _) =>
+                {
+                    var body = req.Content == null ? "" : await req.Content.ReadAsStringAsync();
+                    capture(req, body);
+                    return response;
+                });
+            return handler;
+        }
+
+        private static HttpResponseMessage Ok(string json) =>
+            new HttpResponseMessage { StatusCode = HttpStatusCode.OK, Content = new StringContent(json) };
+
+        private static AuthenticationApiClient Client(Mock<HttpMessageHandler> handler) =>
+            new AuthenticationApiClient(new HttpClient(handler.Object), new Uri($"https://{Domain}"), Options(), Protector);
+
+        [Fact]
+        public void BaseUri_Returns_ConfiguredUri()
+        {
+            var client = Client(Handler(Ok("{}"), (_, _) => { }));
+            client.BaseUri.Should().Be(new Uri($"https://{Domain}"));
+        }
+
+        [Fact]
+        public async Task MfaChallengeAsync_Posts_To_MfaChallenge_With_Body()
+        {
+            HttpRequestMessage? captured = null;
+            string capturedBody = "";
+            var handler = Handler(Ok("{\"challenge_type\":\"oob\",\"oob_code\":\"oc\"}"),
+                (r, b) => { captured = r; capturedBody = b; });
+            var client = Client(handler);
+
+            var result = await client.MfaChallengeAsync(new MfaChallengeRequest
+            {
+                MfaToken = Blob("mt"), ChallengeType = "oob", AuthenticatorId = "auth|1"
+            });
+
+            captured!.Method.Should().Be(HttpMethod.Post);
+            captured.RequestUri!.AbsoluteUri.Should().Be($"https://{Domain}/mfa/challenge");
+            capturedBody.Should().Contain("mfa_token=mt");
+            capturedBody.Should().Contain("client_id=cid");
+            capturedBody.Should().Contain("client_secret=secret");
+            capturedBody.Should().Contain("challenge_type=oob");
+            capturedBody.Should().Contain("authenticator_id=auth%7C1");
+            result.OobCode.Should().Be("oc");
+        }
+
+        [Fact]
+        public async Task GetTokenAsync_Otp_Posts_OtpGrant_To_OAuthToken()
+        {
+            string capturedBody = "";
+            HttpRequestMessage? captured = null;
+            var handler = Handler(Ok("{\"access_token\":\"at\",\"token_type\":\"Bearer\",\"expires_in\":86400}"),
+                (r, b) => { captured = r; capturedBody = b; });
+            var client = Client(handler);
+
+            var result = await client.GetTokenAsync(new MfaOtpTokenRequest { MfaToken = Blob("mt"), Otp = "123456" });
+
+            captured!.RequestUri!.AbsoluteUri.Should().Be($"https://{Domain}/oauth/token");
+            capturedBody.Should().Contain("grant_type=http%3A%2F%2Fauth0.com%2Foauth%2Fgrant-type%2Fmfa-otp");
+            capturedBody.Should().Contain("mfa_token=mt");
+            capturedBody.Should().Contain("otp=123456");
+            result.AccessToken.Should().Be("at");
+            result.ExpiresIn.Should().Be(86400);
+        }
+
+        [Fact]
+        public async Task GetTokenAsync_Oob_Posts_OobGrant()
+        {
+            string capturedBody = "";
+            var handler = Handler(Ok("{\"access_token\":\"at\",\"expires_in\":3600}"),
+                (_, b) => capturedBody = b);
+            var client = Client(handler);
+
+            await client.GetTokenAsync(new MfaOobTokenRequest { MfaToken = Blob("mt"), OobCode = "oc", BindingCode = "999" });
+
+            capturedBody.Should().Contain("grant_type=http%3A%2F%2Fauth0.com%2Foauth%2Fgrant-type%2Fmfa-oob");
+            capturedBody.Should().Contain("oob_code=oc");
+            capturedBody.Should().Contain("binding_code=999");
+        }
+
+        [Fact]
+        public async Task GetTokenAsync_RecoveryCode_Posts_RecoveryGrant()
+        {
+            string capturedBody = "";
+            var handler = Handler(Ok("{\"access_token\":\"at\",\"expires_in\":3600,\"recovery_code\":\"NEW\"}"),
+                (_, b) => capturedBody = b);
+            var client = Client(handler);
+
+            var result = await client.GetTokenAsync(new MfaRecoveryCodeRequest { MfaToken = Blob("mt"), RecoveryCode = "rc" });
+
+            capturedBody.Should().Contain("grant_type=http%3A%2F%2Fauth0.com%2Foauth%2Fgrant-type%2Fmfa-recovery-code");
+            capturedBody.Should().Contain("recovery_code=rc");
+            result.RecoveryCode.Should().Be("NEW");
+        }
+
+        [Fact]
+        public async Task ListMfaAuthenticatorsAsync_Gets_With_BearerHeader()
+        {
+            HttpRequestMessage? captured = null;
+            var handler = Handler(Ok("[{\"id\":\"a1\",\"authenticator_type\":\"otp\",\"active\":true}]"),
+                (r, _) => captured = r);
+            var client = Client(handler);
+
+            var result = await client.ListMfaAuthenticatorsAsync("the-access-token");
+
+            captured!.Method.Should().Be(HttpMethod.Get);
+            captured.RequestUri!.AbsoluteUri.Should().Be($"https://{Domain}/mfa/authenticators");
+            captured.Headers.Authorization!.Scheme.Should().Be("Bearer");
+            captured.Headers.Authorization.Parameter.Should().Be("the-access-token");
+            result.Should().ContainSingle().Which.Id.Should().Be("a1");
+        }
+
+        [Fact]
+        public async Task AssociateMfaAuthenticatorAsync_Posts_Json_With_BearerHeader()
+        {
+            HttpRequestMessage? captured = null;
+            string capturedBody = "";
+            var handler = Handler(Ok("{\"authenticator_type\":\"oob\",\"oob_code\":\"oc\"}"),
+                (r, b) => { captured = r; capturedBody = b; });
+            var client = Client(handler);
+
+            await client.AssociateMfaAuthenticatorAsync(new AssociateMfaAuthenticatorRequest
+            {
+                Token = Blob("mt"), AuthenticatorTypes = new[] { "oob" }, OobChannels = new List<string> { "sms" }, PhoneNumber = "+1555"
+            });
+
+            captured!.Method.Should().Be(HttpMethod.Post);
+            captured.RequestUri!.AbsoluteUri.Should().Be($"https://{Domain}/mfa/associate");
+            captured.Headers.Authorization!.Parameter.Should().Be("mt");
+            capturedBody.Should().Contain("\"authenticator_types\"");
+            capturedBody.Should().Contain("phone_number");
+            capturedBody.Should().Contain("1555");
+            capturedBody.Should().NotContain("\"Token\""); // [JsonIgnore]
+        }
+
+        [Fact]
+        public async Task DeleteMfaAuthenticatorAsync_Deletes_With_BearerHeader()
+        {
+            HttpRequestMessage? captured = null;
+            var handler = Handler(new HttpResponseMessage { StatusCode = HttpStatusCode.NoContent },
+                (r, _) => captured = r);
+            var client = Client(handler);
+
+            await client.DeleteMfaAuthenticatorAsync(new DeleteMfaAuthenticatorRequest
+            {
+                AccessToken = "at", AuthenticatorId = "auth|1"
+            });
+
+            captured!.Method.Should().Be(HttpMethod.Delete);
+            captured.RequestUri!.AbsoluteUri.Should().Be($"https://{Domain}/mfa/authenticators/auth%7C1");
+            captured.Headers.Authorization!.Parameter.Should().Be("at");
+        }
+
+        [Fact]
+        public async Task NonSuccess_Throws_ErrorApiException_With_Details()
+        {
+            var handler = Handler(new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.Forbidden,
+                Content = new StringContent("{\"error\":\"invalid_grant\",\"error_description\":\"Invalid otp_code.\"}")
+            }, (_, _) => { });
+            var client = Client(handler);
+
+            var act = async () => await client.GetTokenAsync(new MfaOtpTokenRequest { MfaToken = Blob("mt"), Otp = "000000" });
+
+            var ex = await act.Should().ThrowAsync<ErrorApiException>();
+            ex.And.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+            ex.And.ApiError!.Error.Should().Be("invalid_grant");
+            ex.And.ApiError.Message.Should().Be("Invalid otp_code.");
+        }
+
+        [Fact]
+        public void Dispose_Disposes_HttpClient_When_Owned()
+        {
+            // When the client owns the HttpClient, Dispose should not throw.
+            var client = new AuthenticationApiClient(new HttpClient(), new Uri($"https://{Domain}"), Options(), Protector);
+            var act = () => client.Dispose();
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public async Task Dispose_DoesNotDispose_HttpClient_When_NotOwned()
+        {
+            var httpClient = new HttpClient(Handler(Ok("{}"), (_, _) => { }).Object);
+            var client = new AuthenticationApiClient(httpClient, new Uri($"https://{Domain}"), Options(), Protector, ownsHttpClient: false);
+
+            client.Dispose();
+
+            // The HttpClient was NOT owned, so it must still be usable after the client is disposed.
+            var act = async () => await httpClient.GetAsync($"https://{Domain}/anything");
+            await act.Should().NotThrowAsync<ObjectDisposedException>();
+        }
+
+        [Fact]
+        public async Task MfaChallengeAsync_Unprotects_Blob_RawTokenOnWire()
+        {
+            string capturedBody = "";
+            var handler = Handler(Ok("{\"challenge_type\":\"oob\",\"oob_code\":\"oc\"}"),
+                (_, b) => { capturedBody = b; });
+            var client = Client(handler);
+
+            await client.MfaChallengeAsync(new MfaChallengeRequest { MfaToken = Blob("raw-mt") });
+
+            capturedBody.Should().Contain("mfa_token=raw-mt");
+            capturedBody.Should().NotContain("CfDJ"); // Data Protection blobs start with this prefix
+        }
+
+        [Fact]
+        public async Task GetTokenAsync_Otp_Unprotects_Blob_And_Sends_BoundAudienceScope()
+        {
+            string capturedBody = "";
+            var handler = Handler(Ok("{\"access_token\":\"at\",\"token_type\":\"Bearer\",\"expires_in\":3600}"),
+                (_, b) => { capturedBody = b; });
+            var client = Client(handler);
+
+            await client.GetTokenAsync(new MfaOtpTokenRequest
+            {
+                MfaToken = Blob("raw-mt", "https://api.example.com", "read:items"),
+                Otp = "123456"
+            });
+
+            capturedBody.Should().Contain("mfa_token=raw-mt");
+            capturedBody.Should().Contain("otp=123456");
+            capturedBody.Should().Contain("audience=https%3A%2F%2Fapi.example.com");
+            capturedBody.Should().Contain("scope=read%3Aitems");
+        }
+
+        [Fact]
+        public async Task GetTokenAsync_Otp_Garbage_Blob_Throws_Invalid_BeforeHttp()
+        {
+            var called = false;
+            var handler = Handler(Ok("{}"), (_, _) => { called = true; });
+            var client = Client(handler);
+
+            Func<Task> act = () => client.GetTokenAsync(new MfaOtpTokenRequest { MfaToken = "garbage", Otp = "1" });
+
+            await act.Should().ThrowAsync<MfaTokenInvalidException>();
+            called.Should().BeFalse();
+        }
+
+        [Fact]
+        public async Task AssociateMfaAuthenticatorAsync_WithBlob_SendsRawTokenAsBearer()
+        {
+            HttpRequestMessage? captured = null;
+            var handler = Handler(Ok("{\"authenticator_type\":\"otp\",\"secret\":\"s\"}"),
+                (r, _) => { captured = r; });
+            var client = Client(handler);
+
+            await client.AssociateMfaAuthenticatorAsync(new AssociateMfaAuthenticatorRequest
+            {
+                Token = Blob("raw-mt"),
+                AuthenticatorTypes = new[] { "otp" }
+            });
+
+            captured!.Headers.Authorization!.Parameter.Should().Be("raw-mt");
+        }
+
+        [Fact]
+        public async Task AssociateMfaAuthenticatorAsync_WithAccessToken_SendsItAsIs()
+        {
+            HttpRequestMessage? captured = null;
+            var handler = Handler(Ok("{\"authenticator_type\":\"otp\",\"secret\":\"s\"}"),
+                (r, _) => { captured = r; });
+            var client = Client(handler);
+
+            await client.AssociateMfaAuthenticatorAsync(new AssociateMfaAuthenticatorRequest
+            {
+                Token = "plain-access-token",
+                AuthenticatorTypes = new[] { "otp" }
+            });
+
+            captured!.Headers.Authorization!.Parameter.Should().Be("plain-access-token");
+        }
+    }
+
+    public class WithAuthenticationApiClientRegistrationTests
+    {
+        [Fact]
+        public void WithAuthenticationApiClient_Registers_Resolvable_Client()
+        {
+            var services = new Microsoft.Extensions.DependencyInjection.ServiceCollection();
+            Microsoft.Extensions.DependencyInjection.DataProtectionServiceCollectionExtensions.AddDataProtection(services);
+            var options = new Auth0WebAppOptions { Domain = "test.auth0.com", ClientId = "cid", ClientSecret = "secret" };
+            var builder = new Auth0WebAppAuthenticationBuilder(services, options);
+
+            builder.WithAuthenticationApiClient();
+
+            var provider = Microsoft.Extensions.DependencyInjection.ServiceCollectionContainerBuilderExtensions.BuildServiceProvider(services);
+            var client = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions
+                .GetService<Auth0.AspNetCore.Authentication.AuthenticationApi.IAuthenticationApiClient>(provider);
+
+            client.Should().NotBeNull();
+            client!.BaseUri.Should().Be(new Uri("https://test.auth0.com"));
+        }
+    }
+}

--- a/tests/Auth0.AspNetCore.Authentication.IntegrationTests/AuthenticationApi/MfaModelSerializationTests.cs
+++ b/tests/Auth0.AspNetCore.Authentication.IntegrationTests/AuthenticationApi/MfaModelSerializationTests.cs
@@ -1,0 +1,86 @@
+using System.Text.Json;
+using Auth0.AspNetCore.Authentication.AuthenticationApi.Models;
+using FluentAssertions;
+using Xunit;
+
+namespace Auth0.AspNetCore.Authentication.IntegrationTests.AuthenticationApi
+{
+    public class MfaModelSerializationTests
+    {
+        [Fact]
+        public void MfaChallengeResponse_Deserializes_WireFields()
+        {
+            var json = "{\"challenge_type\":\"oob\",\"oob_code\":\"abc\",\"binding_method\":\"prompt\"}";
+
+            var result = JsonSerializer.Deserialize<MfaChallengeResponse>(json);
+
+            result.Should().NotBeNull();
+            result!.ChallengeType.Should().Be("oob");
+            result.OobCode.Should().Be("abc");
+            result.BindingMethod.Should().Be("prompt");
+        }
+
+        [Fact]
+        public void MfaOtpTokenResponse_Deserializes_TokenBaseAndExpiresIn()
+        {
+            var json = "{\"access_token\":\"at\",\"token_type\":\"Bearer\",\"expires_in\":86400}";
+
+            var result = JsonSerializer.Deserialize<MfaOtpTokenResponse>(json);
+
+            result!.AccessToken.Should().Be("at");
+            result.TokenType.Should().Be("Bearer");
+            result.ExpiresIn.Should().Be(86400);
+        }
+
+        [Fact]
+        public void MfaOobTokenResponse_Deserializes_ErrorFields()
+        {
+            var json = "{\"error\":\"authorization_pending\",\"error_description\":\"pending\"}";
+
+            var result = JsonSerializer.Deserialize<MfaOobTokenResponse>(json);
+
+            result!.Error.Should().Be("authorization_pending");
+            result.ErrorDescription.Should().Be("pending");
+        }
+
+        [Fact]
+        public void MfaRecoveryCodeResponse_Deserializes_NewRecoveryCode()
+        {
+            var json = "{\"access_token\":\"at\",\"expires_in\":3600,\"recovery_code\":\"NEWCODE\"}";
+
+            var result = JsonSerializer.Deserialize<MfaRecoveryCodeResponse>(json);
+
+            result!.AccessToken.Should().Be("at");
+            result.RecoveryCode.Should().Be("NEWCODE");
+        }
+
+        [Fact]
+        public void AssociateMfaAuthenticatorResponse_Deserializes_WireFields()
+        {
+            var json = "{\"oob_code\":\"oc\",\"binding_method\":\"prompt\",\"authenticator_type\":\"oob\"," +
+                       "\"oob_channel\":\"sms\",\"recovery_codes\":[\"r1\"],\"barcode_uri\":\"uri\",\"secret\":\"s\"}";
+
+            var result = JsonSerializer.Deserialize<AssociateMfaAuthenticatorResponse>(json);
+
+            result!.OobCode.Should().Be("oc");
+            result.AuthenticatorType.Should().Be("oob");
+            result.OobChannel.Should().Be("sms");
+            result.RecoveryCodes.Should().ContainSingle().Which.Should().Be("r1");
+            result.BarcodeUri.Should().Be("uri");
+            result.Secret.Should().Be("s");
+        }
+
+        [Fact]
+        public void Authenticator_Deserializes_WireFields()
+        {
+            var json = "{\"id\":\"auth|1\",\"authenticator_type\":\"otp\",\"oob_channel\":null,\"name\":\"My OTP\",\"active\":true}";
+
+            var result = JsonSerializer.Deserialize<Authenticator>(json);
+
+            result!.Id.Should().Be("auth|1");
+            result.AuthenticatorType.Should().Be("otp");
+            result.Name.Should().Be("My OTP");
+            result.Active.Should().BeTrue();
+        }
+    }
+}

--- a/tests/Auth0.AspNetCore.Authentication.IntegrationTests/AuthenticationApi/MfaRequiredExceptionTests.cs
+++ b/tests/Auth0.AspNetCore.Authentication.IntegrationTests/AuthenticationApi/MfaRequiredExceptionTests.cs
@@ -1,0 +1,37 @@
+using System.Net;
+using Auth0.AspNetCore.Authentication;
+using Auth0.AspNetCore.Authentication.AuthenticationApi.Models;
+using Auth0.AspNetCore.Authentication.Exceptions;
+using FluentAssertions;
+using Xunit;
+
+namespace Auth0.AspNetCore.Authentication.IntegrationTests.AuthenticationApi
+{
+    public class MfaRequiredExceptionTests
+    {
+        [Fact]
+        public void Constructor_WithRequirements_ExposesThem()
+        {
+            var requirements = new MfaRequirements
+            {
+                Challenge = new[] { new MfaChallengeRequirement { Type = "otp" } }
+            };
+
+            var ex = new MfaRequiredException("blob", requirements, HttpStatusCode.Forbidden,
+                new ApiError { Error = "mfa_required" });
+
+            ex.MfaToken.Should().Be("blob");
+            ex.MfaRequirements.Should().BeSameAs(requirements);
+            ex.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+        }
+
+        [Fact]
+        public void Constructor_WithoutRequirements_LeavesThemNull()
+        {
+            var ex = new MfaRequiredException("blob", HttpStatusCode.Forbidden);
+
+            ex.MfaToken.Should().Be("blob");
+            ex.MfaRequirements.Should().BeNull();
+        }
+    }
+}

--- a/tests/Auth0.AspNetCore.Authentication.IntegrationTests/AuthenticationApi/MfaRequirementsSerializationTests.cs
+++ b/tests/Auth0.AspNetCore.Authentication.IntegrationTests/AuthenticationApi/MfaRequirementsSerializationTests.cs
@@ -1,0 +1,36 @@
+using System.Text.Json;
+using Auth0.AspNetCore.Authentication.AuthenticationApi.Models;
+using FluentAssertions;
+using Xunit;
+
+namespace Auth0.AspNetCore.Authentication.IntegrationTests.AuthenticationApi
+{
+    public class MfaRequirementsSerializationTests
+    {
+        [Fact]
+        public void MfaRequirements_Deserializes_ChallengeArray()
+        {
+            var json = "{\"challenge\":[{\"type\":\"otp\"},{\"type\":\"oob\",\"oob_channels\":[\"sms\"],\"authenticator_id\":\"recovery-code|dev_1\"}]}";
+
+            var result = JsonSerializer.Deserialize<MfaRequirements>(json);
+
+            result.Should().NotBeNull();
+            result!.Challenge.Should().HaveCount(2);
+            result.Challenge![0].Type.Should().Be("otp");
+            result.Challenge[1].Type.Should().Be("oob");
+            result.Challenge[1].OobChannels.Should().ContainSingle().Which.Should().Be("sms");
+            result.Challenge[1].AuthenticatorId.Should().Be("recovery-code|dev_1");
+        }
+
+        [Fact]
+        public void MfaRequirements_Ignores_UnknownFields()
+        {
+            var json = "{\"challenge\":[{\"type\":\"otp\",\"future_field\":123}],\"another_unknown\":true}";
+
+            var result = JsonSerializer.Deserialize<MfaRequirements>(json);
+
+            result!.Challenge.Should().ContainSingle();
+            result.Challenge![0].Type.Should().Be("otp");
+        }
+    }
+}

--- a/tests/Auth0.AspNetCore.Authentication.IntegrationTests/AuthenticationApi/MfaTokenExceptionTests.cs
+++ b/tests/Auth0.AspNetCore.Authentication.IntegrationTests/AuthenticationApi/MfaTokenExceptionTests.cs
@@ -1,0 +1,31 @@
+using System.Net;
+using Auth0.AspNetCore.Authentication;
+using Auth0.AspNetCore.Authentication.Exceptions;
+using FluentAssertions;
+using Xunit;
+
+namespace Auth0.AspNetCore.Authentication.IntegrationTests.AuthenticationApi
+{
+    public class MfaTokenExceptionTests
+    {
+        [Fact]
+        public void MfaTokenExpiredException_Is_ErrorApiException_WithApiError()
+        {
+            var ex = new MfaTokenExpiredException();
+
+            ex.Should().BeAssignableTo<ErrorApiException>();
+            ex.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+            ex.ApiError!.Error.Should().Be("mfa_token_expired");
+        }
+
+        [Fact]
+        public void MfaTokenInvalidException_Is_ErrorApiException_WithApiError()
+        {
+            var ex = new MfaTokenInvalidException();
+
+            ex.Should().BeAssignableTo<ErrorApiException>();
+            ex.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+            ex.ApiError!.Error.Should().Be("mfa_token_invalid");
+        }
+    }
+}

--- a/tests/Auth0.AspNetCore.Authentication.IntegrationTests/AuthenticationApi/MfaTokenProtectorTests.cs
+++ b/tests/Auth0.AspNetCore.Authentication.IntegrationTests/AuthenticationApi/MfaTokenProtectorTests.cs
@@ -1,0 +1,97 @@
+using System;
+using Auth0.AspNetCore.Authentication;
+using Auth0.AspNetCore.Authentication.AuthenticationApi;
+using Auth0.AspNetCore.Authentication.AuthenticationApi.Models;
+using FluentAssertions;
+using Microsoft.AspNetCore.DataProtection;
+using Xunit;
+
+namespace Auth0.AspNetCore.Authentication.IntegrationTests.AuthenticationApi
+{
+    public class MfaTokenProtectorTests
+    {
+        private static MfaTokenProtector NewProtector(IDataProtectionProvider? provider = null) =>
+            new MfaTokenProtector(provider ?? new EphemeralDataProtectionProvider());
+
+        private static MfaTokenContext SampleContext() => new MfaTokenContext
+        {
+            MfaToken = "raw-mfa-token",
+            Audience = "https://api.example.com",
+            Scope = "read:items",
+            MfaRequirements = new MfaRequirements(),
+            ExpiresAtUnix = DateTimeOffset.UtcNow.AddMinutes(5).ToUnixTimeSeconds()
+        };
+
+        [Fact]
+        public void Protect_Then_Unprotect_RoundTrips_Context()
+        {
+            var protector = NewProtector();
+
+            var blob = protector.Protect(SampleContext());
+            var recovered = protector.Unprotect(blob);
+
+            blob.Should().NotBe("raw-mfa-token");
+            recovered.MfaToken.Should().Be("raw-mfa-token");
+            recovered.Audience.Should().Be("https://api.example.com");
+            recovered.Scope.Should().Be("read:items");
+        }
+
+        [Fact]
+        public void Protect_SetsFiveMinuteExpiry_WhenNotPreset()
+        {
+            var protector = NewProtector();
+            var ctx = SampleContext();
+            ctx.ExpiresAtUnix = 0; // ask the protector to stamp it
+
+            var before = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+            var blob = protector.Protect(ctx);
+            var recovered = protector.Unprotect(blob);
+
+            recovered.ExpiresAtUnix.Should().BeInRange(before + 290, before + 310);
+        }
+
+        [Fact]
+        public void Unprotect_Tampered_Throws_MfaTokenInvalid()
+        {
+            var protector = NewProtector();
+            var blob = protector.Protect(SampleContext());
+
+            var tampered = blob.Substring(0, blob.Length - 2) + (blob.EndsWith("A") ? "B" : "A");
+
+            Action act = () => protector.Unprotect(tampered);
+            act.Should().Throw<MfaTokenInvalidException>();
+        }
+
+        [Fact]
+        public void Unprotect_Garbage_Throws_MfaTokenInvalid()
+        {
+            var protector = NewProtector();
+
+            Action act = () => protector.Unprotect("not-a-real-blob");
+            act.Should().Throw<MfaTokenInvalidException>();
+        }
+
+        [Fact]
+        public void Unprotect_WrongKey_Throws_MfaTokenInvalid()
+        {
+            var blob = NewProtector().Protect(SampleContext());
+
+            // A different provider => different key ring => MAC fails.
+            Action act = () => NewProtector().Unprotect(blob);
+            act.Should().Throw<MfaTokenInvalidException>();
+        }
+
+        [Fact]
+        public void Unprotect_Expired_Throws_MfaTokenExpired()
+        {
+            var protector = NewProtector();
+            var ctx = SampleContext();
+            ctx.ExpiresAtUnix = DateTimeOffset.UtcNow.AddSeconds(-1).ToUnixTimeSeconds();
+
+            var blob = protector.Protect(ctx);
+
+            Action act = () => protector.Unprotect(blob);
+            act.Should().Throw<MfaTokenExpiredException>();
+        }
+    }
+}

--- a/tests/Auth0.AspNetCore.Authentication.IntegrationTests/HttpContextExtensionsTests.cs
+++ b/tests/Auth0.AspNetCore.Authentication.IntegrationTests/HttpContextExtensionsTests.cs
@@ -14,6 +14,8 @@ using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
+using Auth0.AspNetCore.Authentication.AuthenticationApi;
+using Microsoft.AspNetCore.DataProtection;
 
 namespace Auth0.AspNetCore.Authentication.IntegrationTests
 {
@@ -83,7 +85,7 @@ namespace Auth0.AspNetCore.Authentication.IntegrationTests
             // No refresh token stored.
 
             var missingRefreshTokenFired = false;
-            var context = BuildContext(handler.Object, properties, out _, withAccessTokenOptions =>
+            var context = BuildContext(handler.Object, properties, out _, configureWithAccessToken: withAccessTokenOptions =>
             {
                 withAccessTokenOptions.Events = new Auth0WebAppWithAccessTokenEvents
                 {
@@ -154,7 +156,7 @@ namespace Auth0.AspNetCore.Authentication.IntegrationTests
             properties.Items[".Token.refresh_token"] = "rt";
 
             AccessTokenRefreshFailedContext? captured = null;
-            var context = BuildContext(handler.Object, properties, out _, opts =>
+            var context = BuildContext(handler.Object, properties, out _, configureWithAccessToken: opts =>
             {
                 opts.Events = new Auth0WebAppWithAccessTokenEvents
                 {
@@ -191,7 +193,7 @@ namespace Auth0.AspNetCore.Authentication.IntegrationTests
             properties.Items[".Token.refresh_token"] = "rt";
 
             AccessTokenRefreshFailedContext? captured = null;
-            var context = BuildContext(handler.Object, properties, out var authService, opts =>
+            var context = BuildContext(handler.Object, properties, out var authService, configureWithAccessToken: opts =>
             {
                 opts.Events = new Auth0WebAppWithAccessTokenEvents
                 {
@@ -236,7 +238,7 @@ namespace Auth0.AspNetCore.Authentication.IntegrationTests
             properties.Items[".Token.refresh_token"] = "rt";
 
             AccessTokenRefreshFailedContext? captured = null;
-            var context = BuildContext(handler.Object, properties, out _, opts =>
+            var context = BuildContext(handler.Object, properties, out _, configureWithAccessToken: opts =>
             {
                 opts.Events = new Auth0WebAppWithAccessTokenEvents
                 {
@@ -442,7 +444,7 @@ namespace Auth0.AspNetCore.Authentication.IntegrationTests
             properties.Items[".Token.expires_at"] = DateTimeOffset.Now.AddHours(1).ToString("o");
             properties.Items[".Token.refresh_token"] = "rt";
 
-            var context = BuildContext(handler.Object, properties, out _, opts =>
+            var context = BuildContext(handler.Object, properties, out _, configureWithAccessToken: opts =>
             {
                 opts.ScopeByAudience = new Dictionary<string, string> { ["https://orders"] = "read:orders" };
             });
@@ -455,9 +457,131 @@ namespace Auth0.AspNetCore.Authentication.IntegrationTests
             capturedBody.Should().Contain("scope=read%3Aorders");
         }
 
+        [Fact]
+        public async Task GetAccessTokenAsync_WhenMfaRequired_ThrowsMfaRequiredException_AndDoesNotFireRefreshFailed()
+        {
+            var handler = CreateMfaRequiredHandler();
+            var properties = new AuthenticationProperties();
+            properties.Items[".Token.access_token"] = "cached";
+            properties.Items[".Token.expires_at"] = DateTimeOffset.Now.AddHours(1).ToString("o");
+            properties.Items[".Token.refresh_token"] = "rt";
+
+            var refreshFailedFired = false;
+            var protector = new MfaTokenProtector(new EphemeralDataProtectionProvider());
+            var context = BuildContext(handler.Object, properties, out _, protector, configureWithAccessToken: withAccessTokenOptions =>
+            {
+                withAccessTokenOptions.Events = new Auth0WebAppWithAccessTokenEvents
+                {
+                    OnAccessTokenRefreshFailed = _ => { refreshFailedFired = true; return Task.CompletedTask; }
+                };
+            });
+
+            var act = async () => await context.GetAccessTokenAsync(
+                new AccessTokenRequest { Audience = PrimaryAudience, ForceRefresh = true });
+
+            var ex = await act.Should().ThrowAsync<MfaRequiredException>();
+            ex.And.MfaToken.Should().NotBe("the-mfa-token");
+            ex.And.MfaToken.Should().NotBeNullOrEmpty();
+            protector.Unprotect(ex.And.MfaToken!).MfaToken.Should().Be("the-mfa-token");
+            refreshFailedFired.Should().BeFalse();
+        }
+
+        [Fact]
+        public async Task GetAccessTokenAsync_WhenMfaRequiredWithoutToken_FiresRefreshFailed_AndDoesNotThrow()
+        {
+            // A mfa_required response with no mfa_token is malformed: it cannot drive the MFA
+            // flow, so it must be treated as a refresh failure rather than throwing a
+            // MfaRequiredException carrying an un-unprotectable blob.
+            var handler = new Mock<HttpMessageHandler>();
+            handler
+                .Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+                .ReturnsAsync(new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.Forbidden,
+                    Content = new StringContent("{\"error\":\"mfa_required\",\"error_description\":\"Multifactor authentication required\"}")
+                });
+
+            var properties = new AuthenticationProperties();
+            properties.Items[".Token.access_token"] = "cached";
+            properties.Items[".Token.expires_at"] = DateTimeOffset.Now.AddHours(1).ToString("o");
+            properties.Items[".Token.refresh_token"] = "rt";
+
+            AccessTokenRefreshFailedContext? failedContext = null;
+            var context = BuildContext(handler.Object, properties, out _, configureWithAccessToken: withAccessTokenOptions =>
+            {
+                withAccessTokenOptions.Events = new Auth0WebAppWithAccessTokenEvents
+                {
+                    OnAccessTokenRefreshFailed = c => { failedContext = c; return Task.CompletedTask; }
+                };
+            });
+
+            var result = await context.GetAccessTokenAsync(
+                new AccessTokenRequest { Audience = PrimaryAudience, ForceRefresh = true });
+
+            result.Should().BeNull();
+            failedContext.Should().NotBeNull();
+            failedContext!.Error.Should().Be("mfa_required");
+        }
+
+        [Fact]
+        public async Task GetAccessTokenAsync_WhenOtherError_FiresRefreshFailed_AndDoesNotThrow()
+        {
+            var handler = new Mock<HttpMessageHandler>();
+            handler
+                .Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+                .ReturnsAsync(new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.Forbidden,
+                    Content = new StringContent("{\"error\":\"invalid_grant\",\"error_description\":\"token revoked\"}")
+                });
+
+            var properties = new AuthenticationProperties();
+            properties.Items[".Token.access_token"] = "cached";
+            properties.Items[".Token.expires_at"] = DateTimeOffset.Now.AddHours(1).ToString("o");
+            properties.Items[".Token.refresh_token"] = "rt";
+
+            AccessTokenRefreshFailedContext? failedContext = null;
+            var context = BuildContext(handler.Object, properties, out _, configureWithAccessToken: withAccessTokenOptions =>
+            {
+                withAccessTokenOptions.Events = new Auth0WebAppWithAccessTokenEvents
+                {
+                    OnAccessTokenRefreshFailed = c => { failedContext = c; return Task.CompletedTask; }
+                };
+            });
+
+            var result = await context.GetAccessTokenAsync(
+                new AccessTokenRequest { Audience = PrimaryAudience, ForceRefresh = true });
+
+            result.Should().BeNull();
+            failedContext.Should().NotBeNull();
+            failedContext!.Error.Should().Be("invalid_grant");
+        }
+
         private static string SerializeSets(params AccessTokenSet[] sets)
         {
             return JsonSerializer.Serialize(new List<AccessTokenSet>(sets));
+        }
+
+        private static Mock<HttpMessageHandler> CreateMfaRequiredHandler()
+        {
+            var handler = new Mock<HttpMessageHandler>();
+            handler
+                .Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>())
+                .ReturnsAsync(new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.Forbidden,
+                    Content = new StringContent(
+                        "{\"error\":\"mfa_required\",\"error_description\":\"Multifactor authentication required\",\"mfa_token\":\"the-mfa-token\"}")
+                });
+            return handler;
         }
 
         private static Mock<HttpMessageHandler> CreateFailingHandler(HttpStatusCode statusCode, string body)
@@ -516,6 +640,7 @@ namespace Auth0.AspNetCore.Authentication.IntegrationTests
             HttpMessageHandler backchannelHandler,
             AuthenticationProperties properties,
             out Mock<IAuthenticationService> authService,
+            IMfaTokenProtector? mfaTokenProtector = null,
             Action<Auth0WebAppWithAccessTokenOptions>? configureWithAccessToken = null)
         {
             var webAppOptions = new Auth0WebAppOptions
@@ -554,6 +679,8 @@ namespace Auth0.AspNetCore.Authentication.IntegrationTests
             services.AddSingleton(authService.Object);
             services.AddSingleton(webAppSnapshot.Object);
             services.AddSingleton(withAccessTokenSnapshot.Object);
+            services.AddSingleton<IMfaTokenProtector>(
+                mfaTokenProtector ?? new MfaTokenProtector(new EphemeralDataProtectionProvider()));
 
             return new DefaultHttpContext
             {

--- a/tests/Auth0.AspNetCore.Authentication.IntegrationTests/TokenClientTests.cs
+++ b/tests/Auth0.AspNetCore.Authentication.IntegrationTests/TokenClientTests.cs
@@ -7,6 +7,7 @@ using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
+using Auth0.AspNetCore.Authentication.AuthenticationApi.Models;
 
 namespace Auth0.AspNetCore.Authentication.IntegrationTests
 {
@@ -374,22 +375,75 @@ namespace Auth0.AspNetCore.Authentication.IntegrationTests
         public async Task Refresh_WithEmptyCustomDomain_ThrowsInvalidOperationException()
         {
             var mockHandler = new Mock<HttpMessageHandler>();
-            
+
             var client = new TokenClient(new HttpClient(mockHandler.Object));
-            
+
             Func<Task> act = async () => await client.Refresh(
-                new Auth0WebAppOptions 
-                { 
+                new Auth0WebAppOptions
+                {
                     Domain = "default.auth0.com",
-                    ClientId = "cid", 
-                    ClientSecret = "secret" 
-                }, 
+                    ClientId = "cid",
+                    ClientSecret = "secret"
+                },
                 "refresh_123",
                 string.Empty  // Empty custom domain
             );
 
             await act.Should().ThrowAsync<InvalidOperationException>()
                 .WithMessage("Cannot determine domain for token endpoint*");
+        }
+
+        [Fact]
+        public async Task Returns_Failure_With_MfaToken_When_MfaRequired()
+        {
+            var mockHandler = new Mock<HttpMessageHandler>();
+            mockHandler
+              .Protected()
+                  .Setup<Task<HttpResponseMessage>>(
+                     "SendAsync",
+                     ItExpr.IsAny<HttpRequestMessage>(),
+                     ItExpr.IsAny<CancellationToken>()
+                  )
+                  .ReturnsAsync(new HttpResponseMessage()
+                  {
+                      StatusCode = HttpStatusCode.Forbidden,
+                      Content = new StringContent("{\"error\":\"mfa_required\",\"error_description\":\"Multifactor authentication required\",\"mfa_token\":\"the-mfa-token\"}")
+                  });
+
+            var client = new TokenClient(new HttpClient(mockHandler.Object));
+            var result = await client.Refresh(new Auth0WebAppOptions { Domain = "local.auth0.com", ClientId = "cid", ClientSecret = "secret" }, "123");
+
+            result.IsSuccess.Should().BeFalse();
+            result.Error.Should().Be("mfa_required");
+            result.MfaToken.Should().Be("the-mfa-token");
+        }
+
+        [Fact]
+        public async Task Refresh_WhenMfaRequired_ParsesMfaRequirements()
+        {
+            var body = "{\"error\":\"mfa_required\",\"error_description\":\"Multifactor authentication required\",\"mfa_token\":\"mt\",\"mfa_requirements\":{\"challenge\":[{\"type\":\"otp\"},{\"type\":\"oob\",\"oob_channels\":[\"sms\"]}]}}";
+            var handler = new Mock<HttpMessageHandler>();
+            handler
+                .Protected()
+                .Setup<Task<HttpResponseMessage>>("SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+                .ReturnsAsync(new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.Forbidden,
+                    Content = new StringContent(body)
+                });
+
+            var client = new TokenClient(new HttpClient(handler.Object));
+            var options = new Auth0WebAppOptions { Domain = "test.auth0.com", ClientId = "cid", ClientSecret = "secret" };
+
+            var result = await client.Refresh(options, "rt", "test.auth0.com");
+
+            result.IsSuccess.Should().BeFalse();
+            result.Error.Should().Be("mfa_required");
+            result.MfaToken.Should().Be("mt");
+            result.MfaRequirements.Should().NotBeNull();
+            result.MfaRequirements!.Challenge.Should().HaveCount(2);
+            result.MfaRequirements.Challenge![1].OobChannels.Should().ContainSingle().Which.Should().Be("sms");
         }
     }
 }


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

This PR adds support for handling Multi-Factor Authentication (MFA) challenges that surface during refresh-token exchanges in the Multi-Resource Refresh Token (MRRT) flow.

When a token refresh fails with `mfa_required`, the SDK previously had no way to surface the `mfa_token` and `mfa_requirements` returned by Auth0, nor a way to complete the challenge. This change introduces an end-to-end path to detect, challenge, and verify MFA during token exchange:

- **`TokenClient` failure parsing** — `BuildFailure` now extracts `mfa_token` and best-effort deserializes `mfa_requirements` from the error response, carrying them through `TokenRefreshResult`.
- **`MfaRequiredException`** — thrown when a refresh requires MFA, exposing the requirements so the application can prompt the user.
- **`IAuthenticationApiClient` / `AuthenticationApiClient`** — a new abstraction over the Auth0 Authentication API to trigger MFA challenges, complete MFA grants (OTP, OOB, recovery code), and associate/list/delete authenticators.
- **Secure MFA token handling** — `MfaTokenProtector` encrypts the opaque `mfa_token` (via ASP.NET Core Data Protection) and `MfaTokenContext` enforces a 5-minute lifetime. `MfaTokenExpiredException` / `MfaTokenInvalidException` cover the failure cases.
- **DI registration** — `WithAuthenticationApiClient()` on `Auth0WebAppAuthenticationBuilder` registers the client and its dependencies.

The opaque MFA token is never exposed to the browser in plaintext; it is encrypted at rest and short-lived, with multi-instance deployment guidance documented in `EXAMPLES.md`.

**No breaking changes** — all additions are opt-in.

### References

### Testing

Integration tests were added covering the Authentication API client, MFA model serialization, the MFA token protector, and the new exception types, alongside extended `TokenClient` and `HttpContextExtensions` tests. Existing tests continue to pass.

Manual end-to-end testing: configure a tenant with an MFA-required policy, trigger a refresh-token exchange, confirm `MfaRequiredException` is raised, then complete an OTP/OOB/recovery-code challenge via `IAuthenticationApiClient` and verify a new token set is issued.

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `main`
