### PR TITLE
feat: enforce upstream IdP session_expiry (IPSIE SL1) ceiling

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -359,17 +359,19 @@ Enabling the claim is a connection-level prerequisite done in Auth0, not in your
 - On every session **read**, if the ceiling has been reached the SDK rejects the principal and signs the user out - the request proceeds as if there were no session, which triggers your app's existing redirect-to-login on `[Authorize]` routes.
 - Before using a refresh token the SDK short-circuits once the ceiling is reached, so an expired session is never silently extended by a background refresh.
 
+> **Note:** `GetAccessTokenForConnectionAsync` (Token Vault / federated connection tokens) is **not** gated by the session ceiling. Those tokens follow the upstream IdP's own lifetime, so a passed `session_expiry` ceiling does not block or tear down that exchange.
+
 This **layers on top of** the standard ASP.NET Core cookie idle and absolute lifetimes; it does not replace them. The session ends at whichever limit is hit first - idle timeout, absolute cookie lifetime, or the upstream `session_expiry` ceiling.
 
 A small **negative leeway** (~30 seconds) is applied to the comparison, so the session is treated as expired slightly *before* the wall-clock ceiling rather than after, absorbing minor clock skew between your server and Auth0.
 
 ### Reading the ceiling in your app
 
-The SDK enforces the ceiling for you; if you also want it for app-level logic (for example a "your session ends in N minutes" countdown), read it back with `GetSessionExpiry`:
+The SDK enforces the ceiling for you; if you also want it for app-level logic (for example a "your session ends in N minutes" countdown), read it back with `GetSessionExpiryAsync`:
 
 ```csharp
 // Unix seconds ceiling, or null when the connection emitted no session_expiry claim.
-long? expiresAt = HttpContext.GetSessionExpiry();
+long? expiresAt = await HttpContext.GetSessionExpiryAsync();
 
 if (expiresAt is long ceiling)
 {
@@ -378,7 +380,7 @@ if (expiresAt is long ceiling)
 }
 ```
 
-`GetSessionExpiry` returns `null` when there is no ceiling (the connection did not emit the claim, or the user is not authenticated). It is a read-only convenience over the same value the SDK enforces internally - it does not change any expiry behavior.
+`GetSessionExpiryAsync` returns `null` when there is no ceiling (the connection did not emit the claim, or the user is not authenticated). It reads the persisted value the SDK enforces internally - the same source used for enforcement, so it stays accurate even after a token refresh that does not re-emit the claim - and it does not change any expiry behavior.
 
 ### Fail-open on nonsensical values
 
@@ -388,7 +390,7 @@ Only a sane, positive seconds value enforces a ceiling. Any value that cannot be
 - zero or negative values,
 - values at or above `10,000,000,000` - guarding against a **milliseconds** value emitted by mistake, which would otherwise read as a date thousands of years out and silently switch enforcement off (no real seconds value is that large; `10,000,000,000` seconds is the year 2286).
 
