### PR TITLE
chore: add OpenSSF Scorecard workflow

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,76 @@
+name: Scorecard analysis
+
+# Runs OpenSSF Scorecard supply-chain analysis directly via ossf/scorecard-action
+# (no composite wrapper, no cross-org dependency). All action refs are SHA-pinned.
+#
+# Scorecard requirements
+# ──────────────────────
+# • Must run on push to the default branch or a schedule event — NOT pull_request.
+#   The if: condition below enforces this.
+# • The checkout step MUST set persist-credentials: false (required by Scorecard's
+#   security model to avoid leaking the GITHUB_TOKEN into the analysis environment).
+# • publish_results: true publishes to the public Scorecard API and enables the
+#   Scorecard badge. It requires id-token: write on the job AND a push/schedule
+#   event (not a PR). Set to 'false' to keep results private (id-token can then
+#   be omitted from the job permissions).
+
+on:
+  push:
+    branches: [main]
+  schedule:
+    - cron: '30 1 * * 6'   # weekly, Saturday 01:30 UTC
+
+permissions: read-all   # default: restrict everything; the job overrides what it needs
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request'   # Scorecard must run on push/schedule only
+    permissions:
+      security-events: write   # upload SARIF to the Security tab / Code Scanning dashboard
+      id-token: write           # OIDC token for Scorecard's public API publishing (publish_results: true)
+                                # Remove this line if you set publish_results: false
+      contents: read            # checkout the repository
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false   # required by Scorecard — do not remove
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          # publish_results: true publishes to the Scorecard public dataset and enables the badge.
+          # Requires id-token: write above and a push/schedule event.
+          # Set to 'false' (and remove id-token: write) to keep results private.
+          publish_results: true
+
+      # Upload SARIF as a workflow artifact (optional — comment out to disable).
+      # https://docs.github.com/en/actions/advanced-guides/storing-workflow-data-as-artifacts
+      - name: Upload artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      # Upload SARIF to GitHub Code Scanning dashboard (optional — comment out to disable).
+      - name: Upload to code-scanning
+        uses: github/codeql-action/upload-sarif@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
+        with:
+          sarif_file: results.sarif
+          category: scorecard
+
+      - name: Result
+        if: always()
+        shell: bash
+        run: |
+          if [ "${{ job.status }}" = "success" ]; then
+            echo "::notice title=Scorecard::✅ OpenSSF Scorecard analysis complete — results uploaded to Security tab."
+          else
+            echo "::error title=Scorecard::❌ OpenSSF Scorecard analysis failed."
+          fi


### PR DESCRIPTION
## ✏️ Changes

This pull request adds a security hardening workflow from the unified-pipeline-template (https://github.com/atko-cic/unified-pipeline-template/security). **No functional changes are introduced.**



### OpenSSF Scorecard

This PR adds `.github/workflows/scorecard.yml` from the unified-pipeline-template. It calls `ossf/scorecard-action` **directly** (SHA-pinned to v2.4.3) — no composite action wrapper, no cross-org dependency. Results are uploaded to the Code Scanning dashboard via `github/codeql-action/upload-sarif`.

### Placeholders to fill in before merging

| Placeholder | Description |
|---|---|
| `publish_results: true` | Set to `false` to keep Scorecard results private and remove the `id-token: write` permission. When `true`, results are published to the public Scorecard API (enables the badge) — requires `id-token: write` and a push/schedule event (not a PR) |



## 🔮 Type of Change

- [x] Standard

## 🔗 References

https://auth0team.atlassian.net/browse/SEPIO-1674

- [x] I added at least one link (task, slack thread, etc) to explain why this change is needed.

## 📖 Documentation

No user-facing changes have been introduced.

- [x] I reflected this change in the (internal and/or user-facing) documentation, or added an explanation for why no documentation update is needed.

## 🎯 Testing

This change adds a CI workflow only; validated by the workflow running on this PR.

- [x] This change has integration, unit, or performance test coverage, or I explained why not.

## 🚀 Deployment

- [x] This change can support multiple releases of the code serving traffic at the same time.

## 🔥 Rollback

Reverting this PR removes the added workflow file — no further action required.

- [x] I explained what the rollback for this change will look like.