### PR TITLE
feat: Adds Custom Token Exchange support

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -16,6 +16,8 @@
   - [Retrieving a federated connection token](#retrieving-a-federated-connection-token)
   - [Forcing a refresh](#forcing-a-refresh-1)
   - [Handling a missing refresh token or exchange failure](#handling-a-missing-refresh-token-or-exchange-failure)
+- [Custom Token Exchange](#custom-token-exchange)
+  - [Delegation / impersonation](#delegation--impersonation)
 - [Organizations](#organizations)
 - [Extra parameters](#extra-parameters)
 - [Roles](#roles)
@@ -679,6 +681,58 @@ var googleToken = await HttpContext.GetAccessTokenForConnectionAsync(new AccessT
 ### Handling a missing refresh token or exchange failure
 
 A federated connection token can only be obtained via the session's refresh token. When none is present, the `OnMissingRefreshToken` event fires and the method returns `null`. When a refresh token is present but the exchange is rejected, the `OnAccessTokenRefreshFailed` event fires (carrying `StatusCode`, `Error`, `ErrorDescription`) and the method returns `null`. These are the same events used by MRRT — see [Handling refresh failures](#handling-refresh-failures) and [Detecting the absense of a refresh token](#detecting-the-absense-of-a-refresh-token) for full configuration examples.
+
+## Custom Token Exchange
+
+[Custom Token Exchange](https://auth0.com/docs/authenticate/custom-token-exchange) (RFC 8693) exchanges an
+existing external/custom security token for Auth0 tokens, without a browser redirect. Use it for
+delegation/impersonation and agent-identity scenarios. It requires a configured Custom Token Exchange Profile
+and a validation Action in your Auth0 tenant.
+
+`CustomTokenExchangeAsync` is **stateless**: it performs the exchange and returns the tokens, but does **not**
+sign the user in or write any cookie. The caller decides what to persist.
+
+```csharp
+try
+{
+    var result = await HttpContext.CustomTokenExchangeAsync(new CustomTokenExchangeRequest
+    {
+        SubjectToken = externalToken,
+        SubjectTokenType = "urn:acme:legacy-token", // a custom URI matching your CTE Profile
+        Audience = "https://api.example.com",       // optional
+        Scope = "read:data"                          // optional
+    });
+
+    // result.AccessToken, result.IdToken, result.RefreshToken, result.ExpiresIn, result.Scope
+}
+catch (CustomTokenExchangeException ex)
+{
+    // ex.StatusCode, ex.Error, ex.ErrorDescription describe a token-endpoint rejection;
+    // a validation failure carries a descriptive message instead.
+}
+```
+
+### Delegation / impersonation
+
+Pass an actor token pair to act on behalf of another party (RFC 8693 delegation). When delegation is in play,
+the `act` claim from the returned ID token is decoded and exposed on `result.Act` (the outermost `Sub` is the
+current actor; nested `Act` values are prior actors, informational only). Auth0 suppresses the refresh token in
+delegation flows.
+
+```csharp
+var result = await HttpContext.CustomTokenExchangeAsync(new CustomTokenExchangeRequest
+{
+    SubjectToken = externalToken,
+    SubjectTokenType = "urn:acme:legacy-token",
+    ActorToken = actorToken,
+    ActorTokenType = "urn:acme:actor-token"
+});
+
+var currentActor = result.Act?.Sub;
+```
+
+> **Note:** `subject_token_type` (and `actor_token_type`) must be custom URIs. The reserved `urn:ietf:` and
+> `urn:auth0:` namespaces are rejected client-side.
 
 ## Organizations
 

--- a/src/Auth0.AspNetCore.Authentication/ActClaimReader.cs
+++ b/src/Auth0.AspNetCore.Authentication/ActClaimReader.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Text;
+using System.Text.Json;
+
+namespace Auth0.AspNetCore.Authentication
+{
+    /// <summary>
+    /// Best-effort decoder for the RFC 8693 <c>act</c> (actor) claim from an ID token's JWT payload.
+    /// Performs no signature verification — the token comes directly from the Auth0 token endpoint
+    /// over the backchannel TLS connection. Any malformed input yields <c>null</c>.
+    /// </summary>
+    internal static class ActClaimReader
+    {
+        public static ActClaim? TryRead(string? idToken)
+        {
+            if (string.IsNullOrEmpty(idToken))
+            {
+                return null;
+            }
+
+            try
+            {
+                var parts = idToken.Split('.');
+                if (parts.Length != 3)
+                {
+                    return null;
+                }
+
+                var payloadJson = Encoding.UTF8.GetString(Base64UrlDecode(parts[1]));
+                using var document = JsonDocument.Parse(payloadJson);
+
+                if (!document.RootElement.TryGetProperty("act", out var actElement) ||
+                    actElement.ValueKind != JsonValueKind.Object)
+                {
+                    return null;
+                }
+
+                return ReadActElement(actElement);
+            }
+            catch (Exception)
+            {
+                // Best-effort: a decode/parse hiccup must not fail an exchange the endpoint accepted.
+                return null;
+            }
+        }
+
+        private static ActClaim ReadActElement(JsonElement element)
+        {
+            var claim = new ActClaim();
+
+            if (element.TryGetProperty("sub", out var subElement) &&
+                subElement.ValueKind == JsonValueKind.String)
+            {
+                claim.Sub = subElement.GetString();
+            }
+
+            if (element.TryGetProperty("act", out var nestedElement) &&
+                nestedElement.ValueKind == JsonValueKind.Object)
+            {
+                claim.Act = ReadActElement(nestedElement);
+            }
+
+            return claim;
+        }
+
+        private static byte[] Base64UrlDecode(string input)
+        {
+            var output = input.Replace('-', '+').Replace('_', '/');
+            switch (output.Length % 4)
+            {
+                case 2: output += "=="; break;
+                case 3: output += "="; break;
+            }
+            return Convert.FromBase64String(output);
+        }
+    }
+}

--- a/src/Auth0.AspNetCore.Authentication/CustomTokenExchangeException.cs
+++ b/src/Auth0.AspNetCore.Authentication/CustomTokenExchangeException.cs
@@ -3,7 +3,7 @@ using System;
 namespace Auth0.AspNetCore.Authentication
 {
     /// <summary>
-    /// Thrown when a Custom Token Exchange  fails — either client-side validation of the
+    /// Thrown when a Custom Token Exchange fails — either client-side validation of the
     /// request, or rejection by the Auth0 token endpoint. Carries the token-endpoint status code and
     /// error details when the failure came from the network; never carries token-bearing bytes.
     /// </summary>

--- a/src/Auth0.AspNetCore.Authentication/CustomTokenExchangeException.cs
+++ b/src/Auth0.AspNetCore.Authentication/CustomTokenExchangeException.cs
@@ -1,0 +1,44 @@
+using System;
+
+namespace Auth0.AspNetCore.Authentication
+{
+    /// <summary>
+    /// Thrown when a Custom Token Exchange  fails — either client-side validation of the
+    /// request, or rejection by the Auth0 token endpoint. Carries the token-endpoint status code and
+    /// error details when the failure came from the network; never carries token-bearing bytes.
+    /// </summary>
+    public class CustomTokenExchangeException : Exception
+    {
+        /// <summary>The HTTP status code returned by the token endpoint, when the failure was a rejection.</summary>
+        public int? StatusCode { get; }
+
+        /// <summary>The <c>error</c> code from the token endpoint's error body, when present.</summary>
+        public string? Error { get; }
+
+        /// <summary>The <c>error_description</c> from the token endpoint's error body, when present.</summary>
+        public string? ErrorDescription { get; }
+
+        /// <summary>Creates an exception for a client-side validation failure.</summary>
+        public CustomTokenExchangeException(string message) : base(message)
+        {
+        }
+
+        /// <summary>Creates an exception for a token-endpoint rejection.</summary>
+        public CustomTokenExchangeException(int? statusCode, string? error, string? errorDescription)
+            : base(BuildMessage(statusCode, error, errorDescription))
+        {
+            StatusCode = statusCode;
+            Error = error;
+            ErrorDescription = errorDescription;
+        }
+
+        private static string BuildMessage(int? statusCode, string? error, string? errorDescription)
+        {
+            var code = error ?? "token_exchange_failed";
+            var description = errorDescription ?? "The custom token exchange was rejected by the token endpoint.";
+            return statusCode.HasValue
+                ? $"Custom token exchange failed ({statusCode}): {code} - {description}"
+                : $"Custom token exchange failed: {code} - {description}";
+        }
+    }
+}

--- a/src/Auth0.AspNetCore.Authentication/CustomTokenExchangeRequest.cs
+++ b/src/Auth0.AspNetCore.Authentication/CustomTokenExchangeRequest.cs
@@ -1,0 +1,43 @@
+namespace Auth0.AspNetCore.Authentication
+{
+    /// <summary>
+    /// Describes a Custom Token Exchange request: exchanging an external/custom
+    /// security token for Auth0 tokens, without a browser redirect.
+    /// </summary>
+    public class CustomTokenExchangeRequest
+    {
+        /// <summary>
+        /// The external token to exchange. Validated by your Auth0 Action with the Custom Token
+        /// Exchange trigger. Required; must not be empty/whitespace and must not include a
+        /// <c>"Bearer "</c> prefix.
+        /// </summary>
+        public string SubjectToken { get; set; } = null!;
+
+        /// <summary>
+        /// A custom URI identifying the subject token type, used as the routing key to select a
+        /// Custom Token Exchange Profile. Required; must be 10-100 characters and a valid URI
+        /// (URL or URN). Reserved <c>urn:ietf:</c> and <c>urn:auth0:</c> namespaces are rejected.
+        /// </summary>
+        public string SubjectTokenType { get; set; } = null!;
+
+        /// <summary>The unique identifier of the target API. Optional.</summary>
+        public string? Audience { get; set; }
+
+        /// <summary>Space-delimited OAuth 2.0 scopes. Optional.</summary>
+        public string? Scope { get; set; }
+
+        /// <summary>
+        /// Actor token for delegation/impersonation . If set, <see cref="ActorTokenType"/>
+        /// is required.
+        /// </summary>
+        public string? ActorToken { get; set; }
+
+        /// <summary>
+        /// Actor token type URI. Required when <see cref="ActorToken"/> is set; must be a valid URI.
+        /// </summary>
+        public string? ActorTokenType { get; set; }
+
+        /// <summary>Organization ID or name for multi-tenant scenarios. Optional.</summary>
+        public string? Organization { get; set; }
+    }
+}

--- a/src/Auth0.AspNetCore.Authentication/CustomTokenExchangeRequest.cs
+++ b/src/Auth0.AspNetCore.Authentication/CustomTokenExchangeRequest.cs
@@ -15,8 +15,8 @@ namespace Auth0.AspNetCore.Authentication
 
         /// <summary>
         /// A custom URI identifying the subject token type, used as the routing key to select a
-        /// Custom Token Exchange Profile. Required; must be 10-100 characters and a valid URI
-        /// (URL or URN). Reserved <c>urn:ietf:</c> and <c>urn:auth0:</c> namespaces are rejected.
+        /// Custom Token Exchange Profile. Required. The token endpoint validates the value against
+        /// your configured profile.
         /// </summary>
         public string SubjectTokenType { get; set; } = null!;
 
@@ -27,13 +27,13 @@ namespace Auth0.AspNetCore.Authentication
         public string? Scope { get; set; }
 
         /// <summary>
-        /// Actor token for delegation/impersonation . If set, <see cref="ActorTokenType"/>
+        /// Actor token for delegation/impersonation. If set, <see cref="ActorTokenType"/>
         /// is required.
         /// </summary>
         public string? ActorToken { get; set; }
 
         /// <summary>
-        /// Actor token type URI. Required when <see cref="ActorToken"/> is set; must be a valid URI.
+        /// Actor token type URI. Required when <see cref="ActorToken"/> is set.
         /// </summary>
         public string? ActorTokenType { get; set; }
 

--- a/src/Auth0.AspNetCore.Authentication/CustomTokenExchangeRequestValidator.cs
+++ b/src/Auth0.AspNetCore.Authentication/CustomTokenExchangeRequestValidator.cs
@@ -15,70 +15,20 @@ namespace Auth0.AspNetCore.Authentication
                 throw new CustomTokenExchangeException("subject_token is required and cannot be empty.");
             }
 
-            if (request.SubjectToken.StartsWith("Bearer ", StringComparison.Ordinal))
+            if (request.SubjectToken != request.SubjectToken.Trim())
+            {
+                throw new CustomTokenExchangeException("subject_token must not include leading or trailing whitespace.");
+            }
+
+            if (request.SubjectToken.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase))
             {
                 throw new CustomTokenExchangeException("subject_token must not include a \"Bearer \" prefix.");
             }
 
-            ValidateSubjectTokenType(request.SubjectTokenType);
-
-            var hasActorToken = !string.IsNullOrWhiteSpace(request.ActorToken);
-            var hasActorTokenType = !string.IsNullOrWhiteSpace(request.ActorTokenType);
-
-            if (hasActorToken && !hasActorTokenType)
+            if (!string.IsNullOrWhiteSpace(request.ActorToken) && string.IsNullOrWhiteSpace(request.ActorTokenType))
             {
                 throw new CustomTokenExchangeException("actor_token_type is required when actor_token is provided.");
             }
-
-            if (hasActorTokenType && !hasActorToken)
-            {
-                throw new CustomTokenExchangeException("actor_token is required when actor_token_type is provided.");
-            }
-
-            if (hasActorToken && !IsValidUri(request.ActorTokenType!))
-            {
-                throw new CustomTokenExchangeException("actor_token_type must be a valid URI (URL or URN).");
-            }
-        }
-
-        private static void ValidateSubjectTokenType(string type)
-        {
-            if (string.IsNullOrWhiteSpace(type) || type.Length < 10)
-            {
-                throw new CustomTokenExchangeException("subject_token_type must be at least 10 characters.");
-            }
-
-            if (type.Length > 100)
-            {
-                throw new CustomTokenExchangeException("subject_token_type must be at most 100 characters.");
-            }
-
-            if (type.StartsWith("urn:ietf:", StringComparison.OrdinalIgnoreCase) ||
-                type.StartsWith("urn:auth0:", StringComparison.OrdinalIgnoreCase))
-            {
-                throw new CustomTokenExchangeException(
-                    "subject_token_type must not use the reserved urn:ietf: or urn:auth0: namespaces; use a custom URI.");
-            }
-
-            if (!IsValidUri(type))
-            {
-                throw new CustomTokenExchangeException("subject_token_type must be a valid URI (URL or URN).");
-            }
-        }
-
-        // A valid absolute URL, or a URN of the form urn:<nid>:<nss>.
-        private static bool IsValidUri(string value)
-        {
-            if (Uri.TryCreate(value, UriKind.Absolute, out var uri) &&
-                (uri.Scheme == Uri.UriSchemeHttp || uri.Scheme == Uri.UriSchemeHttps))
-            {
-                return true;
-            }
-
-            return System.Text.RegularExpressions.Regex.IsMatch(
-                value,
-                @"^urn:[a-z0-9][a-z0-9-]{0,31}:[a-z0-9()+,\-.:=@;$_!*'%/?#]+$",
-                System.Text.RegularExpressions.RegexOptions.IgnoreCase);
         }
     }
 }

--- a/src/Auth0.AspNetCore.Authentication/CustomTokenExchangeRequestValidator.cs
+++ b/src/Auth0.AspNetCore.Authentication/CustomTokenExchangeRequestValidator.cs
@@ -1,0 +1,84 @@
+using System;
+
+namespace Auth0.AspNetCore.Authentication
+{
+    /// <summary>
+    /// Validates a <see cref="CustomTokenExchangeRequest"/> client-side, before any network call.
+    /// Throws <see cref="CustomTokenExchangeException"/> on the first violation.
+    /// </summary>
+    internal static class CustomTokenExchangeRequestValidator
+    {
+        public static void Validate(CustomTokenExchangeRequest request)
+        {
+            if (string.IsNullOrWhiteSpace(request.SubjectToken))
+            {
+                throw new CustomTokenExchangeException("subject_token is required and cannot be empty.");
+            }
+
+            if (request.SubjectToken.StartsWith("Bearer ", StringComparison.Ordinal))
+            {
+                throw new CustomTokenExchangeException("subject_token must not include a \"Bearer \" prefix.");
+            }
+
+            ValidateSubjectTokenType(request.SubjectTokenType);
+
+            var hasActorToken = !string.IsNullOrWhiteSpace(request.ActorToken);
+            var hasActorTokenType = !string.IsNullOrWhiteSpace(request.ActorTokenType);
+
+            if (hasActorToken && !hasActorTokenType)
+            {
+                throw new CustomTokenExchangeException("actor_token_type is required when actor_token is provided.");
+            }
+
+            if (hasActorTokenType && !hasActorToken)
+            {
+                throw new CustomTokenExchangeException("actor_token is required when actor_token_type is provided.");
+            }
+
+            if (hasActorToken && !IsValidUri(request.ActorTokenType!))
+            {
+                throw new CustomTokenExchangeException("actor_token_type must be a valid URI (URL or URN).");
+            }
+        }
+
+        private static void ValidateSubjectTokenType(string type)
+        {
+            if (string.IsNullOrWhiteSpace(type) || type.Length < 10)
+            {
+                throw new CustomTokenExchangeException("subject_token_type must be at least 10 characters.");
+            }
+
+            if (type.Length > 100)
+            {
+                throw new CustomTokenExchangeException("subject_token_type must be at most 100 characters.");
+            }
+
+            if (type.StartsWith("urn:ietf:", StringComparison.OrdinalIgnoreCase) ||
+                type.StartsWith("urn:auth0:", StringComparison.OrdinalIgnoreCase))
+            {
+                throw new CustomTokenExchangeException(
+                    "subject_token_type must not use the reserved urn:ietf: or urn:auth0: namespaces; use a custom URI.");
+            }
+
+            if (!IsValidUri(type))
+            {
+                throw new CustomTokenExchangeException("subject_token_type must be a valid URI (URL or URN).");
+            }
+        }
+
+        // A valid absolute URL, or a URN of the form urn:<nid>:<nss>.
+        private static bool IsValidUri(string value)
+        {
+            if (Uri.TryCreate(value, UriKind.Absolute, out var uri) &&
+                (uri.Scheme == Uri.UriSchemeHttp || uri.Scheme == Uri.UriSchemeHttps))
+            {
+                return true;
+            }
+
+            return System.Text.RegularExpressions.Regex.IsMatch(
+                value,
+                @"^urn:[a-z0-9][a-z0-9-]{0,31}:[a-z0-9()+,\-.:=@;$_!*'%/?#]+$",
+                System.Text.RegularExpressions.RegexOptions.IgnoreCase);
+        }
+    }
+}

--- a/src/Auth0.AspNetCore.Authentication/CustomTokenExchangeResult.cs
+++ b/src/Auth0.AspNetCore.Authentication/CustomTokenExchangeResult.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 namespace Auth0.AspNetCore.Authentication
 {
     /// <summary>
-    /// The result of a Custom Token Exchange . Carries the exchanged tokens. This method
+    /// The result of a Custom Token Exchange. Carries the exchanged tokens. This method
     /// has no session side-effects — the caller decides what (if anything) to persist.
     /// </summary>
     public class CustomTokenExchangeResult

--- a/src/Auth0.AspNetCore.Authentication/CustomTokenExchangeResult.cs
+++ b/src/Auth0.AspNetCore.Authentication/CustomTokenExchangeResult.cs
@@ -1,0 +1,50 @@
+using System.Collections.Generic;
+
+namespace Auth0.AspNetCore.Authentication
+{
+    /// <summary>
+    /// The result of a Custom Token Exchange . Carries the exchanged tokens. This method
+    /// has no session side-effects — the caller decides what (if anything) to persist.
+    /// </summary>
+    public class CustomTokenExchangeResult
+    {
+        /// <summary>The access token issued by Auth0.</summary>
+        public string AccessToken { get; set; } = null!;
+
+        /// <summary>The ID token, when an <c>openid</c> scope was granted.</summary>
+        public string? IdToken { get; set; }
+
+        /// <summary>
+        /// The refresh token, when <c>offline_access</c> was granted. Auth0 suppresses the refresh
+        /// token in delegation flows (when <c>actor_token</c> is present), so this is often null then.
+        /// </summary>
+        public string? RefreshToken { get; set; }
+
+        /// <summary>Token lifetime in seconds.</summary>
+        public int ExpiresIn { get; set; }
+
+        /// <summary>The granted scopes, when returned.</summary>
+        public string? Scope { get; set; }
+
+        /// <summary>
+        /// The <c>act</c> (actor) claim decoded from the returned ID token, present in
+        /// delegation/impersonation flows (RFC 8693). Null when there is no ID token, no act
+        /// claim, or the ID token could not be decoded.
+        /// </summary>
+        public ActClaim? Act { get; set; }
+    }
+
+    /// <summary>
+    /// The <c>act</c> (actor) claim from an ID token issued via RFC 8693 delegation. The outermost
+    /// <see cref="Sub"/> identifies the current actor; nested <see cref="Act"/> values are prior
+    /// actors in the delegation chain and are informational only (RFC 8693).
+    /// </summary>
+    public class ActClaim
+    {
+        /// <summary>The subject identifier of the acting party.</summary>
+        public string? Sub { get; set; }
+
+        /// <summary>Nested actor claim representing a delegation chain.</summary>
+        public ActClaim? Act { get; set; }
+    }
+}

--- a/src/Auth0.AspNetCore.Authentication/HttpContextExtensions.cs
+++ b/src/Auth0.AspNetCore.Authentication/HttpContextExtensions.cs
@@ -319,6 +319,11 @@ namespace Auth0.AspNetCore.Authentication
 
             var response = result.Response!;
 
+            if (!string.IsNullOrWhiteSpace(request.Organization))
+            {
+                OrganizationClaimValidator.Validate(response.IdToken, request.Organization!);
+            }
+
             return new CustomTokenExchangeResult
             {
                 AccessToken = response.AccessToken,

--- a/src/Auth0.AspNetCore.Authentication/HttpContextExtensions.cs
+++ b/src/Auth0.AspNetCore.Authentication/HttpContextExtensions.cs
@@ -274,6 +274,63 @@ namespace Auth0.AspNetCore.Authentication
         }
 
         /// <summary>
+        /// Performs a Custom Token Exchange : exchanges the external token described by
+        /// <paramref name="request"/> for Auth0 tokens, without a browser redirect. This is the
+        /// stateless utility — it has <b>no session side-effects</b> (it does not sign the user in or
+        /// write any cookie); the caller decides what to persist. Use it for delegation/impersonation
+        /// and agent-identity scenarios.
+        /// </summary>
+        /// <param name="context">The current <see cref="HttpContext"/>.</param>
+        /// <param name="request">The exchange request (subject token + type, and optional audience,
+        /// scope, actor token pair, organization).</param>
+        /// <param name="scheme">The Auth0 authentication scheme. Defaults to <see cref="Auth0Constants.AuthenticationScheme"/>.</param>
+        /// <returns>The exchanged tokens.</returns>
+        /// <exception cref="CustomTokenExchangeException">
+        /// Thrown when the request fails client-side validation, or when the token endpoint rejects
+        /// the exchange.
+        /// </exception>
+        public static async Task<CustomTokenExchangeResult> CustomTokenExchangeAsync(this HttpContext context, CustomTokenExchangeRequest request, string? scheme = null)
+        {
+            scheme ??= Auth0Constants.AuthenticationScheme;
+
+            CustomTokenExchangeRequestValidator.Validate(request);
+
+            var options = context.RequestServices.GetRequiredService<IOptionsSnapshot<Auth0WebAppOptions>>().Get(scheme);
+
+            var httpClient = options.Backchannel ?? context.RequestServices.GetRequiredService<IHttpClientFactory>().CreateClient();
+            var tokenClient = new TokenClient(httpClient);
+            var resolvedDomain = context.GetResolvedDomain();
+
+            var result = await tokenClient.ExchangeCustomToken(
+                options,
+                request.SubjectToken,
+                request.SubjectTokenType,
+                request.Audience,
+                request.Scope,
+                request.ActorToken,
+                request.ActorTokenType,
+                request.Organization,
+                resolvedDomain).ConfigureAwait(false);
+
+            if (!result.IsSuccess)
+            {
+                throw new CustomTokenExchangeException(result.StatusCode, result.Error, result.ErrorDescription);
+            }
+
+            var response = result.Response!;
+
+            return new CustomTokenExchangeResult
+            {
+                AccessToken = response.AccessToken,
+                IdToken = response.IdToken,
+                RefreshToken = response.RefreshToken,
+                ExpiresIn = response.ExpiresIn,
+                Scope = response.Scope,
+                Act = ActClaimReader.TryRead(response.IdToken)
+            };
+        }
+
+        /// <summary>
         /// Retrieves the resolved domain from the <see cref="HttpContext.Items"/> collection.
         /// </summary>
         /// <param name="httpContext">The current HTTP context.</param>

--- a/src/Auth0.AspNetCore.Authentication/OrganizationClaimValidator.cs
+++ b/src/Auth0.AspNetCore.Authentication/OrganizationClaimValidator.cs
@@ -1,0 +1,53 @@
+using System;
+using System.IdentityModel.Tokens.Jwt;
+using System.Linq;
+
+namespace Auth0.AspNetCore.Authentication
+{
+    /// <summary>
+    /// Validates the organization claim on the ID token returned from a Custom Token Exchange
+    /// against the requested organization. An <c>org_</c>-prefixed value is matched exactly against
+    /// the <c>org_id</c> claim; any other value is matched case-insensitively against <c>org_name</c>.
+    /// </summary>
+    internal static class OrganizationClaimValidator
+    {
+        public static void Validate(string? idToken, string organization)
+        {
+            // No ID token means there is no organization claim to validate (e.g. an exchange that
+            // returned only an access token). Nothing to check.
+            if (string.IsNullOrWhiteSpace(organization) || string.IsNullOrEmpty(idToken))
+            {
+                return;
+            }
+
+            var handler = new JwtSecurityTokenHandler();
+
+            if (!handler.CanReadToken(idToken))
+            {
+                throw new CustomTokenExchangeException(
+                    "organization was requested but the returned ID token could not be read to validate the organization claim.");
+            }
+
+            var token = handler.ReadJwtToken(idToken);
+
+            var organizationClaim = organization.StartsWith("org_", StringComparison.Ordinal) ? "org_id" : "org_name";
+            var claimValue = token.Claims.FirstOrDefault(claim => claim.Type == organizationClaim)?.Value;
+
+            if (string.IsNullOrWhiteSpace(claimValue))
+            {
+                throw new CustomTokenExchangeException(
+                    $"Organization claim ({organizationClaim}) must be present in the returned ID token.");
+            }
+
+            var matches = organizationClaim == "org_name"
+                ? string.Equals(claimValue, organization, StringComparison.OrdinalIgnoreCase)
+                : string.Equals(claimValue, organization, StringComparison.Ordinal);
+
+            if (!matches)
+            {
+                throw new CustomTokenExchangeException(
+                    $"Organization claim ({organizationClaim}) mismatch in the returned ID token; expected \"{organization}\", found \"{claimValue}\".");
+            }
+        }
+    }
+}

--- a/src/Auth0.AspNetCore.Authentication/TokenClient.cs
+++ b/src/Auth0.AspNetCore.Authentication/TokenClient.cs
@@ -92,6 +92,61 @@ namespace Auth0.AspNetCore.Authentication
             return await Send(body, tokenEndpointDomain).ConfigureAwait(false);
         }
 
+        public async Task<TokenRefreshResult> ExchangeCustomToken(
+            Auth0WebAppOptions options,
+            string subjectToken,
+            string subjectTokenType,
+            string? audience = null,
+            string? scope = null,
+            string? actorToken = null,
+            string? actorTokenType = null,
+            string? organization = null,
+            string? domain = null)
+        {
+            var body = new Dictionary<string, string>
+            {
+                { "grant_type", "urn:ietf:params:oauth:grant-type:token-exchange" },
+                { "client_id", options.ClientId },
+                { "subject_token", subjectToken },
+                { "subject_token_type", subjectTokenType }
+            };
+
+            if (!string.IsNullOrWhiteSpace(audience))
+            {
+                body.Add("audience", audience);
+            }
+
+            if (!string.IsNullOrWhiteSpace(scope))
+            {
+                body.Add("scope", scope);
+            }
+
+            if (!string.IsNullOrWhiteSpace(organization))
+            {
+                body.Add("organization", organization);
+            }
+
+            // The actor pair is added together; the mutual requirement is enforced by validation.
+            if (!string.IsNullOrWhiteSpace(actorToken))
+            {
+                body.Add("actor_token", actorToken);
+                body.Add("actor_token_type", actorTokenType!);
+            }
+
+            var tokenEndpointDomain = domain ?? options.Domain;
+
+            if (string.IsNullOrWhiteSpace(tokenEndpointDomain))
+            {
+                throw new InvalidOperationException(
+                    "Cannot determine domain for token endpoint. " +
+                    "Ensure Domain is set or domain resolution is properly configured.");
+            }
+
+            ApplyClientAuthentication(options, body, tokenEndpointDomain);
+
+            return await Send(body, tokenEndpointDomain).ConfigureAwait(false);
+        }
+
         private async Task<TokenRefreshResult> Send(Dictionary<string, string> body, string tokenEndpointDomain)
         {
             var requestContent = new FormUrlEncodedContent(body.Select(p => new KeyValuePair<string?, string?>(p.Key, p.Value ?? "")));

--- a/tests/Auth0.AspNetCore.Authentication.IntegrationTests/ActClaimReaderTests.cs
+++ b/tests/Auth0.AspNetCore.Authentication.IntegrationTests/ActClaimReaderTests.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Text;
+using FluentAssertions;
+using Xunit;
+
+namespace Auth0.AspNetCore.Authentication.IntegrationTests
+{
+    public class ActClaimReaderTests
+    {
+        // Builds a JWT-shaped string (header.payload.signature) with the given JSON payload.
+        private static string JwtWithPayload(string payloadJson)
+        {
+            string B64Url(string s)
+            {
+                var bytes = Encoding.UTF8.GetBytes(s);
+                return Convert.ToBase64String(bytes).TrimEnd('=').Replace('+', '-').Replace('/', '_');
+            }
+            return $"{B64Url("{\"alg\":\"RS256\"}")}.{B64Url(payloadJson)}.signature";
+        }
+
+        [Fact]
+        public void Returns_Null_For_Null_Or_Empty()
+        {
+            ActClaimReader.TryRead(null).Should().BeNull();
+            ActClaimReader.TryRead("").Should().BeNull();
+        }
+
+        [Fact]
+        public void Returns_Null_For_Malformed_Jwt()
+        {
+            ActClaimReader.TryRead("not-a-jwt").Should().BeNull();
+            ActClaimReader.TryRead("only.two").Should().BeNull();
+        }
+
+        [Fact]
+        public void Returns_Null_When_No_Act_Claim()
+        {
+            var jwt = JwtWithPayload("{\"sub\":\"auth0|user123\"}");
+            ActClaimReader.TryRead(jwt).Should().BeNull();
+        }
+
+        [Fact]
+        public void Reads_A_Single_Level_Act_Claim()
+        {
+            var jwt = JwtWithPayload("{\"sub\":\"auth0|user123\",\"act\":{\"sub\":\"mcp_client_id\"}}");
+            var act = ActClaimReader.TryRead(jwt);
+            act.Should().NotBeNull();
+            act!.Sub.Should().Be("mcp_client_id");
+            act.Act.Should().BeNull();
+        }
+
+        [Fact]
+        public void Reads_A_Nested_Delegation_Chain()
+        {
+            var jwt = JwtWithPayload(
+                "{\"sub\":\"auth0|user123\",\"act\":{\"sub\":\"mcp2\",\"act\":{\"sub\":\"mcp1\"}}}");
+            var act = ActClaimReader.TryRead(jwt);
+            act.Should().NotBeNull();
+            act!.Sub.Should().Be("mcp2");
+            act.Act.Should().NotBeNull();
+            act.Act!.Sub.Should().Be("mcp1");
+        }
+    }
+}

--- a/tests/Auth0.AspNetCore.Authentication.IntegrationTests/CustomTokenExchangeRequestValidatorTests.cs
+++ b/tests/Auth0.AspNetCore.Authentication.IntegrationTests/CustomTokenExchangeRequestValidatorTests.cs
@@ -1,0 +1,130 @@
+using System;
+using FluentAssertions;
+using Xunit;
+
+namespace Auth0.AspNetCore.Authentication.IntegrationTests
+{
+    public class CustomTokenExchangeRequestValidatorTests
+    {
+        private static CustomTokenExchangeRequest Valid() => new CustomTokenExchangeRequest
+        {
+            SubjectToken = "external-token-value",
+            SubjectTokenType = "urn:acme:legacy-token"
+        };
+
+        [Fact]
+        public void Accepts_A_Valid_Minimal_Request()
+        {
+            var act = () => CustomTokenExchangeRequestValidator.Validate(Valid());
+            act.Should().NotThrow();
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("   ")]
+        public void Rejects_Empty_SubjectToken(string? token)
+        {
+            var req = Valid();
+            req.SubjectToken = token!;
+            var act = () => CustomTokenExchangeRequestValidator.Validate(req);
+            act.Should().Throw<CustomTokenExchangeException>().WithMessage("*subject_token*");
+        }
+
+        [Fact]
+        public void Rejects_SubjectToken_With_Bearer_Prefix()
+        {
+            var req = Valid();
+            req.SubjectToken = "Bearer abc";
+            var act = () => CustomTokenExchangeRequestValidator.Validate(req);
+            act.Should().Throw<CustomTokenExchangeException>().WithMessage("*Bearer*");
+        }
+
+        [Fact]
+        public void Rejects_SubjectTokenType_Shorter_Than_10_Chars()
+        {
+            var req = Valid();
+            req.SubjectTokenType = "urn:a:b"; // 7 chars
+            var act = () => CustomTokenExchangeRequestValidator.Validate(req);
+            act.Should().Throw<CustomTokenExchangeException>().WithMessage("*subject_token_type*");
+        }
+
+        [Fact]
+        public void Rejects_SubjectTokenType_Longer_Than_100_Chars()
+        {
+            var req = Valid();
+            req.SubjectTokenType = "urn:acme:" + new string('a', 100);
+            var act = () => CustomTokenExchangeRequestValidator.Validate(req);
+            act.Should().Throw<CustomTokenExchangeException>().WithMessage("*subject_token_type*");
+        }
+
+        [Fact]
+        public void Rejects_SubjectTokenType_That_Is_Not_A_Uri()
+        {
+            var req = Valid();
+            req.SubjectTokenType = "not a uri!!";
+            var act = () => CustomTokenExchangeRequestValidator.Validate(req);
+            act.Should().Throw<CustomTokenExchangeException>().WithMessage("*subject_token_type*");
+        }
+
+        [Theory]
+        [InlineData("urn:ietf:params:oauth:token-type:id_token")]
+        [InlineData("urn:auth0:something:reserved")]
+        public void Rejects_Reserved_Namespaces(string reserved)
+        {
+            var req = Valid();
+            req.SubjectTokenType = reserved;
+            var act = () => CustomTokenExchangeRequestValidator.Validate(req);
+            act.Should().Throw<CustomTokenExchangeException>().WithMessage("*reserved*");
+        }
+
+        [Theory]
+        [InlineData("urn:acme:legacy-token")]
+        [InlineData("https://mycompany.com/token-type/v1")]
+        public void Accepts_Valid_Custom_Uri_SubjectTokenTypes(string type)
+        {
+            var req = Valid();
+            req.SubjectTokenType = type;
+            var act = () => CustomTokenExchangeRequestValidator.Validate(req);
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void Rejects_ActorToken_Without_ActorTokenType()
+        {
+            var req = Valid();
+            req.ActorToken = "actor-token";
+            var act = () => CustomTokenExchangeRequestValidator.Validate(req);
+            act.Should().Throw<CustomTokenExchangeException>().WithMessage("*actor_token_type*");
+        }
+
+        [Fact]
+        public void Rejects_ActorTokenType_Without_ActorToken()
+        {
+            var req = Valid();
+            req.ActorTokenType = "urn:acme:actor";
+            var act = () => CustomTokenExchangeRequestValidator.Validate(req);
+            act.Should().Throw<CustomTokenExchangeException>().WithMessage("*actor_token*");
+        }
+
+        [Fact]
+        public void Rejects_ActorTokenType_That_Is_Not_A_Uri()
+        {
+            var req = Valid();
+            req.ActorToken = "actor-token";
+            req.ActorTokenType = "not a uri!!";
+            var act = () => CustomTokenExchangeRequestValidator.Validate(req);
+            act.Should().Throw<CustomTokenExchangeException>().WithMessage("*actor_token_type*");
+        }
+
+        [Fact]
+        public void Accepts_Valid_Actor_Pair()
+        {
+            var req = Valid();
+            req.ActorToken = "actor-token";
+            req.ActorTokenType = "urn:acme:actor-token";
+            var act = () => CustomTokenExchangeRequestValidator.Validate(req);
+            act.Should().NotThrow();
+        }
+    }
+}

--- a/tests/Auth0.AspNetCore.Authentication.IntegrationTests/CustomTokenExchangeRequestValidatorTests.cs
+++ b/tests/Auth0.AspNetCore.Authentication.IntegrationTests/CustomTokenExchangeRequestValidatorTests.cs
@@ -31,51 +31,37 @@ namespace Auth0.AspNetCore.Authentication.IntegrationTests
             act.Should().Throw<CustomTokenExchangeException>().WithMessage("*subject_token*");
         }
 
-        [Fact]
-        public void Rejects_SubjectToken_With_Bearer_Prefix()
+        [Theory]
+        [InlineData("Bearer abc")]
+        [InlineData("bearer abc")]
+        [InlineData("BEARER abc")]
+        public void Rejects_SubjectToken_With_Bearer_Prefix(string token)
         {
             var req = Valid();
-            req.SubjectToken = "Bearer abc";
+            req.SubjectToken = token;
             var act = () => CustomTokenExchangeRequestValidator.Validate(req);
             act.Should().Throw<CustomTokenExchangeException>().WithMessage("*Bearer*");
         }
 
-        [Fact]
-        public void Rejects_SubjectTokenType_Shorter_Than_10_Chars()
-        {
-            var req = Valid();
-            req.SubjectTokenType = "urn:a:b"; // 7 chars
-            var act = () => CustomTokenExchangeRequestValidator.Validate(req);
-            act.Should().Throw<CustomTokenExchangeException>().WithMessage("*subject_token_type*");
-        }
-
-        [Fact]
-        public void Rejects_SubjectTokenType_Longer_Than_100_Chars()
-        {
-            var req = Valid();
-            req.SubjectTokenType = "urn:acme:" + new string('a', 100);
-            var act = () => CustomTokenExchangeRequestValidator.Validate(req);
-            act.Should().Throw<CustomTokenExchangeException>().WithMessage("*subject_token_type*");
-        }
-
-        [Fact]
-        public void Rejects_SubjectTokenType_That_Is_Not_A_Uri()
-        {
-            var req = Valid();
-            req.SubjectTokenType = "not a uri!!";
-            var act = () => CustomTokenExchangeRequestValidator.Validate(req);
-            act.Should().Throw<CustomTokenExchangeException>().WithMessage("*subject_token_type*");
-        }
-
         [Theory]
-        [InlineData("urn:ietf:params:oauth:token-type:id_token")]
-        [InlineData("urn:auth0:something:reserved")]
-        public void Rejects_Reserved_Namespaces(string reserved)
+        [InlineData(" external-token-value")]
+        [InlineData("external-token-value ")]
+        [InlineData(" external-token-value ")]
+        public void Rejects_SubjectToken_With_Surrounding_Whitespace(string token)
         {
             var req = Valid();
-            req.SubjectTokenType = reserved;
+            req.SubjectToken = token;
             var act = () => CustomTokenExchangeRequestValidator.Validate(req);
-            act.Should().Throw<CustomTokenExchangeException>().WithMessage("*reserved*");
+            act.Should().Throw<CustomTokenExchangeException>().WithMessage("*whitespace*");
+        }
+
+        [Fact]
+        public void Accepts_Short_Valid_Urn_SubjectTokenType()
+        {
+            var req = Valid();
+            req.SubjectTokenType = "urn:a:b"; // 7 chars — a legal URN, no length floor
+            var act = () => CustomTokenExchangeRequestValidator.Validate(req);
+            act.Should().NotThrow();
         }
 
         [Theory]
@@ -94,25 +80,6 @@ namespace Auth0.AspNetCore.Authentication.IntegrationTests
         {
             var req = Valid();
             req.ActorToken = "actor-token";
-            var act = () => CustomTokenExchangeRequestValidator.Validate(req);
-            act.Should().Throw<CustomTokenExchangeException>().WithMessage("*actor_token_type*");
-        }
-
-        [Fact]
-        public void Rejects_ActorTokenType_Without_ActorToken()
-        {
-            var req = Valid();
-            req.ActorTokenType = "urn:acme:actor";
-            var act = () => CustomTokenExchangeRequestValidator.Validate(req);
-            act.Should().Throw<CustomTokenExchangeException>().WithMessage("*actor_token*");
-        }
-
-        [Fact]
-        public void Rejects_ActorTokenType_That_Is_Not_A_Uri()
-        {
-            var req = Valid();
-            req.ActorToken = "actor-token";
-            req.ActorTokenType = "not a uri!!";
             var act = () => CustomTokenExchangeRequestValidator.Validate(req);
             act.Should().Throw<CustomTokenExchangeException>().WithMessage("*actor_token_type*");
         }

--- a/tests/Auth0.AspNetCore.Authentication.IntegrationTests/HttpContextExtensionsTests.cs
+++ b/tests/Auth0.AspNetCore.Authentication.IntegrationTests/HttpContextExtensionsTests.cs
@@ -1023,6 +1023,111 @@ namespace Auth0.AspNetCore.Authentication.IntegrationTests
             result.Act!.Sub.Should().Be("mcp_client");
         }
 
+        [Fact]
+        public async Task CustomTokenExchangeAsync_WithMatchingOrgId_Succeeds()
+        {
+            var idToken = BuildIdToken("{\"sub\":\"auth0|u\",\"org_id\":\"org_abc123\"}");
+            var handler = CreateRawTokenHandler(
+                "{\"access_token\":\"at\",\"id_token\":\"" + idToken + "\",\"expires_in\":3600}");
+
+            var context = BuildContext(handler.Object, new AuthenticationProperties(), out _);
+
+            var result = await context.CustomTokenExchangeAsync(new CustomTokenExchangeRequest
+            {
+                SubjectToken = "ext-token",
+                SubjectTokenType = "urn:acme:legacy-token",
+                Organization = "org_abc123"
+            });
+
+            result.AccessToken.Should().Be("at");
+        }
+
+        [Fact]
+        public async Task CustomTokenExchangeAsync_WithMatchingOrgName_IsCaseInsensitive()
+        {
+            var idToken = BuildIdToken("{\"sub\":\"auth0|u\",\"org_name\":\"acme\"}");
+            var handler = CreateRawTokenHandler(
+                "{\"access_token\":\"at\",\"id_token\":\"" + idToken + "\",\"expires_in\":3600}");
+
+            var context = BuildContext(handler.Object, new AuthenticationProperties(), out _);
+
+            var result = await context.CustomTokenExchangeAsync(new CustomTokenExchangeRequest
+            {
+                SubjectToken = "ext-token",
+                SubjectTokenType = "urn:acme:legacy-token",
+                Organization = "ACME"
+            });
+
+            result.AccessToken.Should().Be("at");
+        }
+
+        [Fact]
+        public async Task CustomTokenExchangeAsync_WithMismatchedOrgId_Throws()
+        {
+            var idToken = BuildIdToken("{\"sub\":\"auth0|u\",\"org_id\":\"org_other\"}");
+            var handler = CreateRawTokenHandler(
+                "{\"access_token\":\"at\",\"id_token\":\"" + idToken + "\",\"expires_in\":3600}");
+
+            var context = BuildContext(handler.Object, new AuthenticationProperties(), out _);
+
+            var act = async () => await context.CustomTokenExchangeAsync(new CustomTokenExchangeRequest
+            {
+                SubjectToken = "ext-token",
+                SubjectTokenType = "urn:acme:legacy-token",
+                Organization = "org_abc123"
+            });
+
+            await act.Should().ThrowAsync<CustomTokenExchangeException>().WithMessage("*org_id*mismatch*");
+        }
+
+        [Fact]
+        public async Task CustomTokenExchangeAsync_WithMissingOrgClaim_Throws()
+        {
+            var idToken = BuildIdToken("{\"sub\":\"auth0|u\"}");
+            var handler = CreateRawTokenHandler(
+                "{\"access_token\":\"at\",\"id_token\":\"" + idToken + "\",\"expires_in\":3600}");
+
+            var context = BuildContext(handler.Object, new AuthenticationProperties(), out _);
+
+            var act = async () => await context.CustomTokenExchangeAsync(new CustomTokenExchangeRequest
+            {
+                SubjectToken = "ext-token",
+                SubjectTokenType = "urn:acme:legacy-token",
+                Organization = "org_abc123"
+            });
+
+            await act.Should().ThrowAsync<CustomTokenExchangeException>().WithMessage("*org_id*present*");
+        }
+
+        [Fact]
+        public async Task CustomTokenExchangeAsync_WithOrgButNoIdToken_DoesNotThrow()
+        {
+            // No ID token returned (e.g. access-token-only exchange): nothing to validate against.
+            var handler = CreateRawTokenHandler("{\"access_token\":\"at\",\"expires_in\":3600}");
+
+            var context = BuildContext(handler.Object, new AuthenticationProperties(), out _);
+
+            var result = await context.CustomTokenExchangeAsync(new CustomTokenExchangeRequest
+            {
+                SubjectToken = "ext-token",
+                SubjectTokenType = "urn:acme:legacy-token",
+                Organization = "org_abc123"
+            });
+
+            result.AccessToken.Should().Be("at");
+        }
+
+        private static string BuildIdToken(string payloadJson)
+        {
+            string B64Url(string s)
+            {
+                var bytes = System.Text.Encoding.UTF8.GetBytes(s);
+                return Convert.ToBase64String(bytes).TrimEnd('=').Replace('+', '-').Replace('/', '_');
+            }
+
+            return $"{B64Url("{\"alg\":\"none\",\"typ\":\"JWT\"}")}.{B64Url(payloadJson)}.sig";
+        }
+
         private static HttpContext BuildContext(
             HttpMessageHandler backchannelHandler,
             AuthenticationProperties properties,

--- a/tests/Auth0.AspNetCore.Authentication.IntegrationTests/HttpContextExtensionsTests.cs
+++ b/tests/Auth0.AspNetCore.Authentication.IntegrationTests/HttpContextExtensionsTests.cs
@@ -867,6 +867,162 @@ namespace Auth0.AspNetCore.Authentication.IntegrationTests
             failedContext!.Error.Should().Be("invalid_request");
         }
 
+        [Fact]
+        public async Task CustomTokenExchangeAsync_OnSuccess_MapsResponseToResult()
+        {
+            var handler = new Mock<HttpMessageHandler>();
+            handler
+                .Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>())
+                .ReturnsAsync(new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = new StringContent(
+                        "{\"access_token\":\"at\",\"id_token\":\"id\",\"refresh_token\":\"rt\",\"expires_in\":3600,\"scope\":\"read:data\"}")
+                });
+
+            var context = BuildContext(handler.Object, new AuthenticationProperties(), out _);
+
+            var result = await context.CustomTokenExchangeAsync(new CustomTokenExchangeRequest
+            {
+                SubjectToken = "ext-token",
+                SubjectTokenType = "urn:acme:legacy-token"
+            });
+
+            result.AccessToken.Should().Be("at");
+            result.IdToken.Should().Be("id");
+            result.RefreshToken.Should().Be("rt");
+            result.ExpiresIn.Should().Be(3600);
+            result.Scope.Should().Be("read:data");
+        }
+
+        [Fact]
+        public async Task CustomTokenExchangeAsync_OnSuccess_DoesNotEstablishSession()
+        {
+            var handler = new Mock<HttpMessageHandler>();
+            handler
+                .Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>())
+                .ReturnsAsync(new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = new StringContent("{\"access_token\":\"at\",\"expires_in\":3600}")
+                });
+
+            var context = BuildContext(handler.Object, new AuthenticationProperties(), out var authService);
+
+            await context.CustomTokenExchangeAsync(new CustomTokenExchangeRequest
+            {
+                SubjectToken = "ext-token",
+                SubjectTokenType = "urn:acme:legacy-token"
+            });
+
+            authService.Verify(s => s.SignInAsync(
+                It.IsAny<HttpContext>(), It.IsAny<string>(),
+                It.IsAny<ClaimsPrincipal>(), It.IsAny<AuthenticationProperties>()), Times.Never());
+        }
+
+        [Fact]
+        public async Task CustomTokenExchangeAsync_WhenRejected_ThrowsWithErrorDetails()
+        {
+            var handler = new Mock<HttpMessageHandler>();
+            handler
+                .Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>())
+                .ReturnsAsync(new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.Forbidden,
+                    Content = new StringContent("{\"error\":\"invalid_request\",\"error_description\":\"bad profile\"}")
+                });
+
+            var context = BuildContext(handler.Object, new AuthenticationProperties(), out _);
+
+            var act = async () => await context.CustomTokenExchangeAsync(new CustomTokenExchangeRequest
+            {
+                SubjectToken = "ext-token",
+                SubjectTokenType = "urn:acme:legacy-token"
+            });
+
+            var assertion = await act.Should().ThrowAsync<CustomTokenExchangeException>();
+            assertion.Which.StatusCode.Should().Be((int)HttpStatusCode.Forbidden);
+            assertion.Which.Error.Should().Be("invalid_request");
+            assertion.Which.ErrorDescription.Should().Be("bad profile");
+        }
+
+        [Fact]
+        public async Task CustomTokenExchangeAsync_OnInvalidRequest_ThrowsBeforeNetworkCall()
+        {
+            var handler = new Mock<HttpMessageHandler>();
+            handler
+                .Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>())
+                .ReturnsAsync(new HttpResponseMessage { StatusCode = HttpStatusCode.OK });
+
+            var context = BuildContext(handler.Object, new AuthenticationProperties(), out _);
+
+            var act = async () => await context.CustomTokenExchangeAsync(new CustomTokenExchangeRequest
+            {
+                SubjectToken = "",
+                SubjectTokenType = "urn:acme:legacy-token"
+            });
+
+            await act.Should().ThrowAsync<CustomTokenExchangeException>();
+            handler.Protected().Verify("SendAsync", Times.Never(),
+                ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>());
+        }
+
+        [Fact]
+        public async Task CustomTokenExchangeAsync_OnDelegation_ExposesActClaim()
+        {
+            // id_token payload {"sub":"auth0|u","act":{"sub":"mcp_client"}}
+            string B64Url(string s)
+            {
+                var bytes = System.Text.Encoding.UTF8.GetBytes(s);
+                return Convert.ToBase64String(bytes).TrimEnd('=').Replace('+', '-').Replace('/', '_');
+            }
+            var idToken = $"{B64Url("{\"alg\":\"RS256\"}")}." +
+                          $"{B64Url("{\"sub\":\"auth0|u\",\"act\":{\"sub\":\"mcp_client\"}}")}.sig";
+
+            var handler = new Mock<HttpMessageHandler>();
+            handler
+                .Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>())
+                .ReturnsAsync(new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = new StringContent(
+                        "{\"access_token\":\"at\",\"id_token\":\"" + idToken + "\",\"expires_in\":3600}")
+                });
+
+            var context = BuildContext(handler.Object, new AuthenticationProperties(), out _);
+
+            var result = await context.CustomTokenExchangeAsync(new CustomTokenExchangeRequest
+            {
+                SubjectToken = "ext-token",
+                SubjectTokenType = "urn:acme:legacy-token",
+                ActorToken = "act-token",
+                ActorTokenType = "urn:acme:actor-token"
+            });
+
+            result.Act.Should().NotBeNull();
+            result.Act!.Sub.Should().Be("mcp_client");
+        }
+
         private static HttpContext BuildContext(
             HttpMessageHandler backchannelHandler,
             AuthenticationProperties properties,

--- a/tests/Auth0.AspNetCore.Authentication.IntegrationTests/TokenClientTests.cs
+++ b/tests/Auth0.AspNetCore.Authentication.IntegrationTests/TokenClientTests.cs
@@ -539,5 +539,141 @@ namespace Auth0.AspNetCore.Authentication.IntegrationTests
             result.Error.Should().Be("invalid_request");
             result.ErrorDescription.Should().Be("no linked account");
         }