-The one case that fails the login outright is a *valid, positive* ceiling that is already at or before the token's issued-at time (`iat`) - that indicates a session created already-expired, so login is rejected rather than immediately bounced.
+The one case that fails the login outright is a *valid, positive* ceiling that is already at or before the token's issued-at time (`iat`, plus the same ~30s leeway used when enforcing) - that indicates a session created already-expired, so login is rejected rather than persisting a session that would be rejected on its very next read. When the ID token carries no `iat`, the current time is used as the reference.
 
 > :warning: **Upgrade note:** once a connection starts emitting `session_expiry`, an authenticated session read that previously always succeeded can now resolve to "no session" the moment the ceiling passes. This is intentional and flows through your existing authentication challenge (redirect to login); no code change is required, but be aware that a request can transition from authenticated to unauthenticated purely due to the passage of time.
 

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -6,6 +6,7 @@
   - [Configuring the refresh leeway](#configuring-the-refresh-leeway)
   - [Updating claims and observing a successful refresh](#updating-claims-and-observing-a-successful-refresh)
 - [Server-side session storage](#server-side-session-storage)
+- [Session expiry from the upstream IdP](#session-expiry-from-the-upstream-idp)
 - [Multi-Resource Refresh Tokens (MRRT)](#multi-resource-refresh-tokens-mrrt)
   - [Requesting a token for another audience](#requesting-a-token-for-another-audience)
   - [Configuring default scopes per audience](#configuring-default-scopes-per-audience)
@@ -288,6 +289,8 @@ Server-side session storage is a built-in ASP.NET Core capability (`CookieAuthen
 
 Keep the **default cookie-based session** when you want to stay stateless and avoid running extra infrastructure - for most applications it is the simplest and best choice. Server-side storage is an opt-in for the cases above, and it requires a store that is shared across all your instances (for example a distributed cache) when you run more than one.
 
+Regardless of where the session is stored, its lifetime can also be capped by the upstream identity provider - see [Session expiry from the upstream IdP](#session-expiry-from-the-upstream-idp).
+
 ### Providing the ITicketStore
 
 You can pass either a type (resolved from the dependency injection container, so it may depend on other registered services such as `IDistributedCache` and `IDataProtectionProvider`) or an already-constructed instance:
@@ -343,6 +346,51 @@ public class RedisTicketStore : ITicketStore
 > :warning: **Running multiple instances:** the store must be shared across them (e.g. a distributed cache such as Redis or SQL Server). An in-memory store only works for a single instance and will cause users to appear logged out when their requests are served by a different instance. Likewise, the [Data Protection keys must be persisted and shared](https://learn.microsoft.com/en-us/aspnet/core/security/data-protection/configuration/overview) across all instances - otherwise tickets become unreadable after a key rotation, app restart, or when served by a different node.
 >
 > :warning: **Protecting the ticket:** it holds sensitive data (claims, access and refresh tokens). Encrypting the payload with `IDataProtector` as shown above means an attacker who gains read access to the cache cannot recover those tokens. Treat the cache backend itself as sensitive too: restrict access and enable encryption in transit (e.g. Redis AUTH + TLS) and at rest.
+
+## Session expiry from the upstream IdP
+
+When Auth0 brokers an upstream identity provider (for example an enterprise or social connection) that enforces its **own** session lifetime, that lifetime should cap the session in your application too - otherwise your app could keep a user signed in long after the upstream IdP considers their session over. To support this, Auth0 can emit a `session_expiry` claim on the ID token: an absolute ceiling, in **Unix seconds**, after which the session must no longer be honored.
+
+Enabling the claim is a connection-level prerequisite done in Auth0, not in your app. The connection must have the `id_token_session_expiry_supported` option turned on so the `session_expiry` claim is present on the ID token issued at login. (During development you can also emit it from a Post-Login Action for testing.) When the claim is **absent** the SDK behaves exactly as before - there is nothing to opt into in code.
+
+**Enforcement is automatic and transparent.** You do not call anything to turn it on:
+
+- At login the SDK reads `session_expiry` from the ID token and persists it alongside the session (kept separate from the tokens so it survives token refreshes untouched).
+- On every session **read**, if the ceiling has been reached the SDK rejects the principal and signs the user out - the request proceeds as if there were no session, which triggers your app's existing redirect-to-login on `[Authorize]` routes.
+- Before using a refresh token the SDK short-circuits once the ceiling is reached, so an expired session is never silently extended by a background refresh.
+
+This **layers on top of** the standard ASP.NET Core cookie idle and absolute lifetimes; it does not replace them. The session ends at whichever limit is hit first - idle timeout, absolute cookie lifetime, or the upstream `session_expiry` ceiling.
+
+A small **negative leeway** (~30 seconds) is applied to the comparison, so the session is treated as expired slightly *before* the wall-clock ceiling rather than after, absorbing minor clock skew between your server and Auth0.
+
+### Reading the ceiling in your app
+
+The SDK enforces the ceiling for you; if you also want it for app-level logic (for example a "your session ends in N minutes" countdown), read it back with `GetSessionExpiry`:
+
+```csharp
+// Unix seconds ceiling, or null when the connection emitted no session_expiry claim.
+long? expiresAt = HttpContext.GetSessionExpiry();
+
+if (expiresAt is long ceiling)
+{
+    var remaining = DateTimeOffset.FromUnixTimeSeconds(ceiling) - DateTimeOffset.UtcNow;
+    // ... surface `remaining` in the UI, warn before expiry, etc.
+}
+```
+
+`GetSessionExpiry` returns `null` when there is no ceiling (the connection did not emit the claim, or the user is not authenticated). It is a read-only convenience over the same value the SDK enforces internally - it does not change any expiry behavior.
+
+### Fail-open on nonsensical values
+
+Only a sane, positive seconds value enforces a ceiling. Any value that cannot be a real forward-in-time ceiling is ignored and treated as **"no ceiling"** (fail open) rather than locking the user out:
+
+- non-numeric / unparseable values,
+- zero or negative values,
+- values at or above `10,000,000,000` - guarding against a **milliseconds** value emitted by mistake, which would otherwise read as a date thousands of years out and silently switch enforcement off (no real seconds value is that large; `10,000,000,000` seconds is the year 2286).
+
+The one case that fails the login outright is a *valid, positive* ceiling that is already at or before the token's issued-at time (`iat`) - that indicates a session created already-expired, so login is rejected rather than immediately bounced.
+
+> :warning: **Upgrade note:** once a connection starts emitting `session_expiry`, an authenticated session read that previously always succeeded can now resolve to "no session" the moment the ceiling passes. This is intentional and flows through your existing authentication challenge (redirect to login); no code change is required, but be aware that a request can transition from authenticated to unauthenticated purely due to the passage of time.
 
 ## Multi-Resource Refresh Tokens (MRRT)
 

--- a/src/Auth0.AspNetCore.Authentication/Auth0Constants.cs
+++ b/src/Auth0.AspNetCore.Authentication/Auth0Constants.cs
@@ -38,5 +38,13 @@
         /// the wall-clock ceiling, never after.
         /// </summary>
         internal static readonly long SessionExpiryLeewaySeconds = 30;
+
+        /// <summary>
+        /// Upper bound (exclusive) for a valid <c>session_expiry</c> value, in Unix seconds. A value
+        /// at or above this is rejected and treated as "no ceiling": a millisecond value emitted by
+        /// mistake would read as a date thousands of years out and silently switch off enforcement.
+        /// No real seconds value is this large (10,000,000,000 seconds is the year 2286).
+        /// </summary>
+        internal static readonly long SessionExpiryMaxSeconds = 10_000_000_000;
     }
 }

--- a/src/Auth0.AspNetCore.Authentication/Auth0Constants.cs
+++ b/src/Auth0.AspNetCore.Authentication/Auth0Constants.cs
@@ -19,5 +19,24 @@
         /// Key used to store the resolved domain in the authentication properties.
         /// </summary>
         internal static readonly string ResolvedDomainKey = "auth0:resolved-domain";
+
+        /// <summary>
+        /// Name of the ID token claim carrying the upstream IdP session ceiling (Unix seconds).
+        /// Emitted when the connection option <c>id_token_session_expiry_supported</c> is enabled.
+        /// </summary>
+        public static readonly string SessionExpiryClaim = "session_expiry";
+
+        /// <summary>
+        /// Key used to persist the <c>session_expiry</c> ceiling (Unix seconds) in the authentication
+        /// properties, kept separate from the token entries so it survives refreshes untouched.
+        /// </summary>
+        internal static readonly string SessionExpiryItemKey = "auth0:session_expiry";
+
+        /// <summary>
+        /// Negative leeway (in seconds) applied when comparing against the <c>session_expiry</c>
+        /// ceiling, to account for clock skew: the session is treated as expired slightly before
+        /// the wall-clock ceiling, never after.
+        /// </summary>
+        internal static readonly long SessionExpiryLeewaySeconds = 30;
     }
 }

--- a/src/Auth0.AspNetCore.Authentication/AuthenticationBuilderExtensions.cs
+++ b/src/Auth0.AspNetCore.Authentication/AuthenticationBuilderExtensions.cs
@@ -152,6 +152,18 @@ namespace Auth0.AspNetCore.Authentication
                     }
                 }
 
+                // Upstream-IdP session ceiling (session_expiry). Once the ceiling is reached the
+                // session must behave identically to "no session": reject the principal and sign out
+                // so the app's existing challenge/redirect re-authenticates transparently. Enforced on
+                // every read, ahead of any refresh. Absent ceiling falls through to existing behavior.
+                if (SessionExpiryHelpers.IsSessionExpired(context.Properties, DateTimeOffset.UtcNow.ToUnixTimeSeconds()))
+                {
+                    context.RejectPrincipal();
+                    await context.HttpContext.SignOutAsync();
+
+                    return;
+                }
+
                 if (logoutTokenHandler != null)
                 {
                     await VerifyBackchannelLogoutSupport(context.HttpContext, oidcOptions);

--- a/src/Auth0.AspNetCore.Authentication/HttpContextExtensions.cs
+++ b/src/Auth0.AspNetCore.Authentication/HttpContextExtensions.cs
@@ -216,13 +216,10 @@ namespace Auth0.AspNetCore.Authentication
 
             var properties = authenticateResult.Properties;
 
-            // Hard pre-check against the upstream-IdP session ceiling (session_expiry): once reached,
-            // never serve a cached token or call the token endpoint — surface no-session (null) so the
-            // caller's re-auth path runs. Absent ceiling falls through to existing behavior.
-            if (SessionExpiryHelpers.IsSessionExpired(properties, DateTimeOffset.UtcNow.ToUnixTimeSeconds()))
-            {
-                return null;
-            }
+            // Unlike GetAccessTokenAsync, connection (Token Vault) tokens are intentionally NOT gated
+            // by the session_expiry ceiling: they follow the upstream IdP's own token lifetime, so a
+            // passed RP session ceiling must not block or tear down this exchange. This matches the
+            // auth0-server-python reference (test_get_access_token_for_connection_not_gated_by_ceiling).
 
             // Normalize the login hint so the cache key matches what is actually sent to the token
             // endpoint, which omits an empty/whitespace hint (see TokenClient). Without this, a "" hint
@@ -353,18 +350,31 @@ namespace Auth0.AspNetCore.Authentication
         }
 
         /// <summary>
-        /// Retrieves the upstream-IdP session ceiling (<c>session_expiry</c>, Unix seconds) from the
-        /// authenticated user's claims, when the connection emitted one. This is the read-back of the
-        /// value the SDK enforces internally: use it for app-level logic such as a session countdown.
-        /// Returns <c>null</c> when the claim is absent (no ceiling) or the user is not authenticated.
+        /// Retrieves the upstream-IdP session ceiling (<c>session_expiry</c>, Unix seconds) that the
+        /// SDK persisted on the session at login, when the connection emitted one. This reads the exact
+        /// value the SDK enforces internally — the persisted session item, not the ID token claim — so
+        /// the read-back stays consistent with enforcement even after a token refresh that does not
+        /// re-emit the claim. Use it for app-level logic such as a session countdown. Returns
+        /// <c>null</c> when there is no persisted ceiling or the user is not authenticated.
         /// </summary>
         /// <param name="context">The current <see cref="HttpContext"/>.</param>
+        /// <param name="scheme">The Auth0 authentication scheme. Defaults to <see cref="Auth0Constants.AuthenticationScheme"/>.</param>
         /// <returns>The session ceiling in Unix seconds, or <c>null</c> when there is none.</returns>
-        public static long? GetSessionExpiry(this HttpContext context)
+        public static async Task<long?> GetSessionExpiryAsync(this HttpContext context, string? scheme = null)
         {
-            var raw = context.User?.FindFirst(Auth0Constants.SessionExpiryClaim)?.Value;
+            scheme ??= Auth0Constants.AuthenticationScheme;
 
-            return SessionExpiryHelpers.TryParseCeiling(raw, out var seconds) ? seconds : (long?)null;
+            var options = context.RequestServices.GetRequiredService<IOptionsSnapshot<Auth0WebAppOptions>>().Get(scheme);
+
+            var authenticateResult = await context.AuthenticateAsync(options.CookieAuthenticationScheme).ConfigureAwait(false);
+            if (!authenticateResult.Succeeded || authenticateResult.Properties == null)
+            {
+                return null;
+            }
+
+            return SessionExpiryHelpers.TryGetPersistedCeiling(authenticateResult.Properties, out var seconds)
+                ? seconds
+                : (long?)null;
         }
 
         /// <summary>

--- a/src/Auth0.AspNetCore.Authentication/HttpContextExtensions.cs
+++ b/src/Auth0.AspNetCore.Authentication/HttpContextExtensions.cs
@@ -78,6 +78,15 @@ namespace Auth0.AspNetCore.Authentication
             }
 
             var properties = authenticateResult.Properties;
+
+            // Hard pre-check against the upstream-IdP session ceiling (session_expiry): once reached,
+            // never serve a cached token or call the token endpoint — surface no-session (null) so the
+            // caller's re-auth path runs. Absent ceiling falls through to existing behavior.
+            if (SessionExpiryHelpers.IsSessionExpired(properties, DateTimeOffset.UtcNow.ToUnixTimeSeconds()))
+            {
+                return null;
+            }
+
             var matchesPrimaryToken = MatchesPrimaryToken(audience, mergedScope, optionsWithAccessToken);
 
             // 1. Try to satisfy the request from what is already stored in the session,
@@ -207,6 +216,14 @@ namespace Auth0.AspNetCore.Authentication
 
             var properties = authenticateResult.Properties;
 
+            // Hard pre-check against the upstream-IdP session ceiling (session_expiry): once reached,
+            // never serve a cached token or call the token endpoint — surface no-session (null) so the
+            // caller's re-auth path runs. Absent ceiling falls through to existing behavior.
+            if (SessionExpiryHelpers.IsSessionExpired(properties, DateTimeOffset.UtcNow.ToUnixTimeSeconds()))
+            {
+                return null;
+            }
+
             // Normalize the login hint so the cache key matches what is actually sent to the token
             // endpoint, which omits an empty/whitespace hint (see TokenClient). Without this, a "" hint
             // and a null hint would address the same server-side identity but cache under different keys.
@@ -333,6 +350,21 @@ namespace Auth0.AspNetCore.Authentication
                 Scope = response.Scope,
                 Act = ActClaimReader.TryRead(response.IdToken)
             };
+        }
+
+        /// <summary>
+        /// Retrieves the upstream-IdP session ceiling (<c>session_expiry</c>, Unix seconds) from the
+        /// authenticated user's claims, when the connection emitted one. This is the read-back of the
+        /// value the SDK enforces internally: use it for app-level logic such as a session countdown.
+        /// Returns <c>null</c> when the claim is absent (no ceiling) or the user is not authenticated.
+        /// </summary>
+        /// <param name="context">The current <see cref="HttpContext"/>.</param>
+        /// <returns>The session ceiling in Unix seconds, or <c>null</c> when there is none.</returns>
+        public static long? GetSessionExpiry(this HttpContext context)
+        {
+            var raw = context.User?.FindFirst(Auth0Constants.SessionExpiryClaim)?.Value;
+
+            return SessionExpiryHelpers.TryParseCeiling(raw, out var seconds) ? seconds : (long?)null;
         }
 
         /// <summary>

--- a/src/Auth0.AspNetCore.Authentication/OpenIdConnectEventsFactory.cs
+++ b/src/Auth0.AspNetCore.Authentication/OpenIdConnectEventsFactory.cs
@@ -219,8 +219,10 @@ namespace Auth0.AspNetCore.Authentication
         /// Reads the upstream-IdP <c>session_expiry</c> ceiling from the freshly validated ID token
         /// and persists it on the session so it can be enforced on every subsequent read/refresh.
         /// Absent claim: nothing is persisted (no ceiling — existing behavior). Present but already
-        /// past at login (<c>session_expiry &lt;= iat</c>): fails rather than persisting an
-        /// already-expired session.
+        /// past at login: fails rather than persisting a session the read-gate would reject on its
+        /// very next read. The login check applies the same negative leeway as the read-gate
+        /// (<see cref="Auth0Constants.SessionExpiryLeewaySeconds"/>), and falls back to the current
+        /// time when the ID token carries no <c>iat</c>.
         /// </summary>
         private static void PersistSessionExpiry(TokenValidatedContext context)
         {
@@ -235,11 +237,18 @@ namespace Auth0.AspNetCore.Authentication
             var iatRaw = context.SecurityToken.Claims
                 .FirstOrDefault(c => c.Type == JwtRegisteredClaimNames.Iat)?.Value;
 
-            if (SessionExpiryHelpers.TryParseCeiling(iatRaw, out var iat) && sessionExpiry <= iat)
+            // iat is a plain issued-at timestamp, not a ceiling, so parse it directly rather than
+            // through TryParseCeiling (which applies ceiling-specific sanity bounds). When it is
+            // absent, fall back to "now" so an already-past ceiling is still rejected at login.
+            var reference = long.TryParse(iatRaw, NumberStyles.Integer, CultureInfo.InvariantCulture, out var iat)
+                ? iat
+                : DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+
+            if (sessionExpiry <= reference + Auth0Constants.SessionExpiryLeewaySeconds)
             {
                 throw new IdTokenValidationException(
-                    $"Session Expiry (session_expiry) claim in the ID token indicates the session is already " +
-                    $"past its ceiling at login. session_expiry ({sessionExpiry}) is not after iat ({iat}).");
+                    "The session_expiry claim in the ID token indicates the session is already past its " +
+                    "ceiling at login.");
             }
 
             if (context.Properties != null)

--- a/src/Auth0.AspNetCore.Authentication/OpenIdConnectEventsFactory.cs
+++ b/src/Auth0.AspNetCore.Authentication/OpenIdConnectEventsFactory.cs
@@ -3,6 +3,8 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.IdentityModel.Tokens;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
+using System.IdentityModel.Tokens.Jwt;
 using System.Linq;
 using System.Threading.Tasks;
 using Auth0.AspNetCore.Authentication.PushedAuthorizationRequest;
@@ -166,6 +168,7 @@ namespace Auth0.AspNetCore.Authentication
                 try
                 {
                     IdTokenValidator.Validate(auth0Options, context.SecurityToken, context.Properties?.Items);
+                    PersistSessionExpiry(context);
                 }
                 catch (IdTokenValidationException ex)
                 {
@@ -210,6 +213,40 @@ namespace Auth0.AspNetCore.Authentication
 
                 return Task.CompletedTask;
             };
+        }
+
+        /// <summary>
+        /// Reads the upstream-IdP <c>session_expiry</c> ceiling from the freshly validated ID token
+        /// and persists it on the session so it can be enforced on every subsequent read/refresh.
+        /// Absent claim: nothing is persisted (no ceiling — existing behavior). Present but already
+        /// past at login (<c>session_expiry &lt;= iat</c>): fails rather than persisting an
+        /// already-expired session.
+        /// </summary>
+        private static void PersistSessionExpiry(TokenValidatedContext context)
+        {
+            var sessionExpiryRaw = context.SecurityToken.Claims
+                .FirstOrDefault(c => c.Type == Auth0Constants.SessionExpiryClaim)?.Value;
+
+            if (!SessionExpiryHelpers.TryParseCeiling(sessionExpiryRaw, out var sessionExpiry))
+            {
+                return;
+            }
+
+            var iatRaw = context.SecurityToken.Claims
+                .FirstOrDefault(c => c.Type == JwtRegisteredClaimNames.Iat)?.Value;
+
+            if (SessionExpiryHelpers.TryParseCeiling(iatRaw, out var iat) && sessionExpiry <= iat)
+            {
+                throw new IdTokenValidationException(
+                    $"Session Expiry (session_expiry) claim in the ID token indicates the session is already " +
+                    $"past its ceiling at login. session_expiry ({sessionExpiry}) is not after iat ({iat}).");
+            }
+
+            if (context.Properties != null)
+            {
+                context.Properties.Items[Auth0Constants.SessionExpiryItemKey] =
+                    sessionExpiry.ToString(CultureInfo.InvariantCulture);
+            }
         }
 
 

--- a/src/Auth0.AspNetCore.Authentication/SessionExpiryHelpers.cs
+++ b/src/Auth0.AspNetCore.Authentication/SessionExpiryHelpers.cs
@@ -14,6 +14,15 @@ namespace Auth0.AspNetCore.Authentication
         /// Parses a raw <c>session_expiry</c> value (Unix seconds) into a <see cref="long"/>.
         /// Tolerant of a missing, empty, or malformed value: returns <c>false</c> rather than throwing,
         /// so a session with no (or an unreadable) ceiling falls through to existing behavior.
+        /// Only a sane positive seconds value enforces a ceiling; every nonsensical value falls
+        /// through to "no ceiling" (fail open) rather than locking the user out:
+        /// <list type="bullet">
+        ///   <item>non-numeric (a string) — cannot be parsed;</item>
+        ///   <item>zero or negative — not a real forward-in-time ceiling;</item>
+        ///   <item>at or above <see cref="Auth0Constants.SessionExpiryMaxSeconds"/> — a millisecond
+        ///     value emitted by mistake would otherwise read as a date thousands of years out and
+        ///     silently switch off enforcement.</item>
+        /// </list>
         /// </summary>
         public static bool TryParseCeiling(string? raw, out long seconds)
         {
@@ -28,7 +37,14 @@ namespace Auth0.AspNetCore.Authentication
             // value serialized as "1712345678.0", matching how auth_time is read elsewhere.
             if (double.TryParse(raw, NumberStyles.Any, CultureInfo.InvariantCulture, out var parsed))
             {
-                seconds = (long)parsed;
+                var candidate = (long)parsed;
+
+                if (candidate <= 0 || candidate >= Auth0Constants.SessionExpiryMaxSeconds)
+                {
+                    return false;
+                }
+
+                seconds = candidate;
                 return true;
             }
 

--- a/src/Auth0.AspNetCore.Authentication/SessionExpiryHelpers.cs
+++ b/src/Auth0.AspNetCore.Authentication/SessionExpiryHelpers.cs
@@ -1,0 +1,71 @@
+using Microsoft.AspNetCore.Authentication;
+using System.Globalization;
+
+namespace Auth0.AspNetCore.Authentication
+{
+    /// <summary>
+    /// Pure helpers for the upstream-IdP <c>session_expiry</c> ceiling. All comparisons are in
+    /// integer Unix seconds; callers convert wall-clock time to seconds at the boundary and stay
+    /// in seconds from there.
+    /// </summary>
+    internal static class SessionExpiryHelpers
+    {
+        /// <summary>
+        /// Parses a raw <c>session_expiry</c> value (Unix seconds) into a <see cref="long"/>.
+        /// Tolerant of a missing, empty, or malformed value: returns <c>false</c> rather than throwing,
+        /// so a session with no (or an unreadable) ceiling falls through to existing behavior.
+        /// </summary>
+        public static bool TryParseCeiling(string? raw, out long seconds)
+        {
+            seconds = 0;
+
+            if (string.IsNullOrWhiteSpace(raw))
+            {
+                return false;
+            }
+
+            // The claim is an integer number of seconds; parse via double to tolerate a
+            // value serialized as "1712345678.0", matching how auth_time is read elsewhere.
+            if (double.TryParse(raw, NumberStyles.Any, CultureInfo.InvariantCulture, out var parsed))
+            {
+                seconds = (long)parsed;
+                return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Returns whether the ceiling has been reached, applying the negative clock-skew leeway:
+        /// the session is treated as expired slightly before the wall-clock ceiling, never after.
+        /// </summary>
+        public static bool IsExpired(long ceilingSeconds, long nowSeconds)
+        {
+            return nowSeconds >= ceilingSeconds - Auth0Constants.SessionExpiryLeewaySeconds;
+        }
+
+        /// <summary>
+        /// Reads the persisted ceiling from the session's authentication properties.
+        /// Returns <c>false</c> when the session has no persisted ceiling (a session created before
+        /// this feature, or under a connection without the option enabled) — which must never be
+        /// treated as expired.
+        /// </summary>
+        public static bool TryGetPersistedCeiling(AuthenticationProperties properties, out long seconds)
+        {
+            seconds = 0;
+
+            return properties.Items.TryGetValue(Auth0Constants.SessionExpiryItemKey, out var raw)
+                && TryParseCeiling(raw, out seconds);
+        }
+
+        /// <summary>
+        /// The single revocation gate: whether the persisted <c>session_expiry</c> ceiling has been
+        /// reached as of <paramref name="nowSeconds"/>. A session with no persisted ceiling is never
+        /// expired by this gate (falls through to existing idle/absolute behavior).
+        /// </summary>
+        public static bool IsSessionExpired(AuthenticationProperties properties, long nowSeconds)
+        {
+            return TryGetPersistedCeiling(properties, out var ceiling) && IsExpired(ceiling, nowSeconds);
+        }
+    }
+}

--- a/tests/Auth0.AspNetCore.Authentication.IntegrationTests/Auth0MiddlewareTests.cs
+++ b/tests/Auth0.AspNetCore.Authentication.IntegrationTests/Auth0MiddlewareTests.cs
@@ -1099,6 +1099,98 @@ namespace Auth0.AspNetCore.Authentication.IntegrationTests
         }
 
         [Fact]
+        public async Task Should_Persist_And_Expose_SessionExpiry_When_Present_In_IdToken()
+        {
+            var nonce = "";
+            var configuration = TestConfiguration.GetConfiguration();
+            var domain = configuration["Auth0:Domain"];
+            var clientId = configuration["Auth0:ClientId"];
+            var sessionExpiry = DateTimeOffset.UtcNow.AddHours(8).ToUnixTimeSeconds();
+
+            var mockHandler = new OidcMockBuilder()
+                .MockOpenIdConfig()
+                .MockJwks()
+                .MockToken(() => JwtUtils.GenerateToken(1, $"https://{domain}/", clientId, null, nonce, sessionExpiry: sessionExpiry), (me) => me.HasAuth0ClientHeader())
+                .Build();
+
+            using (var server = TestServerBuilder.CreateServer(opt =>
+            {
+                opt.Backchannel = new HttpClient(mockHandler.Object);
+            }))
+            {
+                using (var client = server.CreateClient())
+                {
+                    var loginResponse = (await client.SendAsync($"{TestServerBuilder.Host}/{TestServerBuilder.Login}"));
+                    var setCookie = Assert.Single(loginResponse.Headers, h => h.Key == "Set-Cookie");
+
+                    var queryParameters = UriUtils.GetQueryParams(loginResponse.Headers.Location);
+                    nonce = queryParameters["nonce"];
+                    var state = queryParameters["state"];
+
+                    var message = new HttpRequestMessage(HttpMethod.Get, $"{TestServerBuilder.Host}/{TestServerBuilder.Callback}?state={state}&nonce={nonce}&code=123");
+
+                    var callbackResponse = (await client.SendAsync(message, setCookie.Value));
+
+                    var response = await client.SendAsync($"{TestServerBuilder.Host}/{TestServerBuilder.Process}", callbackResponse.Headers.GetValues("Set-Cookie"));
+                    var content = JObject.Parse(await response.Content.ReadAsStringAsync());
+
+                    content.GetValue("SessionExpiry").Value<long>().Should().Be(sessionExpiry);
+                }
+            }
+        }
+
+        [Fact]
+        public async Task Should_Fail_Login_When_SessionExpiry_Already_Past_At_Login()
+        {
+            var nonce = "";
+            var configuration = TestConfiguration.GetConfiguration();
+            var domain = configuration["Auth0:Domain"];
+            var clientId = configuration["Auth0:ClientId"];
+            // session_expiry before the token's iat (now) => already past its ceiling at login.
+            var sessionExpiry = DateTimeOffset.UtcNow.AddHours(-1).ToUnixTimeSeconds();
+
+            var mockHandler = new OidcMockBuilder()
+                .MockOpenIdConfig()
+                .MockJwks()
+                .MockToken(() => JwtUtils.GenerateToken(1, $"https://{domain}/", clientId, null, nonce, sessionExpiry: sessionExpiry), (me) => me.HasAuth0ClientHeader())
+                .Build();
+
+            using (var server = TestServerBuilder.CreateServer(opt =>
+            {
+                opt.Backchannel = new HttpClient(mockHandler.Object);
+            }))
+            {
+                using (var client = server.CreateClient())
+                {
+                    var loginResponse = (await client.SendAsync($"{TestServerBuilder.Host}/{TestServerBuilder.Login}"));
+                    var setCookie = Assert.Single(loginResponse.Headers, h => h.Key == "Set-Cookie");
+
+                    var queryParameters = UriUtils.GetQueryParams(loginResponse.Headers.Location);
+                    nonce = queryParameters["nonce"];
+                    var state = queryParameters["state"];
+
+                    var message = new HttpRequestMessage(HttpMethod.Get, $"{TestServerBuilder.Host}/{TestServerBuilder.Callback}?state={state}&nonce={nonce}&code=123");
+
+                    Func<Task> act = async () =>
+                    {
+                        await client.SendAsync(message, setCookie.Value);
+                    };
+
+                    var innerException = act
+                        .Should()
+                        .ThrowAsync<Exception>()
+                        .Result
+                        .And.InnerException;
+
+                    innerException
+                        .Should()
+                        .BeOfType<AuthenticationFailureException>()
+                        .Which.Message.Should().Contain("session_expiry");
+                }
+            }
+        }
+
+        [Fact]
         public async void Should_Refresh_Access_Token_When_Expired()
         {
             var nonce = "";

--- a/tests/Auth0.AspNetCore.Authentication.IntegrationTests/Auth0MiddlewareTests.cs
+++ b/tests/Auth0.AspNetCore.Authentication.IntegrationTests/Auth0MiddlewareTests.cs
@@ -1176,16 +1176,63 @@ namespace Auth0.AspNetCore.Authentication.IntegrationTests
                         await client.SendAsync(message, setCookie.Value);
                     };
 
-                    var innerException = act
-                        .Should()
-                        .ThrowAsync<Exception>()
-                        .Result
-                        .And.InnerException;
+                    (await act.Should().ThrowAsync<Exception>())
+                        .WithInnerException<AuthenticationFailureException>()
+                        .WithMessage("*session_expiry*");
+                }
+            }
+        }
 
-                    innerException
-                        .Should()
-                        .BeOfType<AuthenticationFailureException>()
-                        .Which.Message.Should().Contain("session_expiry");
+        [Fact]
+        public async Task Should_Preserve_SessionExpiry_Across_Token_Refresh()
+        {
+            var nonce = "";
+            var configuration = TestConfiguration.GetConfiguration();
+            var domain = configuration["Auth0:Domain"];
+            var clientId = configuration["Auth0:ClientId"];
+            // A ceiling far in the future so it never expires during the test.
+            var sessionExpiry = DateTimeOffset.UtcNow.AddHours(8).ToUnixTimeSeconds();
+
+            var mockHandler = new OidcMockBuilder()
+                .MockOpenIdConfig()
+                .MockJwks()
+                // Initial login token carries session_expiry; the short lifetime forces a refresh on the next read.
+                .MockToken(() => JwtUtils.GenerateToken(1, $"https://{domain}/", clientId, null, nonce, DateTime.UtcNow.AddSeconds(20), sessionExpiry: sessionExpiry), (me) => me.HasGrantType("authorization_code"), 20)
+                // The refreshed id_token deliberately OMITS session_expiry (the common case). The persisted
+                // ceiling must survive untouched, since it lives outside the token entries.
+                .MockToken(() => JwtUtils.GenerateToken(1, $"https://{domain}/", clientId, null, null, DateTime.UtcNow.AddSeconds(20)), (me) => me.HasGrantType("refresh_token") && me.HasClientSecret(), 20)
+                .Build();
+
+            using (var server = TestServerBuilder.CreateServer(opts =>
+            {
+                opts.ClientSecret = "123";
+                opts.Backchannel = new HttpClient(mockHandler.Object);
+            }, opts =>
+            {
+                opts.Audience = "123";
+                opts.UseRefreshTokens = true;
+            }))
+            {
+                using (var client = server.CreateClient())
+                {
+                    var loginResponse = (await client.SendAsync($"{TestServerBuilder.Host}/{TestServerBuilder.Login}"));
+                    var setCookie = Assert.Single(loginResponse.Headers, h => h.Key == "Set-Cookie");
+
+                    var queryParameters = UriUtils.GetQueryParams(loginResponse.Headers.Location);
+                    nonce = queryParameters["nonce"];
+                    var state = queryParameters["state"];
+
+                    var message = new HttpRequestMessage(HttpMethod.Get, $"{TestServerBuilder.Host}/{TestServerBuilder.Callback}?state={state}&nonce={nonce}&code=123");
+                    var callbackResponse = (await client.SendAsync(message, setCookie.Value));
+
+                    // /process authenticates the cookie (firing OnValidatePrincipal -> refresh) and reads back
+                    // the persisted ceiling via GetSessionExpiryAsync.
+                    var response = await client.SendAsync($"{TestServerBuilder.Host}/{TestServerBuilder.Process}", callbackResponse.Headers.GetValues("Set-Cookie"));
+                    var content = JObject.Parse(await response.Content.ReadAsStringAsync());
+
+                    // Refresh happened, yet the ceiling read back is still the original one.
+                    mockHandler.Verify();
+                    content.GetValue("SessionExpiry").Value<long>().Should().Be(sessionExpiry);
                 }
             }
         }

--- a/tests/Auth0.AspNetCore.Authentication.IntegrationTests/HttpContextExtensionsTests.cs
+++ b/tests/Auth0.AspNetCore.Authentication.IntegrationTests/HttpContextExtensionsTests.cs
@@ -146,6 +146,49 @@ namespace Auth0.AspNetCore.Authentication.IntegrationTests
         }
 
         [Fact]
+        public async Task GetAccessTokenAsync_WhenSessionExpiryReached_ReturnsNullWithoutCallingBackchannel()
+        {
+            // Past the upstream-IdP ceiling: the hard pre-check must short-circuit before serving a
+            // cached token or hitting the token endpoint, surfacing no-session (null).
+            var handler = CreateTokenHandler("fresh");
+            var properties = new AuthenticationProperties();
+            properties.Items[".Token.access_token"] = "cached";
+            properties.Items[".Token.expires_at"] = DateTimeOffset.Now.AddHours(1).ToString("o");
+            properties.Items[".Token.refresh_token"] = "rt";
+            properties.Items[Auth0Constants.SessionExpiryItemKey] =
+                DateTimeOffset.UtcNow.AddHours(-1).ToUnixTimeSeconds().ToString();
+
+            var context = BuildContext(handler.Object, properties, out _);
+
+            var result = await context.GetAccessTokenAsync(
+                new AccessTokenRequest { Audience = PrimaryAudience });
+
+            result.Should().BeNull();
+            // Neither the cached token nor a refresh: no backchannel call at all.
+            handler.Protected().Verify("SendAsync", Times.Never(),
+                ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>());
+        }
+
+        [Fact]
+        public async Task GetAccessTokenAsync_WhenSessionExpiryAbsent_BehavesAsBefore()
+        {
+            // No persisted ceiling (pre-feature session): the pre-check must fall through and serve
+            // the cached token exactly as before.
+            var handler = CreateTokenHandler("fresh");
+            var properties = new AuthenticationProperties();
+            properties.Items[".Token.access_token"] = "cached";
+            properties.Items[".Token.expires_at"] = DateTimeOffset.Now.AddHours(1).ToString("o");
+            properties.Items[".Token.refresh_token"] = "rt";
+
+            var context = BuildContext(handler.Object, properties, out _);
+
+            var result = await context.GetAccessTokenAsync(
+                new AccessTokenRequest { Audience = PrimaryAudience });
+
+            result.Should().Be("cached");
+        }
+
+        [Fact]
         public async Task GetAccessTokenAsync_WhenRefreshRejected_FiresRefreshFailedEventAndReturnsNull()
         {
             var handler = CreateFailingHandler(HttpStatusCode.BadRequest,

--- a/tests/Auth0.AspNetCore.Authentication.IntegrationTests/Infrastructure/TestServerBuilder.cs
+++ b/tests/Auth0.AspNetCore.Authentication.IntegrationTests/Infrastructure/TestServerBuilder.cs
@@ -66,7 +66,7 @@ namespace Auth0.AspNetCore.Authentication.IntegrationTests.Infrastructure
                                         RefreshToken = await context.GetTokenAsync(cookieScheme, "refresh_token"),
                                         Name = ticket.Principal?.FindFirst("name")?.Value,
                                         NameIdentifier = ticket.Principal?.FindFirst(System.Security.Claims.ClaimTypes.NameIdentifier)?.Value,
-                                        SessionExpiry = context.GetSessionExpiry()
+                                        SessionExpiry = await context.GetSessionExpiryAsync()
                                     }));
                                 }
                                 else

--- a/tests/Auth0.AspNetCore.Authentication.IntegrationTests/Infrastructure/TestServerBuilder.cs
+++ b/tests/Auth0.AspNetCore.Authentication.IntegrationTests/Infrastructure/TestServerBuilder.cs
@@ -65,7 +65,8 @@ namespace Auth0.AspNetCore.Authentication.IntegrationTests.Infrastructure
                                     {
                                         RefreshToken = await context.GetTokenAsync(cookieScheme, "refresh_token"),
                                         Name = ticket.Principal?.FindFirst("name")?.Value,
-                                        NameIdentifier = ticket.Principal?.FindFirst(System.Security.Claims.ClaimTypes.NameIdentifier)?.Value
+                                        NameIdentifier = ticket.Principal?.FindFirst(System.Security.Claims.ClaimTypes.NameIdentifier)?.Value,
+                                        SessionExpiry = context.GetSessionExpiry()
                                     }));
                                 }
                                 else

--- a/tests/Auth0.AspNetCore.Authentication.IntegrationTests/SessionExpiryCookieTests.cs
+++ b/tests/Auth0.AspNetCore.Authentication.IntegrationTests/SessionExpiryCookieTests.cs
@@ -1,0 +1,200 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Auth0.AspNetCore.Authentication.IntegrationTests.Extensions;
+using Auth0.AspNetCore.Authentication.IntegrationTests.Infrastructure;
+using Xunit;
+
+namespace Auth0.AspNetCore.Authentication.IntegrationTests
+{
+    /// <summary>
+    /// Integration tests for the IPSIE <c>session_expiry</c> read-gate that lives in the cookie
+    /// handler's <c>OnValidatePrincipal</c> (wired by <c>AddAuth0WebAppAuthentication</c>).
+    ///
+    /// The gate only fires when a previously-issued cookie is read back, so each test first mints a
+    /// real authentication cookie carrying a chosen <c>auth0:session_expiry</c> item (via a /signin
+    /// endpoint), then replays that cookie against a /read endpoint that calls
+    /// <see cref="AuthenticationHttpContextExtensions.AuthenticateAsync(HttpContext, string)"/> to
+    /// trigger the gate. The response reports whether the session survived.
+    ///
+    /// Coverage mirrors the "positive / false-positive / negative" shape:
+    ///  - positive:        a live ceiling in the future -> session is honored.
+    ///  - negative:        a ceiling in the past -> principal rejected, cookie cleared.
+    ///  - false-positive:  no ceiling / malformed ceiling -> must NOT be treated as expired
+    ///                     (pre-existing sessions and garbage values fall through to normal behavior).
+    /// </summary>
+    public class SessionExpiryCookieTests
+    {
+        private const string CookieScheme = CookieAuthenticationDefaults.AuthenticationScheme;
+
+        private static TestServer CreateServer()
+        {
+            var configuration = TestConfiguration.GetConfiguration();
+            var host = new HostBuilder()
+                .ConfigureWebHost(builder =>
+                    builder.UseTestServer()
+                        .Configure(app =>
+                        {
+                            app.UseAuthentication();
+
+                            app.Use(async (context, next) =>
+                            {
+                                var req = context.Request;
+                                var res = context.Response;
+
+                                if (req.Path == new PathString("/signin"))
+                                {
+                                    // Mint a cookie for a fixed user, optionally stamping the persisted
+                                    // session_expiry ceiling so we can replay it and observe the gate.
+                                    var identity = new ClaimsIdentity(new[]
+                                    {
+                                        new Claim(ClaimTypes.NameIdentifier, "user-1"),
+                                        new Claim("name", "Test User"),
+                                    }, CookieScheme);
+
+                                    var principal = new ClaimsPrincipal(identity);
+                                    var properties = new AuthenticationProperties();
+
+                                    if (req.Query.TryGetValue("ceiling", out var ceilingValue))
+                                    {
+                                        properties.Items[Auth0Constants.SessionExpiryItemKey] = ceilingValue.ToString();
+                                    }
+
+                                    await context.SignInAsync(CookieScheme, principal, properties);
+                                    return;
+                                }
+
+                                if (req.Path == new PathString("/read"))
+                                {
+                                    // Reading the cookie runs OnValidatePrincipal -> the session_expiry gate.
+                                    var result = await context.AuthenticateAsync(CookieScheme);
+                                    res.StatusCode = (int)HttpStatusCode.OK;
+                                    await res.WriteAsync(result.Succeeded ? "authenticated" : "no-session");
+                                    return;
+                                }
+
+                                await next();
+                            });
+                        })
+                        .ConfigureServices(services =>
+                        {
+                            services.AddAuthentication(options =>
+                                {
+                                    options.DefaultAuthenticateScheme = CookieScheme;
+                                    options.DefaultSignInScheme = CookieScheme;
+                                    options.DefaultChallengeScheme = CookieScheme;
+                                })
+                                .AddAuth0WebAppAuthentication(options =>
+                                {
+                                    options.Domain = configuration["Auth0:Domain"];
+                                    options.ClientId = configuration["Auth0:ClientId"];
+                                });
+                        })
+                        .UseConfiguration(configuration))
+                .Build();
+
+            host.Start();
+            return host.GetTestServer();
+        }
+
+        private static string Ceiling(TimeSpan fromNow) =>
+            (DateTimeOffset.UtcNow.ToUnixTimeSeconds() + (long)fromNow.TotalSeconds)
+                .ToString(CultureInfo.InvariantCulture);
+
+        private static async Task<(IEnumerable<string> cookies, HttpResponseMessage response)> SignIn(
+            TestServer server, string ceiling = null)
+        {
+            using var client = server.CreateClient();
+            var url = ceiling == null
+                ? $"{TestServerBuilder.Host}/signin"
+                : $"{TestServerBuilder.Host}/signin?ceiling={ceiling}";
+            var response = await client.SendAsync(url);
+            var cookies = response.Headers.GetValues("Set-Cookie");
+            return (cookies, response);
+        }
+
+        private static async Task<string> Read(TestServer server, IEnumerable<string> cookies)
+        {
+            using var client = server.CreateClient();
+            var response = await client.SendAsync($"{TestServerBuilder.Host}/read", cookies);
+            return await response.Content.ReadAsStringAsync();
+        }
+
+        [Fact]
+        public async Task Positive_CeilingInFuture_SessionIsHonored()
+        {
+            using var server = CreateServer();
+
+            var (cookies, _) = await SignIn(server, Ceiling(TimeSpan.FromHours(8)));
+            var body = await Read(server, cookies);
+
+            body.Should().Be("authenticated");
+        }
+
+        [Fact]
+        public async Task Negative_CeilingInPast_SessionIsRejected()
+        {
+            using var server = CreateServer();
+
+            var (cookies, _) = await SignIn(server, Ceiling(TimeSpan.FromHours(-1)));
+            var body = await Read(server, cookies);
+
+            body.Should().Be("no-session");
+        }
+
+        [Fact]
+        public async Task Negative_CeilingWithinLeewayWindow_SessionIsRejected()
+        {
+            using var server = CreateServer();
+
+            // The gate applies a negative leeway: at (ceiling - leeway) the session is already expired,
+            // so a ceiling only a few seconds in the future is still rejected.
+            var justInsideLeeway = DateTimeOffset.UtcNow.ToUnixTimeSeconds()
+                + Auth0Constants.SessionExpiryLeewaySeconds - 5;
+            var (cookies, _) = await SignIn(server, justInsideLeeway.ToString(CultureInfo.InvariantCulture));
+            var body = await Read(server, cookies);
+
+            body.Should().Be("no-session");
+        }
+
+        [Fact]
+        public async Task FalsePositive_NoCeilingPersisted_SessionIsHonored()
+        {
+            using var server = CreateServer();
+
+            // A session created before this feature has no persisted ceiling: it must never be
+            // treated as expired.
+            var (cookies, _) = await SignIn(server, ceiling: null);
+            var body = await Read(server, cookies);
+
+            body.Should().Be("authenticated");
+        }
+
+        [Fact]
+        public async Task FalsePositive_MalformedCeiling_SessionIsHonored()
+        {
+            using var server = CreateServer();
+
+            // A garbage ceiling value must be tolerated as "no ceiling", not fail the read.
+            var (cookies, _) = await SignIn(server, "not-a-number");
+            var body = await Read(server, cookies);
+
+            body.Should().Be("authenticated");
+        }
+    }
+}

--- a/tests/Auth0.AspNetCore.Authentication.IntegrationTests/SessionExpiryHelpersTests.cs
+++ b/tests/Auth0.AspNetCore.Authentication.IntegrationTests/SessionExpiryHelpersTests.cs
@@ -27,6 +27,37 @@ namespace Auth0.AspNetCore.Authentication.IntegrationTests
             seconds.Should().Be(expected);
         }
 
+        [Theory]
+        // A millisecond value (seconds * 1000) is far above the cap and must be rejected as "no
+        // ceiling" so a units mistake in an Action can't silently switch off enforcement.
+        [InlineData("1712345678000")]
+        [InlineData("10000000000")]
+        public void TryParseCeiling_RejectsValuesAtOrAboveCap(string raw)
+        {
+            SessionExpiryHelpers.TryParseCeiling(raw, out var seconds).Should().BeFalse();
+            seconds.Should().Be(0);
+        }
+
+        [Fact]
+        public void TryParseCeiling_AcceptsValueJustBelowCap()
+        {
+            SessionExpiryHelpers.TryParseCeiling("9999999999", out var seconds).Should().BeTrue();
+            seconds.Should().Be(9999999999L);
+        }
+
+        [Theory]
+        // Zero and negative are numbers, so they clear the range check — but they are not a real
+        // forward-in-time ceiling. They must fall through to "no ceiling" (fail open) rather than
+        // reaching the at-or-before-iat throw and locking the user out.
+        [InlineData("0")]
+        [InlineData("-1")]
+        [InlineData("-1712345678")]
+        public void TryParseCeiling_ReturnsFalse_ForZeroOrNegative(string raw)
+        {
+            SessionExpiryHelpers.TryParseCeiling(raw, out var seconds).Should().BeFalse();
+            seconds.Should().Be(0);
+        }
+
         [Fact]
         public void IsExpired_IsFalse_WellBeforeCeiling()
         {

--- a/tests/Auth0.AspNetCore.Authentication.IntegrationTests/SessionExpiryHelpersTests.cs
+++ b/tests/Auth0.AspNetCore.Authentication.IntegrationTests/SessionExpiryHelpersTests.cs
@@ -1,0 +1,98 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.Authentication;
+using System.Globalization;
+using Xunit;
+
+namespace Auth0.AspNetCore.Authentication.IntegrationTests
+{
+    public class SessionExpiryHelpersTests
+    {
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("   ")]
+        [InlineData("not-a-number")]
+        public void TryParseCeiling_ReturnsFalse_ForMissingOrMalformed(string? raw)
+        {
+            SessionExpiryHelpers.TryParseCeiling(raw, out var seconds).Should().BeFalse();
+            seconds.Should().Be(0);
+        }
+
+        [Theory]
+        [InlineData("1712345678", 1712345678L)]
+        [InlineData("1712345678.0", 1712345678L)]
+        public void TryParseCeiling_ParsesIntegerSeconds(string raw, long expected)
+        {
+            SessionExpiryHelpers.TryParseCeiling(raw, out var seconds).Should().BeTrue();
+            seconds.Should().Be(expected);
+        }
+
+        [Fact]
+        public void IsExpired_IsFalse_WellBeforeCeiling()
+        {
+            var ceiling = 1_000_000L;
+            // A minute before the ceiling (beyond the 30s leeway) is not expired.
+            SessionExpiryHelpers.IsExpired(ceiling, ceiling - 60).Should().BeFalse();
+        }
+
+        [Fact]
+        public void IsExpired_AppliesNegativeLeeway_ExpiresBeforeWallClockCeiling()
+        {
+            var ceiling = 1_000_000L;
+            var leeway = Auth0Constants.SessionExpiryLeewaySeconds;
+
+            // Exactly at (ceiling - leeway) the session is already treated as expired (>=),
+            // i.e. expiry fires slightly before the wall-clock ceiling, never after.
+            SessionExpiryHelpers.IsExpired(ceiling, ceiling - leeway).Should().BeTrue();
+            // One second inside the leeway window is still live.
+            SessionExpiryHelpers.IsExpired(ceiling, ceiling - leeway - 1).Should().BeFalse();
+        }
+
+        [Fact]
+        public void IsExpired_IsTrue_AtAndAfterCeiling()
+        {
+            var ceiling = 1_000_000L;
+            SessionExpiryHelpers.IsExpired(ceiling, ceiling).Should().BeTrue();
+            SessionExpiryHelpers.IsExpired(ceiling, ceiling + 3600).Should().BeTrue();
+        }
+
+        [Fact]
+        public void IsSessionExpired_NoPersistedCeiling_IsNeverExpired()
+        {
+            // A session created before this feature has no persisted ceiling: it must never be
+            // treated as expired, regardless of how far "now" has advanced.
+            var properties = new AuthenticationProperties();
+
+            SessionExpiryHelpers.IsSessionExpired(properties, long.MaxValue).Should().BeFalse();
+        }
+
+        [Fact]
+        public void IsSessionExpired_MalformedPersistedCeiling_IsNeverExpired()
+        {
+            var properties = new AuthenticationProperties();
+            properties.Items[Auth0Constants.SessionExpiryItemKey] = "garbage";
+
+            SessionExpiryHelpers.IsSessionExpired(properties, long.MaxValue).Should().BeFalse();
+        }
+
+        [Fact]
+        public void IsSessionExpired_PastCeiling_IsExpired()
+        {
+            var ceiling = 1_000_000L;
+            var properties = new AuthenticationProperties();
+            properties.Items[Auth0Constants.SessionExpiryItemKey] = ceiling.ToString(CultureInfo.InvariantCulture);
+
+            SessionExpiryHelpers.IsSessionExpired(properties, ceiling + 1).Should().BeTrue();
+        }
+
+        [Fact]
+        public void IsSessionExpired_BeforeCeiling_IsNotExpired()
+        {
+            var ceiling = 1_000_000L;
+            var properties = new AuthenticationProperties();
+            properties.Items[Auth0Constants.SessionExpiryItemKey] = ceiling.ToString(CultureInfo.InvariantCulture);
+
+            SessionExpiryHelpers.IsSessionExpired(properties, ceiling - 3600).Should().BeFalse();
+        }
+    }
+}

--- a/tests/Auth0.AspNetCore.Authentication.IntegrationTests/Utils/JwtUtils.cs
+++ b/tests/Auth0.AspNetCore.Authentication.IntegrationTests/Utils/JwtUtils.cs
@@ -22,7 +22,7 @@ namespace Auth0.AspNetCore.Authentication.IntegrationTests.Utils
         /// <param name="orgId">The (optional) org_id claim to be used.</param>
         /// <param name="nonce">The (optional) nonce to be used.</param>
         /// <returns>The generated JWT token.</returns>
-        public static string GenerateToken(int userId, string issuer, string audience, string orgId = null, string nonce = null, DateTime? expires = null, string name = null, DateTime? authTime = null)
+        public static string GenerateToken(int userId, string issuer, string audience, string orgId = null, string nonce = null, DateTime? expires = null, string name = null, DateTime? authTime = null, long? sessionExpiry = null)
         {
             var tokenHandler = new JwtSecurityTokenHandler();
             var claims = new List<Claim>
@@ -30,6 +30,11 @@ namespace Auth0.AspNetCore.Authentication.IntegrationTests.Utils
                 new Claim(ClaimTypes.NameIdentifier, userId.ToString()),
                 new Claim(JwtRegisteredClaimNames.Sub, userId.ToString()),
             };
+
+            if (sessionExpiry.HasValue)
+            {
+                claims.Add(new Claim(Auth0Constants.SessionExpiryClaim, sessionExpiry.Value.ToString(), ClaimValueTypes.Integer64));
+            }
 
             if (!string.IsNullOrWhiteSpace(orgId))
             {


### PR DESCRIPTION
# Summary

Adds support for the IPSIE SL1 `session_expiry` claim—an absolute Unix timestamp (seconds) asserted by the upstream IdP that defines the maximum lifetime of the application session.

When a connection advertises support via `id_token_session_expiry_supported`, the SDK:

* Persists the `session_expiry` value at login.
* Enforces the session expiry on every session read.
* Prevents token refresh after the session has expired.

If the claim is not present, existing behavior is unchanged.


---

# Changes

### Persist session expiry at login

* Added `OpenIdConnectEventsFactory.PersistSessionExpiry`.
* Reads the `session_expiry` claim from the validated ID token.
* Stores the value in authentication properties (separate from token entries so it survives token refreshes).
* Rejects login if the session is already expired at sign-in time.
* Uses the ID token `iat` claim as the reference time when available, otherwise falls back to the current time.

### Enforce expiry on session reads

* Added enforcement in `AuthenticationBuilderExtensions.OnValidatePrincipal`.
* Once the configured session ceiling is reached:

  * Rejects the authentication principal.
  * Signs the user out.
* Existing `[Authorize]` challenge flow then transparently redirects the user to re-authenticate.

### Prevent refresh after expiry

* Added enforcement in `HttpContextExtensions.GetAccessTokenAsync`.
* Returns `null` once the session has expired instead of:

  * returning a cached access token, or
  * attempting a refresh token exchange.

### Do not gate connection tokens

* `GetAccessTokenForConnectionAsync` intentionally ignores `session_expiry`.
* Token Vault / federated connection tokens continue to follow the upstream IdP's own lifetime.

### Read-back API

* Added `GetSessionExpiryAsync`.
* Returns:

  * persisted session expiry (Unix seconds), or
  * `null` if no session ceiling exists.
* Enables application scenarios such as session countdowns or custom warnings.

### Fail-open parsing

Added `SessionExpiryHelpers` to safely parse the claim.

Invalid values are treated as **"no session ceiling"** instead of failing authentication:

* Non-numeric values
* Zero or negative values
* Implausibly large values (`>= 10,000,000,000`), which are assumed to be milliseconds instead of seconds

### Clock skew

* Applies approximately **30 seconds** of negative clock skew.
* Sessions expire slightly before the declared wall-clock time to avoid edge cases around expiration.

### Documentation

* Added **"Session expiry from the upstream IdP"** section to `EXAMPLES.md`.

---

# Test Plan

* [ ] `SessionExpiryHelpersTests`

  * Parse valid values
  * Fail-open behavior
  * Clock skew / leeway boundary cases

* [ ] `SessionExpiryCookieTests`

  * Session read rejects expired principal
  * User is signed out after expiry

* [ ] `HttpContextExtensionsTests`

  * `GetSessionExpiryAsync` returns persisted value

* [ ] `Auth0MiddlewareTests`

  * Login rejected when session is already expired
  * Session expiry survives refreshes that omit the claim
  * Connection token exchange is **not** gated by session expiry

* [ ] Full test suite passes (398 tests)


