### PR TITLE
feat: add claims refresh and OnTokensRefreshed event on token refresh

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -4,6 +4,7 @@
 - [Scopes](#scopes)
 - [Calling an API](#calling-an-api)
   - [Configuring the refresh leeway](#configuring-the-refresh-leeway)
+  - [Updating claims and observing a successful refresh](#updating-claims-and-observing-a-successful-refresh)
 - [Server-side session storage](#server-side-session-storage)
 - [Multi-Resource Refresh Tokens (MRRT)](#multi-resource-refresh-tokens-mrrt)
   - [Requesting a token for another audience](#requesting-a-token-for-another-audience)
@@ -206,6 +207,58 @@ services
 The above snippet checks whether the SDK is configured to use refresh tokens, if there is an existing ID token (meaning the user is authenticated) as well as the absence of a refresh token. If each of these criteria are met, it logs the user out from the application and initializes a new login flow.
 
 > :information_source: In order for Auth0 to redirect back to the application's login URL, ensure to add the configured redirect URL to the application's `Allowed Logout URLs` in Auth0's dashboard.
+
+#### Updating claims and observing a successful refresh
+
+When the SDK refreshes an expired access token, it persists the new tokens but, by default, leaves the `ClaimsPrincipal` untouched — so `User.Claims` keeps serving the login-time snapshot for the lifetime of the refresh token, even though each refresh can return a fresh `id_token` that may carry updated user information.
+
+Two opt-in additions let you react to a refresh:
+
+- **`RebuildPrincipalOnRefresh`** — when `true`, the `ClaimsPrincipal` is rebuilt from the refreshed `id_token` after a successful primary refresh, so `User.Claims` (and `User.Identity.Name`) reflect current user information. Defaults to `false` (today's behavior).
+- **`OnTokensRefreshed`** — a success event that fires after a successful primary refresh, carrying the refreshed `AccessToken`, `IdToken`, `RefreshToken` (null when not rotated), and `ExpiresAt`. It fires independently of `RebuildPrincipalOnRefresh`, and when both are used the event fires *after* the rebuild so it observes the updated principal.
+
+```csharp
+services
+    .AddAuth0WebAppAuthentication(options => {})
+    .WithAccessToken(options =>
+    {
+        options.Audience = Configuration["Auth0:Audience"];
+        options.UseRefreshTokens = true;
+
+        // Rebuild User.Claims from the refreshed id_token.
+        options.RebuildPrincipalOnRefresh = true;
+
+        options.Events = new Auth0WebAppWithAccessTokenEvents
+        {
+            OnTokensRefreshed = (context) =>
+            {
+                // context.AccessToken, context.IdToken, context.RefreshToken, context.ExpiresAt
+                return Task.CompletedTask;
+            }
+        };
+    });
+```
+
+##### Controlling how the refreshed id_token is validated
+
+`RefreshClaimsValidationType` controls how rigorously the refreshed `id_token` is validated before its claims replace the principal. It is only consulted when `RebuildPrincipalOnRefresh` is `true`:
+
+- **`Full`** (default) — validates the refreshed `id_token`'s signature against the cached JWKS, plus issuer/audience and the SDK's business-rule checks. Highest fidelity. The signature check runs only on an actual refresh (when the token expired), not on every request, and the JWKS is cached, so it is inexpensive in the hot path.
+- **`SkipSignature`** — skips signature validation (trusting the back-channel TLS exchange for token authenticity) while still running the SDK's business-rule checks. Lower cost, lower fidelity; an opt-in escape hatch.
+
+```csharp
+    .WithAccessToken(options =>
+    {
+        options.Audience = Configuration["Auth0:Audience"];
+        options.UseRefreshTokens = true;
+        options.RebuildPrincipalOnRefresh = true;
+        options.RefreshClaimsValidationType = RefreshClaimsValidationType.SkipSignature;
+    });
+```
+
+If a refresh succeeds but rebuilding the principal fails (a signature failure in `Full` mode, a malformed `id_token`, or a business-rule failure), the SDK degrades gracefully: the refreshed tokens are kept, the existing (stale) principal is retained, a warning is logged, and `OnTokensRefreshed` still fires — the refresh genuinely succeeded.
+
+> :information_source: Both additions apply only to the primary (login-time) refresh path. Tokens fetched for **additional** audiences via [MRRT](#multi-resource-refresh-tokens-mrrt) do not rebuild the principal or fire `OnTokensRefreshed`.
 
 ## Server-side session storage
 

--- a/src/Auth0.AspNetCore.Authentication/AccessTokenRefreshedContext.cs
+++ b/src/Auth0.AspNetCore.Authentication/AccessTokenRefreshedContext.cs
@@ -1,0 +1,53 @@
+using Microsoft.AspNetCore.Http;
+using System;
+
+namespace Auth0.AspNetCore.Authentication
+{
+    /// <summary>
+    /// Provides the refreshed tokens to subscribers of
+    /// <see cref="Auth0WebAppWithAccessTokenEvents.OnTokensRefreshed"/> after a successful
+    /// primary token refresh. When <see cref="Auth0WebAppWithAccessTokenOptions.RebuildPrincipalOnRefresh"/>
+    /// is enabled, the principal has already been rebuilt by the time this fires.
+    /// </summary>
+    public class AccessTokenRefreshedContext
+    {
+        private AccessTokenRefreshedContext(HttpContext httpContext, string accessToken, string idToken, string? refreshToken, DateTimeOffset expiresAt)
+        {
+            HttpContext = httpContext;
+            AccessToken = accessToken;
+            IdToken = idToken;
+            RefreshToken = refreshToken;
+            ExpiresAt = expiresAt;
+        }
+
+        internal static AccessTokenRefreshedContext Create(HttpContext httpContext, string accessToken, string idToken, string? refreshToken, DateTimeOffset expiresAt) =>
+            new AccessTokenRefreshedContext(httpContext, accessToken, idToken, refreshToken, expiresAt);
+
+        /// <summary>
+        /// The current <see cref="HttpContext"/>, allowing you to resolve services or react to
+        /// the successful refresh.
+        /// </summary>
+        public HttpContext HttpContext { get; }
+
+        /// <summary>
+        /// The refreshed access token.
+        /// </summary>
+        public string AccessToken { get; }
+
+        /// <summary>
+        /// The refreshed ID token.
+        /// </summary>
+        public string IdToken { get; }
+
+        /// <summary>
+        /// The rotated refresh token, when the token endpoint returned a new one;
+        /// <c>null</c> when the refresh token was not rotated.
+        /// </summary>
+        public string? RefreshToken { get; }
+
+        /// <summary>
+        /// The absolute expiry of the refreshed access token.
+        /// </summary>
+        public DateTimeOffset ExpiresAt { get; }
+    }
+}

--- a/src/Auth0.AspNetCore.Authentication/Auth0WebAppWithAccessTokenEvents.cs
+++ b/src/Auth0.AspNetCore.Authentication/Auth0WebAppWithAccessTokenEvents.cs
@@ -87,5 +87,35 @@ namespace Auth0.AspNetCore.Authentication
         /// </code>
         /// </example>
         public Func<AccessTokenRefreshFailedContext, Task>? OnAccessTokenRefreshFailed { get; set; }
+
+        /// <summary>
+        /// Executed after a successful primary token refresh, allowing you to react to the new
+        /// tokens (for example to mirror claims into another store, or invalidate caches). The
+        /// supplied <see cref="AccessTokenRefreshedContext"/> carries the refreshed access, ID,
+        /// and (when rotated) refresh tokens, plus the new expiry. This fires independently of
+        /// <see cref="Auth0WebAppWithAccessTokenOptions.RebuildPrincipalOnRefresh"/>; when that
+        /// option is enabled the principal has already been rebuilt by the time this fires.
+        /// It does not fire on a failed refresh (see <see cref="OnAccessTokenRefreshFailed"/>),
+        /// nor for additional-audience (MRRT) token fetches.
+        /// </summary>
+        /// <example>
+        /// <code>
+        /// services
+        ///   .AddAuth0WebAppAuthentication(options => {})
+        ///   .WithAccessToken(options =>
+        ///   {
+        ///       options.UseRefreshTokens = true;
+        ///       options.Events = new Auth0WebAppWithAccessTokenEvents
+        ///       {
+        ///           OnTokensRefreshed = (context) =>
+        ///           {
+        ///               // React to the refreshed tokens, e.g. log or mirror claims.
+        ///               return Task.CompletedTask;
+        ///           }
+        ///       };
+        ///   });
+        /// </code>
+        /// </example>
+        public Func<AccessTokenRefreshedContext, Task>? OnTokensRefreshed { get; set; }
     }
 }

--- a/src/Auth0.AspNetCore.Authentication/Auth0WebAppWithAccessTokenEvents.cs
+++ b/src/Auth0.AspNetCore.Authentication/Auth0WebAppWithAccessTokenEvents.cs
@@ -97,6 +97,11 @@ namespace Auth0.AspNetCore.Authentication
         /// option is enabled the principal has already been rebuilt by the time this fires.
         /// It does not fire on a failed refresh (see <see cref="OnAccessTokenRefreshFailed"/>),
         /// nor for additional-audience (MRRT) token fetches.
+        /// <para>
+        /// This handler runs inside the cookie middleware's <c>OnValidatePrincipal</c> event, so an
+        /// exception thrown here is not swallowed &#8212; it surfaces into the authentication pipeline
+        /// and fails the current request. Guard any I/O you perform here accordingly.
+        /// </para>
         /// </summary>
         /// <example>
         /// <code>

--- a/src/Auth0.AspNetCore.Authentication/Auth0WebAppWithAccessTokenOptions.cs
+++ b/src/Auth0.AspNetCore.Authentication/Auth0WebAppWithAccessTokenOptions.cs
@@ -39,6 +39,21 @@ namespace Auth0.AspNetCore.Authentication
         public TimeSpan AccessTokenExpirationLeeway { get; set; } = TimeSpan.FromSeconds(60);
 
         /// <summary>
+        /// When <c>true</c>, the <see cref="System.Security.Claims.ClaimsPrincipal"/> is rebuilt
+        /// from the refreshed <c>id_token</c> after a successful primary token refresh, so
+        /// <c>User.Claims</c> reflect current user information. Defaults to <c>false</c>, which
+        /// preserves the historical behavior where claims are never updated on refresh.
+        /// </summary>
+        public bool RebuildPrincipalOnRefresh { get; set; } = false;
+
+        /// <summary>
+        /// Controls how rigorously the refreshed <c>id_token</c> is validated before its claims
+        /// replace the principal. Only consulted when <see cref="RebuildPrincipalOnRefresh"/> is
+        /// <c>true</c>. Defaults to <see cref="RefreshClaimsValidationType.Full"/>.
+        /// </summary>
+        public RefreshClaimsValidationType RefreshClaimsValidationType { get; set; } = RefreshClaimsValidationType.Full;
+
+        /// <summary>
         /// Events allowing you to hook into specific moments in the Auth0 middleware.
         /// </summary>
         public Auth0WebAppWithAccessTokenEvents? Events { get; set; }

--- a/src/Auth0.AspNetCore.Authentication/AuthenticationBuilderExtensions.cs
+++ b/src/Auth0.AspNetCore.Authentication/AuthenticationBuilderExtensions.cs
@@ -215,7 +215,42 @@ namespace Auth0.AspNetCore.Authentication
                                     context.Properties.UpdateTokenValue("refresh_token", result.RefreshToken);
                                 }
                                 context.Properties.UpdateTokenValue("id_token", result.IdToken);
-                                context.Properties.UpdateTokenValue("expires_at", DateTimeOffset.Now.AddSeconds(result.ExpiresIn).ToString("o"));
+                                var newExpiresAt = DateTimeOffset.Now.AddSeconds(result.ExpiresIn);
+                                context.Properties.UpdateTokenValue("expires_at", newExpiresAt.ToString("o"));
+
+                                if (optionsWithAccessToken.RebuildPrincipalOnRefresh && context.Principal != null)
+                                {
+                                    var rebuilt = await PrincipalRefresher.RebuildAsync(
+                                        result.IdToken,
+                                        context.Principal,
+                                        options,
+                                        oidcOptions,
+                                        optionsWithAccessToken.RefreshClaimsValidationType,
+                                        context.Properties.Items,
+                                        context.HttpContext.RequestAborted);
+
+                                    if (rebuilt != null)
+                                    {
+                                        context.ReplacePrincipal(rebuilt);
+                                    }
+                                    else
+                                    {
+                                        var loggerFactory = context.HttpContext.RequestServices.GetService<ILoggerFactory>();
+                                        loggerFactory?.CreateLogger("Auth0").LogWarning(
+                                            "Token refresh succeeded but rebuilding the principal from the refreshed id_token failed; keeping the existing claims.");
+                                    }
+                                }
+
+                                if (optionsWithAccessToken.Events?.OnTokensRefreshed != null)
+                                {
+                                    await optionsWithAccessToken.Events.OnTokensRefreshed(
+                                        AccessTokenRefreshedContext.Create(
+                                            context.HttpContext,
+                                            result.AccessToken,
+                                            result.IdToken,
+                                            string.IsNullOrEmpty(result.RefreshToken) ? null : result.RefreshToken,
+                                            newExpiresAt));
+                                }
                             }
                             else
                             {

--- a/src/Auth0.AspNetCore.Authentication/AuthenticationBuilderExtensions.cs
+++ b/src/Auth0.AspNetCore.Authentication/AuthenticationBuilderExtensions.cs
@@ -227,6 +227,7 @@ namespace Auth0.AspNetCore.Authentication
                                         oidcOptions,
                                         optionsWithAccessToken.RefreshClaimsValidationType,
                                         context.Properties.Items,
+                                        context.HttpContext,
                                         context.HttpContext.RequestAborted);
 
                                     if (rebuilt != null)

--- a/src/Auth0.AspNetCore.Authentication/IdTokenValidator.cs
+++ b/src/Auth0.AspNetCore.Authentication/IdTokenValidator.cs
@@ -12,7 +12,7 @@ namespace Auth0.AspNetCore.Authentication
 {
     internal static class IdTokenValidator
     {
-        public static void Validate(Auth0WebAppOptions auth0Options, JwtSecurityToken token, IDictionary<string, string?>? properties = null)
+        public static void Validate(Auth0WebAppOptions auth0Options, JwtSecurityToken token, IDictionary<string, string?>? properties = null, bool validateAuthTime = true)
         {
             var organization = properties != null && properties.ContainsKey(Auth0AuthenticationParameters.Organization) ? properties[Auth0AuthenticationParameters.Organization] : null;
 
@@ -59,7 +59,7 @@ namespace Auth0.AspNetCore.Authentication
                 }
             }
 
-            if (auth0Options.MaxAge.HasValue)
+            if (validateAuthTime && auth0Options.MaxAge.HasValue)
             {
                 var authTimeRaw = token.Claims.SingleOrDefault(claim => claim.Type == JwtRegisteredClaimNames.AuthTime)?.Value;
                 long? authTime = !string.IsNullOrWhiteSpace(authTimeRaw) ? (long?)Convert.ToDouble(authTimeRaw, CultureInfo.InvariantCulture) : null;

--- a/src/Auth0.AspNetCore.Authentication/PrincipalRefresher.cs
+++ b/src/Auth0.AspNetCore.Authentication/PrincipalRefresher.cs
@@ -1,0 +1,93 @@
+using Microsoft.AspNetCore.Authentication.OpenIdConnect;
+using Microsoft.IdentityModel.Tokens;
+using System;
+using System.Collections.Generic;
+using System.IdentityModel.Tokens.Jwt;
+using System.Linq;
+using System.Security.Claims;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Auth0.AspNetCore.Authentication
+{
+    internal static class PrincipalRefresher
+    {
+        /// <summary>
+        /// Rebuilds a <see cref="ClaimsPrincipal"/> from the refreshed <paramref name="idToken"/>,
+        /// mirroring the login-time claim mapping. Returns <c>null</c> if the token is malformed,
+        /// fails signature/issuer/audience validation (Full mode), or fails the SDK's
+        /// business-rule checks; the caller then keeps the existing principal.
+        /// </summary>
+        public static async Task<ClaimsPrincipal?> RebuildAsync(
+            string idToken,
+            ClaimsPrincipal currentPrincipal,
+            Auth0WebAppOptions options,
+            OpenIdConnectOptions oidcOptions,
+            RefreshClaimsValidationType validationType,
+            IDictionary<string, string?>? properties,
+            CancellationToken cancellationToken)
+        {
+            var handler = new JwtSecurityTokenHandler();
+            if (string.IsNullOrEmpty(idToken) || !handler.CanReadToken(idToken))
+            {
+                return null;
+            }
+
+            try
+            {
+                ClaimsPrincipal principal;
+
+                if (validationType == RefreshClaimsValidationType.Full)
+                {
+                    var configuration = oidcOptions.ConfigurationManager != null
+                        ? await oidcOptions.ConfigurationManager.GetConfigurationAsync(cancellationToken)
+                        : null;
+
+                    var tokenValidationParameters = new TokenValidationParameters
+                    {
+                        ValidateAudience = true,
+                        ValidateIssuer = true,
+                        ValidateLifetime = true,
+                        RequireExpirationTime = true,
+                        ValidIssuer = oidcOptions.TokenValidationParameters.ValidIssuer,
+                        ValidAudience = oidcOptions.TokenValidationParameters.ValidAudience,
+                        NameClaimType = oidcOptions.TokenValidationParameters.NameClaimType,
+                        RoleClaimType = oidcOptions.TokenValidationParameters.RoleClaimType,
+                    };
+
+                    if (configuration != null)
+                    {
+                        tokenValidationParameters.IssuerSigningKeys =
+                            oidcOptions.TokenValidationParameters.IssuerSigningKeys?.Concat(configuration.SigningKeys)
+                            ?? configuration.SigningKeys;
+                    }
+
+                    principal = oidcOptions.SecurityTokenValidator.ValidateToken(idToken, tokenValidationParameters, out _);
+                }
+                else
+                {
+                    // SkipSignature: parse the token and project its claims onto a fresh identity
+                    // that mirrors the login-time name/role mapping, without verifying the signature.
+                    var jwt = handler.ReadJwtToken(idToken);
+                    var identity = new ClaimsIdentity(
+                        jwt.Claims,
+                        currentPrincipal.Identity?.AuthenticationType,
+                        oidcOptions.TokenValidationParameters.NameClaimType,
+                        oidcOptions.TokenValidationParameters.RoleClaimType);
+                    principal = new ClaimsPrincipal(identity);
+                }
+
+                // Both modes run the SDK's business-rule checks (sub, iat, azp, org, auth_time).
+                // Passing the auth properties re-applies the login-time organization constraint.
+                IdTokenValidator.Validate(options, handler.ReadJwtToken(idToken), properties);
+
+                return principal;
+            }
+            catch (Exception)
+            {
+                // Any validation/parse failure degrades gracefully: caller keeps the stale principal.
+                return null;
+            }
+        }
+    }
+}

--- a/src/Auth0.AspNetCore.Authentication/PrincipalRefresher.cs
+++ b/src/Auth0.AspNetCore.Authentication/PrincipalRefresher.cs
@@ -1,6 +1,6 @@
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
+using Microsoft.AspNetCore.Http;
 using Microsoft.IdentityModel.Tokens;
-using System;
 using System.Collections.Generic;
 using System.IdentityModel.Tokens.Jwt;
 using System.Linq;
@@ -25,6 +25,7 @@ namespace Auth0.AspNetCore.Authentication
             OpenIdConnectOptions oidcOptions,
             RefreshClaimsValidationType validationType,
             IDictionary<string, string?>? properties,
+            HttpContext httpContext,
             CancellationToken cancellationToken)
         {
             var handler = new JwtSecurityTokenHandler();
@@ -35,55 +36,71 @@ namespace Auth0.AspNetCore.Authentication
 
             try
             {
-                ClaimsPrincipal principal;
+                var configuration = oidcOptions.ConfigurationManager != null
+                    ? await oidcOptions.ConfigurationManager.GetConfigurationAsync(cancellationToken)
+                    : null;
 
-                if (validationType == RefreshClaimsValidationType.Full)
+                // In multiple-custom-domains mode the SDK disables static issuer validation
+                // (ValidateIssuer = false) because the real issuer is the per-request resolved
+                // domain. Resolve it the same way the rest of the SDK does (prefer the token's
+                // own issuer, then the domain resolved for this request) so issuer validation
+                // still holds instead of failing against the static ValidIssuer.
+                var validateIssuer = oidcOptions.TokenValidationParameters.ValidateIssuer;
+                var validIssuer = oidcOptions.TokenValidationParameters.ValidIssuer;
+
+                if (!validateIssuer)
                 {
-                    var configuration = oidcOptions.ConfigurationManager != null
-                        ? await oidcOptions.ConfigurationManager.GetConfigurationAsync(cancellationToken)
-                        : null;
+                    var resolvedIssuer = currentPrincipal.FindFirst("iss")?.Value
+                        ?? httpContext.GetResolvedDomain();
 
-                    var tokenValidationParameters = new TokenValidationParameters
+                    if (!string.IsNullOrWhiteSpace(resolvedIssuer))
                     {
-                        ValidateAudience = true,
-                        ValidateIssuer = true,
-                        ValidateLifetime = true,
-                        RequireExpirationTime = true,
-                        ValidIssuer = oidcOptions.TokenValidationParameters.ValidIssuer,
-                        ValidAudience = oidcOptions.TokenValidationParameters.ValidAudience,
-                        NameClaimType = oidcOptions.TokenValidationParameters.NameClaimType,
-                        RoleClaimType = oidcOptions.TokenValidationParameters.RoleClaimType,
-                    };
-
-                    if (configuration != null)
-                    {
-                        tokenValidationParameters.IssuerSigningKeys =
-                            oidcOptions.TokenValidationParameters.IssuerSigningKeys?.Concat(configuration.SigningKeys)
-                            ?? configuration.SigningKeys;
+                        validIssuer = Utils.ToAuthority(resolvedIssuer);
+                        validateIssuer = true;
                     }
-
-                    principal = oidcOptions.SecurityTokenValidator.ValidateToken(idToken, tokenValidationParameters, out _);
                 }
-                else
+
+                var tokenValidationParameters = new TokenValidationParameters
                 {
-                    // SkipSignature: parse the token and project its claims onto a fresh identity
-                    // that mirrors the login-time name/role mapping, without verifying the signature.
-                    var jwt = handler.ReadJwtToken(idToken);
-                    var identity = new ClaimsIdentity(
-                        jwt.Claims,
-                        currentPrincipal.Identity?.AuthenticationType,
-                        oidcOptions.TokenValidationParameters.NameClaimType,
-                        oidcOptions.TokenValidationParameters.RoleClaimType);
-                    principal = new ClaimsPrincipal(identity);
+                    ValidateAudience = true,
+                    ValidateIssuer = validateIssuer,
+                    ValidateLifetime = true,
+                    RequireExpirationTime = true,
+                    ValidIssuer = validIssuer,
+                    ValidAudience = oidcOptions.TokenValidationParameters.ValidAudience,
+                    NameClaimType = oidcOptions.TokenValidationParameters.NameClaimType,
+                    RoleClaimType = oidcOptions.TokenValidationParameters.RoleClaimType,
+                };
+
+                if (configuration != null)
+                {
+                    tokenValidationParameters.IssuerSigningKeys =
+                        oidcOptions.TokenValidationParameters.IssuerSigningKeys?.Concat(configuration.SigningKeys)
+                        ?? configuration.SigningKeys;
                 }
 
-                // Both modes run the SDK's business-rule checks (sub, iat, azp, org, auth_time).
+                if (validationType == RefreshClaimsValidationType.SkipSignature)
+                {
+                    // SkipSignature trusts the back-channel TLS exchange with the token endpoint,
+                    // so we bypass signature verification. We still run the token through the same
+                    // SecurityTokenValidator as Full mode so the inbound claim-type mapping matches
+                    // the login path (e.g. ClaimTypes.NameIdentifier vs the short "sub" name).
+                    tokenValidationParameters.RequireSignedTokens = false;
+                    tokenValidationParameters.SignatureValidator = (token, _) => new JwtSecurityToken(token);
+                }
+
+                var principal = oidcOptions.SecurityTokenValidator.ValidateToken(idToken, tokenValidationParameters, out _);
+
+                // Both modes run the SDK's business-rule checks (sub, iat, azp, org). The
+                // auth_time/MaxAge check is deliberately skipped: a refresh grant does not
+                // re-authenticate the user, so auth_time never advances and enforcing MaxAge
+                // here would make every refresh fail once the login-freshness window elapses.
                 // Passing the auth properties re-applies the login-time organization constraint.
-                IdTokenValidator.Validate(options, handler.ReadJwtToken(idToken), properties);
+                IdTokenValidator.Validate(options, handler.ReadJwtToken(idToken), properties, validateAuthTime: false);
 
                 return principal;
             }
-            catch (Exception)
+            catch (System.Exception)
             {
                 // Any validation/parse failure degrades gracefully: caller keeps the stale principal.
                 return null;

--- a/src/Auth0.AspNetCore.Authentication/RefreshClaimsValidationType.cs
+++ b/src/Auth0.AspNetCore.Authentication/RefreshClaimsValidationType.cs
@@ -1,0 +1,24 @@
+namespace Auth0.AspNetCore.Authentication
+{
+    /// <summary>
+    /// Controls how rigorously the refreshed <c>id_token</c> is validated before its claims
+    /// replace the <see cref="System.Security.Claims.ClaimsPrincipal"/> when
+    /// <see cref="Auth0WebAppWithAccessTokenOptions.RebuildPrincipalOnRefresh"/> is enabled.
+    /// </summary>
+    public enum RefreshClaimsValidationType
+    {
+        /// <summary>
+        /// Validate the refreshed <c>id_token</c> signature against the cached JWKS, plus
+        /// issuer/audience and the SDK's business-rule checks (sub, iat, azp, org, auth_time).
+        /// This is the default and the safe choice.
+        /// </summary>
+        Full,
+
+        /// <summary>
+        /// Skip signature validation (trusting the back-channel TLS exchange with the token
+        /// endpoint), while still running the SDK's business-rule checks. Lower cost and lower
+        /// fidelity than <see cref="Full"/>.
+        /// </summary>
+        SkipSignature
+    }
+}

--- a/src/Auth0.AspNetCore.Authentication/RefreshClaimsValidationType.cs
+++ b/src/Auth0.AspNetCore.Authentication/RefreshClaimsValidationType.cs
@@ -9,15 +9,19 @@ namespace Auth0.AspNetCore.Authentication
     {
         /// <summary>
         /// Validate the refreshed <c>id_token</c> signature against the cached JWKS, plus
-        /// issuer/audience and the SDK's business-rule checks (sub, iat, azp, org, auth_time).
-        /// This is the default and the safe choice.
+        /// issuer, audience and lifetime, and the SDK's business-rule checks (sub, iat, azp, org).
+        /// The <c>auth_time</c>/<c>MaxAge</c> login-freshness check is intentionally not applied
+        /// on refresh, since a refresh grant does not re-authenticate the user. This is the
+        /// default and the safe choice.
         /// </summary>
         Full,
 
         /// <summary>
-        /// Skip signature validation (trusting the back-channel TLS exchange with the token
-        /// endpoint), while still running the SDK's business-rule checks. Lower cost and lower
-        /// fidelity than <see cref="Full"/>.
+        /// Skip <b>only</b> the cryptographic signature check (trusting the back-channel TLS
+        /// exchange with the token endpoint). Issuer, audience and lifetime are still validated,
+        /// and the SDK's business-rule checks (sub, iat, azp, org) still run, so the resulting
+        /// claims are mapped identically to <see cref="Full"/>. Lower cost and lower fidelity
+        /// than <see cref="Full"/>.
         /// </summary>
         SkipSignature
     }

--- a/tests/Auth0.AspNetCore.Authentication.IntegrationTests/ClaimsRefreshTests.cs
+++ b/tests/Auth0.AspNetCore.Authentication.IntegrationTests/ClaimsRefreshTests.cs
@@ -1,0 +1,235 @@
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Auth0.AspNetCore.Authentication.IntegrationTests.Builders;
+using Auth0.AspNetCore.Authentication.IntegrationTests.Extensions;
+using Auth0.AspNetCore.Authentication.IntegrationTests.Infrastructure;
+using Auth0.AspNetCore.Authentication.IntegrationTests.Utils;
+using Xunit;
+
+namespace Auth0.AspNetCore.Authentication.IntegrationTests
+{
+    public class ClaimsRefreshTests
+    {
+        private readonly IConfiguration _configuration = TestConfiguration.GetConfiguration();
+
+        /// <summary>
+        /// Logs in (issuing an id_token with <paramref name="loginName"/>), then issues a
+        /// /process request that forces a refresh. The refresh grant returns an id_token with
+        /// <paramref name="refreshName"/>. Returns the parsed /process JSON ({ RefreshToken, Name }).
+        /// A 120s leeway against a 70s token guarantees the refresh fires on the /process call.
+        /// </summary>
+        private async Task<JObject> RunRefreshAsync(
+            string loginName,
+            string refreshName,
+            Action<Auth0WebAppWithAccessTokenOptions> configureAccessToken,
+            HttpStatusCode refreshStatus = HttpStatusCode.OK,
+            bool tamperRefreshSignature = false,
+            string organization = null,
+            string loginOrgId = null,
+            string refreshOrgId = null)
+        {
+            var nonce = "";
+            var domain = _configuration["Auth0:Domain"];
+            var clientId = _configuration["Auth0:ClientId"];
+
+            var mockHandler = new OidcMockBuilder()
+                .MockOpenIdConfig()
+                .MockJwks()
+                .MockToken(
+                    () => JwtUtils.GenerateToken(1, $"https://{domain}/", clientId, loginOrgId, nonce, DateTime.UtcNow.AddSeconds(70), loginName),
+                    (me) => me.HasGrantType("authorization_code"))
+                .MockToken(
+                    () => tamperRefreshSignature
+                        ? JwtUtils.GenerateToken(1, $"https://{domain}/", clientId, refreshOrgId, null, DateTime.UtcNow.AddSeconds(70), refreshName) + "tampered"
+                        : JwtUtils.GenerateToken(1, $"https://{domain}/", clientId, refreshOrgId, null, DateTime.UtcNow.AddSeconds(70), refreshName),
+                    (me) => me.HasGrantType("refresh_token"), 70, true, refreshStatus, "456_ROTATED")
+                .Build();
+
+            using var server = TestServerBuilder.CreateServer(opts =>
+            {
+                opts.ClientSecret = "123";
+                opts.Backchannel = new HttpClient(mockHandler.Object);
+                if (organization != null)
+                {
+                    opts.Organization = organization;
+                }
+            }, opts =>
+            {
+                opts.Audience = "123";
+                opts.UseRefreshTokens = true;
+                opts.AccessTokenExpirationLeeway = TimeSpan.FromSeconds(120);
+                configureAccessToken(opts);
+            });
+
+            using var client = server.CreateClient();
+
+            var loginResponse = await client.SendAsync($"{TestServerBuilder.Host}/{TestServerBuilder.Login}");
+            var setCookie = Assert.Single(loginResponse.Headers, h => h.Key == "Set-Cookie");
+            var queryParameters = UriUtils.GetQueryParams(loginResponse.Headers.Location);
+            nonce = queryParameters["nonce"];
+            var state = queryParameters["state"];
+
+            var message = new HttpRequestMessage(HttpMethod.Get, $"{TestServerBuilder.Host}/{TestServerBuilder.Callback}?state={state}&nonce={nonce}&code=123");
+            var callbackResponse = await client.SendAsync(message, setCookie.Value);
+            callbackResponse.Headers.Location.OriginalString.Should().Be("/");
+
+            var response = await client.SendAsync($"{TestServerBuilder.Host}/{TestServerBuilder.Process}", callbackResponse.Headers.GetValues("Set-Cookie"));
+            return JObject.Parse(await response.Content.ReadAsStringAsync());
+        }
+
+        [Fact]
+        public async Task Should_Rebuild_Principal_With_Full_Validation_When_Enabled()
+        {
+            var content = await RunRefreshAsync(
+                loginName: "Old Name",
+                refreshName: "New Name",
+                configureAccessToken: opts =>
+                {
+                    opts.RebuildPrincipalOnRefresh = true;
+                    opts.RefreshClaimsValidationType = RefreshClaimsValidationType.Full;
+                });
+
+            content.GetValue("Name").Value<string>().Should().Be("New Name");
+        }
+
+        [Fact]
+        public async Task Should_Not_Rebuild_Principal_When_Flag_Off()
+        {
+            var content = await RunRefreshAsync(
+                loginName: "Old Name",
+                refreshName: "New Name",
+                configureAccessToken: opts =>
+                {
+                    // RebuildPrincipalOnRefresh defaults to false; do not set it.
+                });
+
+            content.GetValue("RefreshToken").Value<string>().Should().Be("456_ROTATED");
+            content.GetValue("Name").Value<string>().Should().Be("Old Name");
+        }
+
+        [Fact]
+        public async Task Should_Rebuild_Principal_In_SkipSignature_Mode_Despite_Bad_Signature()
+        {
+            var content = await RunRefreshAsync(
+                loginName: "Old Name",
+                refreshName: "New Name",
+                configureAccessToken: opts =>
+                {
+                    opts.RebuildPrincipalOnRefresh = true;
+                    opts.RefreshClaimsValidationType = RefreshClaimsValidationType.SkipSignature;
+                },
+                tamperRefreshSignature: true);
+
+            content.GetValue("Name").Value<string>().Should().Be("New Name");
+        }
+
+        [Fact]
+        public async Task Should_Keep_Stale_Principal_When_Full_Validation_Fails()
+        {
+            // A rebuild failure must still fire OnTokensRefreshed: the refresh genuinely
+            // succeeded (tokens are valid), only the principal rebuild was rejected.
+            var eventFired = false;
+
+            var content = await RunRefreshAsync(
+                loginName: "Old Name",
+                refreshName: "New Name",
+                configureAccessToken: opts =>
+                {
+                    opts.RebuildPrincipalOnRefresh = true;
+                    opts.RefreshClaimsValidationType = RefreshClaimsValidationType.Full;
+                    opts.Events = new Auth0WebAppWithAccessTokenEvents
+                    {
+                        OnTokensRefreshed = (context) =>
+                        {
+                            eventFired = true;
+                            return Task.CompletedTask;
+                        }
+                    };
+                },
+                tamperRefreshSignature: true);
+
+            content.GetValue("RefreshToken").Value<string>().Should().Be("456_ROTATED");
+            content.GetValue("Name").Value<string>().Should().Be("Old Name");
+            eventFired.Should().BeTrue();
+        }
+
+        [Fact]
+        public async Task Should_Keep_Stale_Principal_When_Refreshed_Token_Has_Mismatched_Organization()
+        {
+            // Login under org_123; the refresh grant returns an id_token for org_456.
+            // The login-time organization constraint must be re-applied on refresh, so the
+            // rebuild fails its business-rule check, the stale principal is kept, and the
+            // refreshed tokens are still persisted.
+            var content = await RunRefreshAsync(
+                loginName: "Old Name",
+                refreshName: "New Name",
+                configureAccessToken: opts =>
+                {
+                    opts.RebuildPrincipalOnRefresh = true;
+                    opts.RefreshClaimsValidationType = RefreshClaimsValidationType.SkipSignature;
+                },
+                organization: "org_123",
+                loginOrgId: "org_123",
+                refreshOrgId: "org_456");
+
+            content.GetValue("RefreshToken").Value<string>().Should().Be("456_ROTATED");
+            content.GetValue("Name").Value<string>().Should().Be("Old Name");
+        }
+
+        [Fact]
+        public async Task Should_Fire_OnTokensRefreshed_On_Success_Independent_Of_Flag()
+        {
+            AccessTokenRefreshedContext captured = null;
+
+            await RunRefreshAsync(
+                loginName: "Old Name",
+                refreshName: "New Name",
+                configureAccessToken: opts =>
+                {
+                    opts.Events = new Auth0WebAppWithAccessTokenEvents
+                    {
+                        OnTokensRefreshed = (context) =>
+                        {
+                            captured = context;
+                            return Task.CompletedTask;
+                        }
+                    };
+                });
+
+            captured.Should().NotBeNull();
+            captured.RefreshToken.Should().Be("456_ROTATED");
+            captured.AccessToken.Should().NotBeNullOrEmpty();
+            captured.IdToken.Should().NotBeNullOrEmpty();
+            captured.ExpiresAt.Should().BeAfter(DateTimeOffset.Now);
+        }
+
+        [Fact]
+        public async Task Should_Not_Fire_OnTokensRefreshed_When_Refresh_Fails()
+        {
+            var fired = false;
+
+            await RunRefreshAsync(
+                loginName: "Old Name",
+                refreshName: "New Name",
+                configureAccessToken: opts =>
+                {
+                    opts.Events = new Auth0WebAppWithAccessTokenEvents
+                    {
+                        OnTokensRefreshed = (context) =>
+                        {
+                            fired = true;
+                            return Task.CompletedTask;
+                        }
+                    };
+                },
+                refreshStatus: HttpStatusCode.BadRequest);
+
+            fired.Should().BeFalse();
+        }
+    }
+}

--- a/tests/Auth0.AspNetCore.Authentication.IntegrationTests/ClaimsRefreshTests.cs
+++ b/tests/Auth0.AspNetCore.Authentication.IntegrationTests/ClaimsRefreshTests.cs
@@ -31,7 +31,10 @@ namespace Auth0.AspNetCore.Authentication.IntegrationTests
             bool tamperRefreshSignature = false,
             string organization = null,
             string loginOrgId = null,
-            string refreshOrgId = null)
+            string refreshOrgId = null,
+            TimeSpan? maxAge = null,
+            DateTime? loginAuthTime = null,
+            DateTime? refreshAuthTime = null)
         {
             var nonce = "";
             var domain = _configuration["Auth0:Domain"];
@@ -41,12 +44,12 @@ namespace Auth0.AspNetCore.Authentication.IntegrationTests
                 .MockOpenIdConfig()
                 .MockJwks()
                 .MockToken(
-                    () => JwtUtils.GenerateToken(1, $"https://{domain}/", clientId, loginOrgId, nonce, DateTime.UtcNow.AddSeconds(70), loginName),
+                    () => JwtUtils.GenerateToken(1, $"https://{domain}/", clientId, loginOrgId, nonce, DateTime.UtcNow.AddSeconds(70), loginName, loginAuthTime),
                     (me) => me.HasGrantType("authorization_code"))
                 .MockToken(
                     () => tamperRefreshSignature
-                        ? JwtUtils.GenerateToken(1, $"https://{domain}/", clientId, refreshOrgId, null, DateTime.UtcNow.AddSeconds(70), refreshName) + "tampered"
-                        : JwtUtils.GenerateToken(1, $"https://{domain}/", clientId, refreshOrgId, null, DateTime.UtcNow.AddSeconds(70), refreshName),
+                        ? JwtUtils.GenerateToken(1, $"https://{domain}/", clientId, refreshOrgId, null, DateTime.UtcNow.AddSeconds(70), refreshName, refreshAuthTime) + "tampered"
+                        : JwtUtils.GenerateToken(1, $"https://{domain}/", clientId, refreshOrgId, null, DateTime.UtcNow.AddSeconds(70), refreshName, refreshAuthTime),
                     (me) => me.HasGrantType("refresh_token"), 70, true, refreshStatus, "456_ROTATED")
                 .Build();
 
@@ -57,6 +60,10 @@ namespace Auth0.AspNetCore.Authentication.IntegrationTests
                 if (organization != null)
                 {
                     opts.Organization = organization;
+                }
+                if (maxAge != null)
+                {
+                    opts.MaxAge = maxAge;
                 }
             }, opts =>
             {
@@ -206,6 +213,47 @@ namespace Auth0.AspNetCore.Authentication.IntegrationTests
             captured.AccessToken.Should().NotBeNullOrEmpty();
             captured.IdToken.Should().NotBeNullOrEmpty();
             captured.ExpiresAt.Should().BeAfter(DateTimeOffset.Now);
+        }
+
+        [Fact]
+        public async Task Should_Rebuild_Principal_On_Refresh_Even_When_MaxAge_Window_Has_Elapsed()
+        {
+            // A refresh grant does not re-authenticate, so auth_time stays at the original login
+            // time. With MaxAge set, that time is already outside the freshness window by the time
+            // the refresh fires. The auth_time/MaxAge check is a login-freshness rule, not a claims
+            // rule, so it must not block the rebuild on the refresh path.
+            var content = await RunRefreshAsync(
+                loginName: "Old Name",
+                refreshName: "New Name",
+                configureAccessToken: opts =>
+                {
+                    opts.RebuildPrincipalOnRefresh = true;
+                    opts.RefreshClaimsValidationType = RefreshClaimsValidationType.Full;
+                },
+                maxAge: TimeSpan.FromSeconds(30),
+                loginAuthTime: DateTime.UtcNow,
+                refreshAuthTime: DateTime.UtcNow.AddSeconds(-300));
+
+            content.GetValue("Name").Value<string>().Should().Be("New Name");
+        }
+
+        [Fact]
+        public async Task Should_Map_Claim_Types_Consistently_In_SkipSignature_Mode()
+        {
+            // SkipSignature must run the refreshed token through the same validator as Full so the
+            // inbound claim-type mapping matches the login path. NameIdentifier is the mapped form
+            // of "sub"; if SkipSignature projected raw JWT claims it would be missing here.
+            var content = await RunRefreshAsync(
+                loginName: "Old Name",
+                refreshName: "New Name",
+                configureAccessToken: opts =>
+                {
+                    opts.RebuildPrincipalOnRefresh = true;
+                    opts.RefreshClaimsValidationType = RefreshClaimsValidationType.SkipSignature;
+                });
+
+            content.GetValue("Name").Value<string>().Should().Be("New Name");
+            content.GetValue("NameIdentifier").Value<string>().Should().Be("1");
         }
 
         [Fact]

--- a/tests/Auth0.AspNetCore.Authentication.IntegrationTests/Infrastructure/TestServerBuilder.cs
+++ b/tests/Auth0.AspNetCore.Authentication.IntegrationTests/Infrastructure/TestServerBuilder.cs
@@ -63,7 +63,8 @@ namespace Auth0.AspNetCore.Authentication.IntegrationTests.Infrastructure
                                     var ticket = await context.AuthenticateAsync(cookieScheme);
                                     await res.WriteAsync(JsonSerializer.Serialize(new
                                     {
-                                        RefreshToken = await context.GetTokenAsync(cookieScheme, "refresh_token")
+                                        RefreshToken = await context.GetTokenAsync(cookieScheme, "refresh_token"),
+                                        Name = ticket.Principal?.FindFirst("name")?.Value
                                     }));
                                 }
                                 else

--- a/tests/Auth0.AspNetCore.Authentication.IntegrationTests/Infrastructure/TestServerBuilder.cs
+++ b/tests/Auth0.AspNetCore.Authentication.IntegrationTests/Infrastructure/TestServerBuilder.cs
@@ -64,7 +64,8 @@ namespace Auth0.AspNetCore.Authentication.IntegrationTests.Infrastructure
                                     await res.WriteAsync(JsonSerializer.Serialize(new
                                     {
                                         RefreshToken = await context.GetTokenAsync(cookieScheme, "refresh_token"),
-                                        Name = ticket.Principal?.FindFirst("name")?.Value
+                                        Name = ticket.Principal?.FindFirst("name")?.Value,
+                                        NameIdentifier = ticket.Principal?.FindFirst(System.Security.Claims.ClaimTypes.NameIdentifier)?.Value
                                     }));
                                 }
                                 else

--- a/tests/Auth0.AspNetCore.Authentication.IntegrationTests/PrincipalRefresherTests.cs
+++ b/tests/Auth0.AspNetCore.Authentication.IntegrationTests/PrincipalRefresherTests.cs
@@ -1,0 +1,134 @@
+using System;
+using System.Collections.Generic;
+using System.IdentityModel.Tokens.Jwt;
+using System.IO;
+using System.Security.Claims;
+using System.Threading;
+using System.Threading.Tasks;
+using Auth0.AspNetCore.Authentication.IntegrationTests.Utils;
+using FluentAssertions;
+using Microsoft.AspNetCore.Authentication.OpenIdConnect;
+using Microsoft.AspNetCore.Http;
+using Microsoft.IdentityModel.Protocols;
+using Microsoft.IdentityModel.Protocols.OpenIdConnect;
+using Microsoft.IdentityModel.Tokens;
+using Xunit;
+
+namespace Auth0.AspNetCore.Authentication.IntegrationTests
+{
+    public class PrincipalRefresherTests
+    {
+        private const string ClientId = "123";
+
+        private static JsonWebKeySet LoadKeys()
+        {
+            var resourceName = "Auth0.AspNetCore.Authentication.IntegrationTests.jwks.json";
+            using var stream = typeof(Startup).Assembly.GetManifestResourceStream(resourceName);
+            using var reader = new StreamReader(stream!);
+            return new JsonWebKeySet(reader.ReadToEnd());
+        }
+
+        /// <summary>
+        /// Builds OpenIdConnectOptions that mirror how the SDK configures multiple-custom-domains
+        /// mode: issuer validation is disabled (ValidateIssuer = false) because the real issuer is
+        /// the per-request resolved domain, and ValidIssuer still points at the static primary
+        /// domain. The signing keys are supplied directly so no ConfigurationManager is needed.
+        /// </summary>
+        private static OpenIdConnectOptions BuildMcdOidcOptions()
+        {
+            var keys = LoadKeys();
+
+            // The SDK sources signing keys from the ConfigurationManager on the refresh path, so
+            // provide a static one holding the test JWKS (mirrors production, where MCD always has
+            // a ConfigurationManager configured).
+            var configuration = new OpenIdConnectConfiguration();
+            foreach (var key in keys.GetSigningKeys())
+            {
+                configuration.SigningKeys.Add(key);
+            }
+
+            var oidcOptions = new OpenIdConnectOptions
+            {
+                SecurityTokenValidator = new JwtSecurityTokenHandler(),
+                ConfigurationManager = new StaticConfigurationManager<OpenIdConnectConfiguration>(configuration),
+                TokenValidationParameters = new TokenValidationParameters
+                {
+                    NameClaimType = "name",
+                    ValidateAudience = true,
+                    ValidAudience = ClientId,
+                    // MCD disables static issuer validation on purpose.
+                    ValidateIssuer = false,
+                    ValidIssuer = "https://primary.example.com/",
+                    ValidateLifetime = true,
+                    RequireExpirationTime = true,
+                }
+            };
+            return oidcOptions;
+        }
+
+        [Fact]
+        public async Task RebuildAsync_With_CustomDomain_Issuer_Rebuilds_In_Full_Mode()
+        {
+            // The refreshed id_token is issued by the custom domain, not the static primary domain.
+            // With issuer validation disabled (MCD), the refresher must resolve the issuer from the
+            // principal's iss claim and still validate the token, rather than failing against the
+            // static ValidIssuer.
+            const string customDomainIssuer = "https://custom.example.com/";
+
+            var currentPrincipal = new ClaimsPrincipal(new ClaimsIdentity(new[]
+            {
+                new Claim("iss", customDomainIssuer),
+                new Claim("name", "Old Name"),
+            }, "Test"));
+
+            var refreshedIdToken = JwtUtils.GenerateToken(
+                1, customDomainIssuer, ClientId, null, null, DateTime.UtcNow.AddSeconds(70), "New Name");
+
+            var rebuilt = await PrincipalRefresher.RebuildAsync(
+                refreshedIdToken,
+                currentPrincipal,
+                new Auth0WebAppOptions { Domain = "primary.example.com", ClientId = ClientId },
+                BuildMcdOidcOptions(),
+                RefreshClaimsValidationType.Full,
+                new Dictionary<string, string?>(),
+                new DefaultHttpContext(),
+                CancellationToken.None);
+
+            rebuilt.Should().NotBeNull();
+            rebuilt!.FindFirst("name")?.Value.Should().Be("New Name");
+        }
+
+        [Fact]
+        public async Task RebuildAsync_With_CustomDomain_Falls_Back_To_ResolvedDomain_When_Principal_Has_No_Iss()
+        {
+            // When the current principal carries no iss claim, the refresher falls back to the
+            // domain resolved for the current request (stored in HttpContext.Items), matching how
+            // the rest of the SDK resolves the issuer under custom domains.
+            const string customDomainIssuer = "https://custom.example.com/";
+
+            var currentPrincipal = new ClaimsPrincipal(new ClaimsIdentity(new[]
+            {
+                new Claim("name", "Old Name"),
+            }, "Test"));
+
+            var httpContext = new DefaultHttpContext();
+            httpContext.Items[Auth0Constants.ResolvedDomainKey] = customDomainIssuer;
+
+            var refreshedIdToken = JwtUtils.GenerateToken(
+                1, customDomainIssuer, ClientId, null, null, DateTime.UtcNow.AddSeconds(70), "New Name");
+
+            var rebuilt = await PrincipalRefresher.RebuildAsync(
+                refreshedIdToken,
+                currentPrincipal,
+                new Auth0WebAppOptions { Domain = "primary.example.com", ClientId = ClientId },
+                BuildMcdOidcOptions(),
+                RefreshClaimsValidationType.Full,
+                new Dictionary<string, string?>(),
+                httpContext,
+                CancellationToken.None);
+
+            rebuilt.Should().NotBeNull();
+            rebuilt!.FindFirst("name")?.Value.Should().Be("New Name");
+        }
+    }
+}

--- a/tests/Auth0.AspNetCore.Authentication.IntegrationTests/Utils/JwtUtils.cs
+++ b/tests/Auth0.AspNetCore.Authentication.IntegrationTests/Utils/JwtUtils.cs
@@ -22,7 +22,7 @@ namespace Auth0.AspNetCore.Authentication.IntegrationTests.Utils
         /// <param name="orgId">The (optional) org_id claim to be used.</param>
         /// <param name="nonce">The (optional) nonce to be used.</param>
         /// <returns>The generated JWT token.</returns>
-        public static string GenerateToken(int userId, string issuer, string audience, string orgId = null, string nonce = null, DateTime? expires = null)
+        public static string GenerateToken(int userId, string issuer, string audience, string orgId = null, string nonce = null, DateTime? expires = null, string name = null)
         {
             var tokenHandler = new JwtSecurityTokenHandler();
             var claims = new List<Claim>
@@ -39,6 +39,11 @@ namespace Auth0.AspNetCore.Authentication.IntegrationTests.Utils
             if (!string.IsNullOrWhiteSpace(nonce))
             {
                 claims.Add(new Claim(JwtRegisteredClaimNames.Nonce, nonce));
+            }
+
+            if (!string.IsNullOrWhiteSpace(name))
+            {
+                claims.Add(new Claim("name", name));
             }
 
             JsonWebKeySet keys = new JsonWebKeySet(GetKeys().Result);

--- a/tests/Auth0.AspNetCore.Authentication.IntegrationTests/Utils/JwtUtils.cs
+++ b/tests/Auth0.AspNetCore.Authentication.IntegrationTests/Utils/JwtUtils.cs
@@ -22,7 +22,7 @@ namespace Auth0.AspNetCore.Authentication.IntegrationTests.Utils
         /// <param name="orgId">The (optional) org_id claim to be used.</param>
         /// <param name="nonce">The (optional) nonce to be used.</param>
         /// <returns>The generated JWT token.</returns>
-        public static string GenerateToken(int userId, string issuer, string audience, string orgId = null, string nonce = null, DateTime? expires = null, string name = null)
+        public static string GenerateToken(int userId, string issuer, string audience, string orgId = null, string nonce = null, DateTime? expires = null, string name = null, DateTime? authTime = null)
         {
             var tokenHandler = new JwtSecurityTokenHandler();
             var claims = new List<Claim>
@@ -44,6 +44,12 @@ namespace Auth0.AspNetCore.Authentication.IntegrationTests.Utils
             if (!string.IsNullOrWhiteSpace(name))
             {
                 claims.Add(new Claim("name", name));
+            }
+
+            if (authTime.HasValue)
+            {
+                var authTimeEpoch = EpochTime.GetIntDate(authTime.Value.ToUniversalTime());
+                claims.Add(new Claim(JwtRegisteredClaimNames.AuthTime, authTimeEpoch.ToString(), ClaimValueTypes.Integer64));
             }
 
             JsonWebKeySet keys = new JsonWebKeySet(GetKeys().Result);


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

When the SDK refreshes an expired access token it persists the new tokens but, by default, leaves the `ClaimsPrincipal` untouched — so `User.Claims` continues to serve the login-time snapshot for the entire lifetime of the refresh token, even though each refresh returns a fresh `id_token` that may carry updated user information.

This PR adds two opt-in features that allow applications to react to a successful primary token refresh:

**`RebuildPrincipalOnRefresh`** (`Auth0WebAppWithAccessTokenOptions`)  
When `true`, the `ClaimsPrincipal` is rebuilt from the refreshed `id_token` after a successful primary refresh so that `User.Claims` (and `User.Identity.Name`) reflect current user information. Defaults to `false`, which preserves the existing behavior.

**`RefreshClaimsValidationType`** (`Auth0WebAppWithAccessTokenOptions`)  
Controls how rigorously the refreshed `id_token` is validated before its claims replace the principal (only consulted when `RebuildPrincipalOnRefresh` is `true`):
- `Full` (default) — validates signature against the cached JWKS, plus issuer/audience and the SDK's business-rule checks.
- `SkipSignature` — skips signature validation (trusting the back-channel TLS exchange), while still running the SDK's business-rule checks.

**`OnTokensRefreshed`** (`Auth0WebAppWithAccessTokenEvents`)  
A new event that fires after every successful primary token refresh. The supplied `AccessTokenRefreshedContext` carries the refreshed `AccessToken`, `IdToken`, `RefreshToken` (null when not rotated), and `ExpiresAt`. Fires independently of `RebuildPrincipalOnRefresh`; when both are used, the event fires after the principal has been rebuilt.

**Graceful degradation:** If the refresh succeeds but rebuilding the principal fails (signature failure, malformed token, or a business-rule failure), the SDK keeps the refreshed tokens, retains the existing (stale) principal, logs a warning, and still fires `OnTokensRefreshed`.

**Scope:** Both additions apply only to the primary (login-time) refresh path. Tokens fetched for additional audiences via MRRT do not rebuild the principal or fire `OnTokensRefreshed`.

### References
- Fixes #174 


### Testing

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `main`