+
+        [Fact]
+        public async Task ExchangeCustomToken_SendsExpectedGrantBody()
+        {
+            string capturedBody = string.Empty;
+            var mockHandler = new Mock<HttpMessageHandler>();
+            mockHandler
+                .Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>())
+                .Callback<HttpRequestMessage, CancellationToken>((req, _) =>
+                {
+                    capturedBody = req.Content!.ReadAsStringAsync().GetAwaiter().GetResult();
+                })
+                .ReturnsAsync(new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = new StringContent("{\"access_token\":\"at\",\"expires_in\":3600}")
+                });
+
+            var client = new TokenClient(new HttpClient(mockHandler.Object));
+            await client.ExchangeCustomToken(
+                new Auth0WebAppOptions { Domain = "local.auth0.com", ClientId = "cid", ClientSecret = "secret" },
+                subjectToken: "ext-token",
+                subjectTokenType: "urn:acme:legacy-token",
+                audience: "https://api.example.com",
+                scope: "read:data");
+
+            capturedBody.Should().Contain("grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Atoken-exchange");
+            capturedBody.Should().Contain("client_id=cid");
+            capturedBody.Should().Contain("subject_token=ext-token");
+            capturedBody.Should().Contain("subject_token_type=urn%3Aacme%3Alegacy-token");
+            capturedBody.Should().Contain("audience=https%3A%2F%2Fapi.example.com");
+            capturedBody.Should().Contain("scope=read%3Adata");
+            // CTE selects the issued token type via the Action/profile, so no requested_token_type.
+            capturedBody.Should().NotContain("requested_token_type=");
+        }
+
+        [Fact]
+        public async Task ExchangeCustomToken_SendsActorTokenPair_AndOrganization()
+        {
+            string capturedBody = string.Empty;
+            var mockHandler = new Mock<HttpMessageHandler>();
+            mockHandler
+                .Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>())
+                .Callback<HttpRequestMessage, CancellationToken>((req, _) =>
+                {
+                    capturedBody = req.Content!.ReadAsStringAsync().GetAwaiter().GetResult();
+                })
+                .ReturnsAsync(new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = new StringContent("{\"access_token\":\"at\",\"expires_in\":3600}")
+                });
+
+            var client = new TokenClient(new HttpClient(mockHandler.Object));
+            await client.ExchangeCustomToken(
+                new Auth0WebAppOptions { Domain = "local.auth0.com", ClientId = "cid", ClientSecret = "secret" },
+                subjectToken: "ext-token",
+                subjectTokenType: "urn:acme:legacy-token",
+                actorToken: "act-token",
+                actorTokenType: "urn:acme:actor-token",
+                organization: "org_123");
+
+            capturedBody.Should().Contain("actor_token=act-token");
+            capturedBody.Should().Contain("actor_token_type=urn%3Aacme%3Aactor-token");
+            capturedBody.Should().Contain("organization=org_123");
+        }
+
+        [Fact]
+        public async Task ExchangeCustomToken_OmitsOptionalParams_WhenNotProvided()
+        {
+            string capturedBody = string.Empty;
+            var mockHandler = new Mock<HttpMessageHandler>();
+            mockHandler
+                .Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>())
+                .Callback<HttpRequestMessage, CancellationToken>((req, _) =>
+                {
+                    capturedBody = req.Content!.ReadAsStringAsync().GetAwaiter().GetResult();
+                })
+                .ReturnsAsync(new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = new StringContent("{\"access_token\":\"at\",\"expires_in\":3600}")
+                });
+
+            var client = new TokenClient(new HttpClient(mockHandler.Object));
+            await client.ExchangeCustomToken(
+                new Auth0WebAppOptions { Domain = "local.auth0.com", ClientId = "cid", ClientSecret = "secret" },
+                subjectToken: "ext-token",
+                subjectTokenType: "urn:acme:legacy-token");
+
+            capturedBody.Should().NotContain("audience=");
+            capturedBody.Should().NotContain("scope=");
+            capturedBody.Should().NotContain("organization=");
+            capturedBody.Should().NotContain("actor_token=");
+            capturedBody.Should().NotContain("actor_token_type=");
+        }
+
+        [Fact]
+        public async Task ExchangeCustomToken_ReturnsFailure_WhenRejected()
+        {
+            var mockHandler = new Mock<HttpMessageHandler>();
+            mockHandler
+                .Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>())
+                .ReturnsAsync(new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.Forbidden,
+                    Content = new StringContent("{\"error\":\"invalid_request\",\"error_description\":\"bad profile\"}")
+                });
+
+            var client = new TokenClient(new HttpClient(mockHandler.Object));
+            var result = await client.ExchangeCustomToken(
+                new Auth0WebAppOptions { Domain = "local.auth0.com", ClientId = "cid", ClientSecret = "secret" },
+                subjectToken: "ext-token",
+                subjectTokenType: "urn:acme:legacy-token");
+
+            result.IsSuccess.Should().BeFalse();
+            result.StatusCode.Should().Be((int)HttpStatusCode.Forbidden);
+            result.Error.Should().Be("invalid_request");
+            result.ErrorDescription.Should().Be("bad profile");
+        }
     }
 }


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

This PR adds support for [Custom Token Exchange](https://auth0.com/docs/authenticate/custom-token-exchange) (RFC 8693) to the SDK, letting an application exchange an existing external/custom security token for Auth0 tokens without a browser redirect. The primary use cases are delegation/impersonation and agent-identity scenarios. It requires a configured Custom Token Exchange Profile and a validation Action in the Auth0 tenant.

The feature is exposed through a new `HttpContext.CustomTokenExchangeAsync(CustomTokenExchangeRequest)` extension method:

- `CustomTokenExchangeRequest` describes the exchange: `SubjectToken` and `SubjectTokenType` (required), plus optional `Audience`, `Scope`, `ActorToken`/`ActorTokenType` (delegation pair), and `Organization`.
- `CustomTokenExchangeResult` returns the exchanged tokens (`AccessToken`, `IdToken`, `RefreshToken`, `ExpiresIn`, `Scope`) and the decoded `act` (actor) claim (`Act`) for delegation flows.
- `CustomTokenExchangeException` is thrown on client-side validation failures or token-endpoint rejections, carrying `StatusCode`, `Error`, and `ErrorDescription` for the latter. It never carries token-bearing bytes.

- **Stateless by design.** `CustomTokenExchangeAsync` performs the exchange and returns the tokens but has **no session side-effects** — it does not sign the user in or write any cookie. The caller decides what (if anything) to persist.
- **Client-side validation** (`CustomTokenExchangeRequestValidator`) runs before any network call: `subject_token` must be non-empty and must not include a `Bearer ` prefix; `subject_token_type` must be a valid URI (URL or URN), 10–100 characters, and the reserved `urn:ietf:` and `urn:auth0:` namespaces are rejected; an actor token requires its matching type and vice-versa.
- **Delegation / impersonation.** When an actor token pair is supplied, the `act` claim from the returned ID token is decoded and exposed on `result.Act` (`ActClaimReader`). The outermost `Sub` is the current actor; nested `Act` values are prior actors and are informational only. Auth0 suppresses the refresh token in delegation flows.

The exchange is implemented on `TokenClient` (`ExchangeCustomToken`) and integrates with the SDK's existing domain resolution (including Multiple Custom Domain support) and backchannel client.

### References

- [Custom Token Exchange documentation](https://auth0.com/docs/authenticate/custom-token-exchange)

### Testing

Unit/integration tests were added covering the new functionality:
- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `main`
