### PR TITLE
feat: Adds Custom Token Exchange via Session Transfer

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -21,6 +21,7 @@
 - [Custom Token Exchange](#custom-token-exchange)
   - [Delegation / impersonation](#delegation--impersonation)
 - [Impersonation via Session Transfer](#impersonation-via-session-transfer)
+  - [Handling MFA step-up while sourcing the actor](#handling-mfa-step-up-while-sourcing-the-actor)
 - [Organizations](#organizations)
 - [Extra parameters](#extra-parameters)
 - [Roles](#roles)
@@ -928,6 +929,50 @@ var actor = http.User.FindFirst("act")?.Value; // JSON: {"sub":"<agent>"}
 >   throws `CustomTokenExchangeException` with `Error == "invalid_issued_token_type"` rather than
 >   handing back an ordinary access token as if it were an STT.
 > - The two-client tenant prerequisites are configured out of band.
+
+### Handling MFA step-up while sourcing the actor
+
+When the actor is auto-sourced and the agent's session ID token has expired, the SDK refreshes it. If
+your tenant requires step-up MFA on that refresh, `RequestSessionTransferTokenAsync` throws
+`MfaRequiredException` rather than collapsing it into `ActorUnavailable` — the session is fine, it
+just needs a challenge completed.
+
+The refresh requests the `openid` scope, which is bound into the `mfa_token` blob, so the MFA grant
+returns an `id_token`. Pass that back as `ActorToken` to complete the request:
+
+```csharp
+try
+{
+    var result = await HttpContext.RequestSessionTransferTokenAsync(request);
+    return Redirect(HttpContext.BuildSessionTransferRedirect(targetLoginUrl, result));
+}
+catch (MfaRequiredException ex)
+{
+    // Store ex.MfaToken, run the challenge/verify flow (see the MRRT MFA section above),
+    // then retry with the id_token from the completed grant as the explicit actor.
+    var tokens = await _authClient.GetTokenAsync(new MfaOtpTokenRequest
+    {
+        MfaToken = mfaToken,
+        Otp = otp
+    });
+
+    request.ActorToken = tokens.IdToken;   // skips the refresh path entirely
+    var result = await HttpContext.RequestSessionTransferTokenAsync(request);
+    return Redirect(HttpContext.BuildSessionTransferRedirect(targetLoginUrl, result));
+}
+catch (CustomTokenExchangeException ex) when (ex.Code == CustomTokenExchangeErrorCode.ActorUnavailable)
+{
+    // No usable ID token and no refresh token — the agent must log in again.
+    // Note `UseRefreshTokens` defaults to false; enable it via
+    // .WithAccessToken(o => o.UseRefreshTokens = true) so a stale ID token can be refreshed at all.
+    return Challenge();
+}
+```
+
+> :information_source: A transport failure reaching the token endpoint — on either the actor refresh
+> or the exchange — surfaces as `CustomTokenExchangeException` with the original
+> `HttpRequestException` / `TaskCanceledException` on `InnerException`, so a timeout stays
+> distinguishable from a rejection.
 
 ## Organizations
 

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -923,7 +923,10 @@ var actor = http.User.FindFirst("act")?.Value; // JSON: {"sub":"<agent>"}
 > - The agent must be logged in on the initiator app — that session is the actor source.
 > - The STT is single-use and short-lived (~60s); never persist it.
 > - Branch on `result.IssuedTokenType` (`Auth0Constants.SessionTransferTokenType`), never on
->   `result.TokenType` (which is the informational `N_A`).
+>   `result.TokenType`, if the token
+>   endpoint returns 200 without `issued_token_type` set to the session-transfer URN, `RequestSessionTransferTokenAsync`
+>   throws `CustomTokenExchangeException` with `Error == "invalid_issued_token_type"` rather than
+>   handing back an ordinary access token as if it were an STT.
 > - The two-client tenant prerequisites are configured out of band.
 
 ## Organizations

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -877,15 +877,18 @@ app.MapGet("/impersonate/{customerToken}", async (HttpContext http, string custo
 {
     try
     {
-        var result = await http.RequestSessionTransferTokenAsync(new SessionTransferTokenRequest
+        var request = new SessionTransferTokenRequest
         {
             SubjectToken = customerToken,                 // the customer to impersonate (opaque to Auth0)
             SubjectTokenType = "urn:acme:customer-token", // routes to your CTE Profile
-        });
+        };
+
+        var result = await http.RequestSessionTransferTokenAsync(request);
 
         var url = http.BuildSessionTransferRedirect(
             "https://customer-app.example.com/login",     // app-controlled target login URL (absolute HTTPS)
-            result);
+            result,
+            request);                                     // forwards request.Organization, if any
 
         return Results.Redirect(url);
     }
@@ -908,6 +911,11 @@ app.MapGet("/impersonate/{customerToken}", async (HttpContext http, string custo
 `BuildSessionTransferRedirect` returns a `string` (not an `IActionResult`) so it works in both Minimal APIs
 (`Results.Redirect(url)`) and MVC (`return Redirect(url);`). It requires an absolute HTTPS `targetLoginUrl`
 and throws `ArgumentException` otherwise - the STT is a live credential, so the target must be app-controlled.
+
+If the exchange was organization-scoped, pass the same `SessionTransferTokenRequest` (as above) rather than
+restating the value: the target app needs the `organization` parameter to match the STT, and passing the
+request keeps one source of truth. There is also an overload taking `string? organization` for callers that
+don't have the request in scope.
 
 ### Target: redeem the STT at login
 

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -836,8 +836,12 @@ var result = await HttpContext.CustomTokenExchangeAsync(new CustomTokenExchangeR
 var currentActor = result.Act?.Sub;
 ```
 
-> **Note:** `subject_token_type` (and `actor_token_type`) must be custom URIs. The reserved `urn:ietf:` and
-> `urn:auth0:` namespaces are rejected client-side.
+> **Note:** `subject_token_type` must be a custom URI in a namespace you control. The reserved `urn:ietf:`
+> and `urn:auth0:` namespaces are not accepted for it - but that is enforced by Auth0 when the CTE Profile is
+> configured and by the token endpoint, **not** client-side: the SDK sends whatever you pass and surfaces the
+> rejection as `CustomTokenExchangeException`. `actor_token_type` is not subject to the same restriction; it
+> names an RFC 8693 token type, and the SDK itself defaults it to `urn:ietf:params:oauth:token-type:id_token`
+> when auto-sourcing the actor for a session transfer.
 
 ## Impersonation via Session Transfer
 
@@ -917,6 +921,15 @@ restating the value: the target app needs the `organization` parameter to match 
 request keeps one source of truth. There is also an overload taking `string? organization` for callers that
 don't have the request in scope.
 
+> :warning: **The STT travels in a query string, so treat the redirect URL as a credential.** That is
+> inherent to the protocol - the target reads `session_transfer_token` from the query - but it means the
+> token predictably lands in places URLs land: initiator and target access logs, reverse-proxy and CDN logs,
+> browser history, and potentially the `Referer` header on requests the target page makes afterwards. The
+> ~60s lifetime and single-use redemption are what keep that acceptable: by the time the URL is sitting in a
+> log it is already spent or expired. So do not build on the URL as if it were durable - never cache it,
+> persist it, email or message it, put it in a QR code, log it yourself, or hand it to a redirect service.
+> Generate it per request, immediately before redirecting, and let it expire.
+
 ### Target: redeem the STT at login
 
 On the target app, forward the incoming `session_transfer_token` query parameter into the Auth0 login
@@ -961,6 +974,28 @@ var actor = http.User.FindFirst("act")?.Value; // JSON: {"sub":"<agent>"}
 >   throws `CustomTokenExchangeException` with `Error == "invalid_issued_token_type"` rather than
 >   handing back an ordinary access token as if it were an STT.
 > - The two-client tenant prerequisites are configured out of band.
+
+#### Which errors you can match on
+
+`CustomTokenExchangeException.Code` is only set for failures the SDK raises itself, plus token-endpoint
+rejections whose `error` field maps onto a known code. When it is `null`, inspect `ex.Error` /
+`ex.ErrorDescription` instead.
+
+| `ex.Code`                | Raised by  | Fires today                                                    |
+| ------------------------ | ---------- | -------------------------------------------------------------- |
+| `ActorUnavailable`       | SDK        | Yes - no authenticated session at all; or no usable id_token and nothing to refresh it with; or an `mfa_required` refresh carrying no `mfa_token` |
+| `InvalidTokenFormat`     | SDK        | Yes - explicit actor blank, untrimmed, or `"Bearer "`-prefixed; or `ActorTokenType` set without `ActorToken` |
+| `SetActorRequired`       | Token endpoint | Only if the endpoint reports that literal `error` value    |
+| `SessionTransferDisabled`| Token endpoint | Only if the endpoint reports that literal `error` value    |
+
+The two server-side codes are mapped defensively: Auth0 currently reports both of those rejections as a
+generic `invalid_request`, so in practice `Code` is `null` and the detail is in `ex.ErrorDescription`. Do not
+write a `when (ex.Code == CustomTokenExchangeErrorCode.SessionTransferDisabled)` clause as your only handler
+for a misconfigured tenant - keep a general `catch (CustomTokenExchangeException)` that surfaces
+`ex.ErrorDescription`, as the example above does.
+
+One error is deliberately *not* a `Code`: a 200 response carrying a non-STT `issued_token_type` throws with
+`ex.Error == "invalid_issued_token_type"`, since it describes the response shape rather than a rejection.
 
 ### Handling MFA step-up while sourcing the actor
 

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -20,6 +20,7 @@
   - [Handling a missing refresh token or exchange failure](#handling-a-missing-refresh-token-or-exchange-failure)
 - [Custom Token Exchange](#custom-token-exchange)
   - [Delegation / impersonation](#delegation--impersonation)
+- [Impersonation via Session Transfer](#impersonation-via-session-transfer)
 - [Organizations](#organizations)
 - [Extra parameters](#extra-parameters)
 - [Roles](#roles)
@@ -836,6 +837,94 @@ var currentActor = result.Act?.Sub;
 
 > **Note:** `subject_token_type` (and `actor_token_type`) must be custom URIs. The reserved `urn:ietf:` and
 > `urn:auth0:` namespaces are rejected client-side.
+
+## Impersonation via Session Transfer
+
+Session Transfer builds on Custom Token Exchange to let an initiator app (e.g. a support/admin console —
+the *actor*) start an authenticated web session in a target app *as a customer* (the *subject*), with the
+agent recorded in the `act` claim. The initiator requests a short-lived, single-use **Session Transfer
+Token (STT)** and redirects the agent's browser to the target's login URL carrying that STT; the target
+redeems it at `/authorize`.
+
+This requires a two-client tenant setup (initiator + target, with `session_transfer` delegation configured)
+that is provisioned out of band via the Management API.
+
+### Initiator: request an STT and redirect
+
+`RequestSessionTransferTokenAsync` performs the exchange. The **actor is auto-sourced from the agent's
+current session id_token** (refreshed automatically if stale), so the agent must be logged in. Pass an
+explicit `ActorToken` only to override that. The audience is set for you to
+`urn:{your-domain}:session_transfer`. The STT is one-shot and **never stored** — use it immediately.
+
+```csharp
+// Minimal API — the agent (actor) is already logged in on this app.
+app.MapGet("/impersonate/{customerToken}", async (HttpContext http, string customerToken) =>
+{
+    try
+    {
+        var result = await http.RequestSessionTransferTokenAsync(new SessionTransferTokenRequest
+        {
+            SubjectToken = customerToken,                 // the customer to impersonate (opaque to Auth0)
+            SubjectTokenType = "urn:acme:customer-token", // routes to your CTE Profile
+        });
+
+        var url = http.BuildSessionTransferRedirect(
+            "https://customer-app.example.com/login",     // app-controlled target login URL (absolute HTTPS)
+            result);
+
+        return Results.Redirect(url);
+    }
+    catch (CustomTokenExchangeException ex) when (ex.Code == CustomTokenExchangeErrorCode.ActorUnavailable)
+    {
+        // The agent has no usable session to act as. Send them to log in first.
+        return Results.Challenge();
+    }
+    catch (CustomTokenExchangeException ex)
+    {
+        // ex.StatusCode / ex.Error / ex.ErrorDescription describe a token-endpoint rejection
+        // (e.g. session transfer disabled, or setActor required).
+        return Results.Problem(ex.Message);
+    }
+});
+```
+
+`BuildSessionTransferRedirect` returns a `string` (not an `IActionResult`) so it works in both Minimal APIs
+(`Results.Redirect(url)`) and MVC (`return Redirect(url);`). It requires an absolute HTTPS `targetLoginUrl`
+and throws `ArgumentException` otherwise — the STT is a live credential, so the target must be app-controlled.
+
+### Target: redeem the STT at login
+
+On the target app, forward the incoming `session_transfer_token` query parameter into the Auth0 login
+request using the existing `LoginAuthenticationPropertiesBuilder`:
+
+```csharp
+app.MapGet("/login", async (HttpContext http, string? session_transfer_token) =>
+{
+    var propertiesBuilder = new LoginAuthenticationPropertiesBuilder()
+        .WithRedirectUri("/");
+
+    if (!string.IsNullOrEmpty(session_transfer_token))
+    {
+        propertiesBuilder.WithParameter("session_transfer_token", session_transfer_token);
+    }
+
+    await http.ChallengeAsync(Auth0Constants.AuthenticationScheme, propertiesBuilder.Build());
+});
+```
+
+After redemption, the established session is short-lived and non-refreshable. The agent behind the
+impersonated session is available via the `act` claim on `HttpContext.User`:
+
+```csharp
+var actor = http.User.FindFirst("act")?.Value; // JSON: {"sub":"<agent>"}
+```
+
+> **Notes:**
+> - The agent must be logged in on the initiator app — that session is the actor source.
+> - The STT is single-use and short-lived (~60s); never persist it.
+> - Branch on `result.IssuedTokenType` (`Auth0Constants.SessionTransferTokenType`), never on
+>   `result.TokenType` (which is the informational `N_A`).
+> - The two-client tenant prerequisites are configured out of band.
 
 ## Organizations
 

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -213,12 +213,12 @@ The above snippet checks whether the SDK is configured to use refresh tokens, if
 
 #### Updating claims and observing a successful refresh
 
-When the SDK refreshes an expired access token, it persists the new tokens but, by default, leaves the `ClaimsPrincipal` untouched — so `User.Claims` keeps serving the login-time snapshot for the lifetime of the refresh token, even though each refresh can return a fresh `id_token` that may carry updated user information.
+When the SDK refreshes an expired access token, it persists the new tokens but, by default, leaves the `ClaimsPrincipal` untouched - so `User.Claims` keeps serving the login-time snapshot for the lifetime of the refresh token, even though each refresh can return a fresh `id_token` that may carry updated user information.
 
 Two opt-in additions let you react to a refresh:
 
-- **`RebuildPrincipalOnRefresh`** — when `true`, the `ClaimsPrincipal` is rebuilt from the refreshed `id_token` after a successful primary refresh, so `User.Claims` (and `User.Identity.Name`) reflect current user information. Defaults to `false` (today's behavior).
-- **`OnTokensRefreshed`** — a success event that fires after a successful primary refresh, carrying the refreshed `AccessToken`, `IdToken`, `RefreshToken` (null when not rotated), and `ExpiresAt`. It fires independently of `RebuildPrincipalOnRefresh`, and when both are used the event fires *after* the rebuild so it observes the updated principal.
+- **`RebuildPrincipalOnRefresh`** - when `true`, the `ClaimsPrincipal` is rebuilt from the refreshed `id_token` after a successful primary refresh, so `User.Claims` (and `User.Identity.Name`) reflect current user information. Defaults to `false` (today's behavior).
+- **`OnTokensRefreshed`** - a success event that fires after a successful primary refresh, carrying the refreshed `AccessToken`, `IdToken`, `RefreshToken` (null when not rotated), and `ExpiresAt`. It fires independently of `RebuildPrincipalOnRefresh`, and when both are used the event fires *after* the rebuild so it observes the updated principal.
 
 ```csharp
 services
@@ -246,8 +246,8 @@ services
 
 `RefreshClaimsValidationType` controls how rigorously the refreshed `id_token` is validated before its claims replace the principal. It is only consulted when `RebuildPrincipalOnRefresh` is `true`:
 
-- **`Full`** (default) — validates the refreshed `id_token`'s signature against the cached JWKS, plus issuer/audience and the SDK's business-rule checks. Highest fidelity. The signature check runs only on an actual refresh (when the token expired), not on every request, and the JWKS is cached, so it is inexpensive in the hot path.
-- **`SkipSignature`** — skips signature validation (trusting the back-channel TLS exchange for token authenticity) while still running the SDK's business-rule checks. Lower cost, lower fidelity; an opt-in escape hatch.
+- **`Full`** (default) - validates the refreshed `id_token`'s signature against the cached JWKS, plus issuer/audience and the SDK's business-rule checks. Highest fidelity. The signature check runs only on an actual refresh (when the token expired), not on every request, and the JWKS is cached, so it is inexpensive in the hot path.
+- **`SkipSignature`** - skips signature validation (trusting the back-channel TLS exchange for token authenticity) while still running the SDK's business-rule checks. Lower cost, lower fidelity; an opt-in escape hatch.
 
 ```csharp
     .WithAccessToken(options =>
@@ -259,7 +259,7 @@ services
     });
 ```
 
-If a refresh succeeds but rebuilding the principal fails (a signature failure in `Full` mode, a malformed `id_token`, or a business-rule failure), the SDK degrades gracefully: the refreshed tokens are kept, the existing (stale) principal is retained, a warning is logged, and `OnTokensRefreshed` still fires — the refresh genuinely succeeded.
+If a refresh succeeds but rebuilding the principal fails (a signature failure in `Full` mode, a malformed `id_token`, or a business-rule failure), the SDK degrades gracefully: the refreshed tokens are kept, the existing (stale) principal is retained, a warning is logged, and `OnTokensRefreshed` still fires - the refresh genuinely succeeded.
 
 > :information_source: Both additions apply only to the primary (login-time) refresh path. Tokens fetched for **additional** audiences via [MRRT](#multi-resource-refresh-tokens-mrrt) do not rebuild the principal or fire `OnTokensRefreshed`.
 
@@ -398,13 +398,13 @@ The one case that fails the login outright is a *valid, positive* ceiling that i
 
 ## Multi-Resource Refresh Tokens (MRRT)
 
-[Multi-Resource Refresh Tokens (MRRT)](https://auth0.com/docs/secure/tokens/refresh-tokens/multi-resource-refresh-token) let a single session obtain access tokens for *additional* audiences and scopes on demand, by exchanging the session's refresh token — without forcing the user through another interactive login.
+[Multi-Resource Refresh Tokens (MRRT)](https://auth0.com/docs/secure/tokens/refresh-tokens/multi-resource-refresh-token) let a single session obtain access tokens for *additional* audiences and scopes on demand, by exchanging the session's refresh token - without forcing the user through another interactive login.
 
 A typical use case: the user logs in once, and your web app then needs to call a downstream API that expects a token for a *different* audience than the one requested at login. Instead of re-authenticating, you exchange the existing refresh token for a token scoped to that API.
 
 > :information_source: MRRT requires refresh tokens. Configure `UseRefreshTokens = true` and a `ClientSecret`, and ensure MRRT is enabled for your client/APIs in the Auth0 Dashboard. Tokens obtained for additional audiences are cached in the session alongside the login-time ("primary") token and reused until they near expiry.
 
-> :warning: **Token storage and cookie size.** Each additional audience/scope you obtain a token for adds another entry to the cached token set, which by default is serialized into the encrypted **authentication cookie** along with the rest of the session. Cookies cannot grow indefinitely — browsers cap them at around 4 KB each, and request-header limits apply on top of that. An application that fans out across several audiences can therefore accumulate enough tokens to exceed those limits and have the session rejected. If you expect to hold tokens for more than a couple of audiences, move the session **server-side** so only a small session key rides in the cookie while the token set lives in a store you control — see [Server-side session storage](#server-side-session-storage) above. The MRRT API is identical either way; only where the token set is persisted changes.
+> :warning: **Token storage and cookie size.** Each additional audience/scope you obtain a token for adds another entry to the cached token set, which by default is serialized into the encrypted **authentication cookie** along with the rest of the session. Cookies cannot grow indefinitely - browsers cap them at around 4 KB each, and request-header limits apply on top of that. An application that fans out across several audiences can therefore accumulate enough tokens to exceed those limits and have the session rejected. If you expect to hold tokens for more than a couple of audiences, move the session **server-side** so only a small session key rides in the cookie while the token set lives in a store you control - see [Server-side session storage](#server-side-session-storage) above. The MRRT API is identical either way; only where the token set is persisted changes.
 
 ### Requesting a token for another audience
 
@@ -422,7 +422,7 @@ public async Task<IActionResult> CallMessagesApi()
 
     if (accessToken == null)
     {
-        // No refresh token available, or the refresh failed — see "Handling refresh failures" below.
+        // No refresh token available, or the refresh failed - see "Handling refresh failures" below.
         return Challenge();
     }
 
@@ -490,7 +490,7 @@ var accessToken = await HttpContext.GetAccessTokenAsync(new AccessTokenRequest
 
 When a refresh token is present but the exchange fails, the `OnAccessTokenRefreshFailed` event fires and `GetAccessTokenAsync` returns `null`. The supplied `AccessTokenRefreshFailedContext` carries the failure details so you can distinguish a **terminal** failure (such as an `invalid_grant` for a revoked or expired refresh token, which warrants a re-login) from a **transient** one (such as a timeout or rate-limit, which may be retried).
 
-All refresh failures — token-endpoint rejections, malformed responses, and transport/misconfiguration errors — flow through this single event. For HTTP rejections, `StatusCode`, `Error`, and `ErrorDescription` are populated; for transport failures, `Exception` is populated instead.
+All refresh failures - token-endpoint rejections, malformed responses, and transport/misconfiguration errors - flow through this single event. For HTTP rejections, `StatusCode`, `Error`, and `ErrorDescription` are populated; for transport failures, `Exception` is populated instead.
 
 ```csharp
 services
@@ -508,7 +508,7 @@ services
         {
             OnAccessTokenRefreshFailed = async (context) =>
             {
-                // A revoked or expired refresh token is terminal — force a re-login.
+                // A revoked or expired refresh token is terminal - force a re-login.
                 if (context.Error == "invalid_grant")
                 {
                     await context.HttpContext.SignOutAsync(CookieAuthenticationDefaults.AuthenticationScheme);
@@ -522,7 +522,7 @@ services
     });
 ```
 
-> :warning: `AccessTokenRefreshFailedContext.Exception` may contain transport/diagnostic detail — log it server-side only, do not surface it to end users.
+> :warning: `AccessTokenRefreshFailedContext.Exception` may contain transport/diagnostic detail - log it server-side only, do not surface it to end users.
 
 ### Handling MFA during token exchange (`mfa_required`)
 
@@ -531,7 +531,7 @@ When an access-token exchange (for example a Multi-Resource Refresh Token reques
 `MfaRequiredException`. You drive the MFA challenge/verify flow with `IAuthenticationApiClient`
 and decide what to do with the resulting tokens.
 
-`ex.MfaToken` is an **opaque, encrypted token with a 5-minute lifetime** — the raw `mfa_token`
+`ex.MfaToken` is an **opaque, encrypted token with a 5-minute lifetime** - the raw `mfa_token`
 never leaves the SDK. Pass it back to the `IAuthenticationApiClient` methods unchanged; do not
 inspect, parse, or store it long-term. `ex.MfaRequirements` describes the challenge types the
 user can satisfy (for example `otp` or `oob`).
@@ -539,7 +539,7 @@ user can satisfy (for example `otp` or `oob`).
 > :information_source: `MfaRequiredException` is raised by `GetAccessTokenAsync` whenever the
 > exchange returns `mfa_required`, regardless of whether you called `WithAuthenticationApiClient()`.
 > You still need `WithAuthenticationApiClient()` to register the `IAuthenticationApiClient` that
-> *completes* the challenge — so register it whenever your tenant may return `mfa_required` on a
+> *completes* the challenge - so register it whenever your tenant may return `mfa_required` on a
 > refresh, otherwise you can catch the exception but have no client to drive the verify step.
 
 #### Register the client
@@ -612,17 +612,17 @@ public class ResourceController : Controller
             });
 
             // tokens.AccessToken is now valid for the requested audience.
-            // Persisting these tokens into the session is your responsibility — see below.
+            // Persisting these tokens into the session is your responsibility - see below.
             return Ok();
         }
         catch (MfaTokenExpiredException)
         {
-            // The 5-minute window elapsed — restart the flow to obtain a fresh token.
+            // The 5-minute window elapsed - restart the flow to obtain a fresh token.
             return RedirectToAction("CallApi");
         }
         catch (MfaTokenInvalidException)
         {
-            // The token was tampered with or malformed — restart the flow.
+            // The token was tampered with or malformed - restart the flow.
             return RedirectToAction("CallApi");
         }
     }
@@ -631,7 +631,7 @@ public class ResourceController : Controller
 
 > :information_source: The SDK returns the MFA-grant tokens to you; it does not write them back
 > into the authentication session automatically. If you want subsequent
-> `GetAccessTokenAsync` calls to reuse them, persist them yourself — for example by updating
+> `GetAccessTokenAsync` calls to reuse them, persist them yourself - for example by updating
 > the authentication properties and calling `HttpContext.SignInAsync(...)` with the updated
 > principal.
 
@@ -644,7 +644,7 @@ lifetime throws `MfaTokenExpiredException`; a tampered or malformed token throws
 
 Out-of-band factors (push notifications, SMS) are **asynchronous**: after you trigger the
 challenge you must poll the token endpoint until the user approves it. Unlike the OTP grant, the
-OOB grant does **not** throw while the user has not yet responded — Auth0 replies with
+OOB grant does **not** throw while the user has not yet responded - Auth0 replies with
 `authorization_pending` (or `slow_down` if you are polling too fast), and the SDK surfaces those
 on `MfaOobTokenResponse.Error` so you can keep polling. A populated `AccessToken` (with
 `Error == null`) means the challenge succeeded. Any genuine failure (for example an expired
@@ -697,7 +697,7 @@ public async Task<IActionResult> PollOob()
     }
     catch (MfaTokenExpiredException)
     {
-        // The 5-minute window elapsed — restart the flow to obtain a fresh token.
+        // The 5-minute window elapsed - restart the flow to obtain a fresh token.
         return RedirectToAction("CallApi");
     }
     // A genuine rejection (e.g. invalid/expired oob_code) throws ErrorApiException.
@@ -705,7 +705,7 @@ public async Task<IActionResult> PollOob()
 ```
 
 > :information_source: The `mfa_token` blob is encrypted and **self-expires 5 minutes after the
-> original `mfa_required`** — not after the challenge is triggered. Since OOB approval is
+> original `mfa_required`** - not after the challenge is triggered. Since OOB approval is
 > user-paced, treat that window as your real polling budget: if it lapses, the next
 > `GetTokenAsync` throws `MfaTokenExpiredException` before any network call, and you must restart
 > from `GetAccessTokenAsync` to mint a fresh token.
@@ -720,15 +720,15 @@ public async Task<IActionResult> PollOob()
 
 ## Token Vault (Federated Connection Access Tokens)
 
-[Token Vault](https://auth0.com/docs/secure/tokens/token-vault) lets your web app obtain a **third-party API access token** (for a federated connection such as Google, GitHub, or Slack) for the logged-in user — so your app, or an agent acting on the user's behalf, can call that provider's API. The token is obtained by exchanging the session's refresh token; the user does not have to re-authenticate.
+[Token Vault](https://auth0.com/docs/secure/tokens/token-vault) lets your web app obtain a **third-party API access token** (for a federated connection such as Google, GitHub, or Slack) for the logged-in user - so your app, or an agent acting on the user's behalf, can call that provider's API. The token is obtained by exchanging the session's refresh token; the user does not have to re-authenticate.
 
 A typical use case: the user logged in with (or has linked) their Google account, and your app needs a Google access token to read their calendar. Instead of running a separate Google OAuth flow, you exchange the existing refresh token for a Google connection token.
 
 > :information_source: Token Vault requires refresh tokens. Configure `UseRefreshTokens = true` and a `ClientSecret`, and enable Token Vault for the connection in the Auth0 Dashboard. Connection tokens are cached in the session, keyed by connection name, and reused until they near expiry.
 
-> :information_source: Unlike MRRT, the federated-connection exchange does **not** take a requested `scope` — it returns the scopes already granted for the connection. Tokens are therefore cached per **connection**, not per audience/scope. To change the granted scopes, reconfigure the connection (or re-link the account) in the Auth0 Dashboard.
+> :information_source: Unlike MRRT, the federated-connection exchange does **not** take a requested `scope` - it returns the scopes already granted for the connection. Tokens are therefore cached per **connection**, not per audience/scope. To change the granted scopes, reconfigure the connection (or re-link the account) in the Auth0 Dashboard.
 
-> :warning: **Token storage and cookie size.** Like MRRT, each connection token is cached in the encrypted **authentication cookie** by default, so retrieving tokens for several connections grows the session the same way fanning out across audiences does. If you expect to hold tokens for more than a couple of connections, move the session **server-side** — see [Server-side session storage](#server-side-session-storage). Where the token set is persisted is the only thing that changes; the API is identical either way.
+> :warning: **Token storage and cookie size.** Like MRRT, each connection token is cached in the encrypted **authentication cookie** by default, so retrieving tokens for several connections grows the session the same way fanning out across audiences does. If you expect to hold tokens for more than a couple of connections, move the session **server-side** - see [Server-side session storage](#server-side-session-storage). Where the token set is persisted is the only thing that changes; the API is identical either way.
 
 ### Retrieving a federated connection token
 
@@ -745,7 +745,7 @@ public async Task<IActionResult> CallGoogleCalendar()
 
     if (googleToken == null)
     {
-        // No refresh token available, or the exchange failed — see "Handling…" below.
+        // No refresh token available, or the exchange failed - see "Handling…" below.
         return Challenge();
     }
 
@@ -759,7 +759,7 @@ public async Task<IActionResult> CallGoogleCalendar()
 
 > :information_source: `GetAccessTokenForConnectionAsync` returns `null` rather than throwing when no refresh token is available or the exchange fails. Always check for `null` before using the token.
 
-The optional `LoginHint` disambiguates which linked identity to use when the user has more than one. It is the **provider-side identity-provider user ID** (e.g. a Google user ID) — not the Auth0 user `sub`, and not the user's email.
+The optional `LoginHint` disambiguates which linked identity to use when the user has more than one. It is the **provider-side identity-provider user ID** (e.g. a Google user ID) - not the Auth0 user `sub`, and not the user's email.
 
 `LoginHint` is part of the cache key: tokens for different login hints on the same connection are cached separately, so requesting identity B never returns identity A's cached token. A request with no `LoginHint` is cached separately from one that specifies a hint.
 
@@ -785,7 +785,7 @@ var googleToken = await HttpContext.GetAccessTokenForConnectionAsync(new AccessT
 
 ### Handling a missing refresh token or exchange failure
 
-A federated connection token can only be obtained via the session's refresh token. When none is present, the `OnMissingRefreshToken` event fires and the method returns `null`. When a refresh token is present but the exchange is rejected, the `OnAccessTokenRefreshFailed` event fires (carrying `StatusCode`, `Error`, `ErrorDescription`) and the method returns `null`. These are the same events used by MRRT — see [Handling refresh failures](#handling-refresh-failures) and [Detecting the absense of a refresh token](#detecting-the-absense-of-a-refresh-token) for full configuration examples.
+A federated connection token can only be obtained via the session's refresh token. When none is present, the `OnMissingRefreshToken` event fires and the method returns `null`. When a refresh token is present but the exchange is rejected, the `OnAccessTokenRefreshFailed` event fires (carrying `StatusCode`, `Error`, `ErrorDescription`) and the method returns `null`. These are the same events used by MRRT - see [Handling refresh failures](#handling-refresh-failures) and [Detecting the absense of a refresh token](#detecting-the-absense-of-a-refresh-token) for full configuration examples.
 
 ## Custom Token Exchange
 
@@ -841,7 +841,7 @@ var currentActor = result.Act?.Sub;
 
 ## Impersonation via Session Transfer
 
-Session Transfer builds on Custom Token Exchange to let an initiator app (e.g. a support/admin console —
+Session Transfer builds on Custom Token Exchange to let an initiator app (e.g. a support/admin console -
 the *actor*) start an authenticated web session in a target app *as a customer* (the *subject*), with the
 agent recorded in the `act` claim. The initiator requests a short-lived, single-use **Session Transfer
 Token (STT)** and redirects the agent's browser to the target's login URL carrying that STT; the target
@@ -855,10 +855,24 @@ that is provisioned out of band via the Management API.
 `RequestSessionTransferTokenAsync` performs the exchange. The **actor is auto-sourced from the agent's
 current session id_token** (refreshed automatically if stale), so the agent must be logged in. Pass an
 explicit `ActorToken` only to override that. The audience is set for you to
-`urn:{your-domain}:session_transfer`. The STT is one-shot and **never stored** — use it immediately.
+`urn:{your-domain}:session_transfer`. The STT is one-shot and **never stored** - use it immediately.
+
+> :warning: **Enable `UseRefreshTokens`.** It defaults to `false`, and without it the session carries no
+> refresh token - so once the agent's id_token expires there is no way to refresh it and every call throws
+> `CustomTokenExchangeException` with `Code == ActorUnavailable`. id_tokens are typically far shorter-lived
+> than the authentication cookie, so this is the common path rather than an edge case. The example below
+> works right after login and then starts failing in production with nothing obvious to point at.
+>
+> ```csharp
+> services.AddAuth0WebAppAuthentication(options => { /* ... */ })
+>         .WithAccessToken(options =>
+>         {
+>             options.UseRefreshTokens = true;   // adds offline_access; required for actor auto-sourcing
+>         });
+> ```
 
 ```csharp
-// Minimal API — the agent (actor) is already logged in on this app.
+// Minimal API - the agent (actor) is already logged in on this app.
 app.MapGet("/impersonate/{customerToken}", async (HttpContext http, string customerToken) =>
 {
     try
@@ -878,6 +892,8 @@ app.MapGet("/impersonate/{customerToken}", async (HttpContext http, string custo
     catch (CustomTokenExchangeException ex) when (ex.Code == CustomTokenExchangeErrorCode.ActorUnavailable)
     {
         // The agent has no usable session to act as. Send them to log in first.
+        // If this fires for an agent who *is* logged in, check UseRefreshTokens (see the warning above) -
+        // ex.Message names it.
         return Results.Challenge();
     }
     catch (CustomTokenExchangeException ex)
@@ -891,7 +907,7 @@ app.MapGet("/impersonate/{customerToken}", async (HttpContext http, string custo
 
 `BuildSessionTransferRedirect` returns a `string` (not an `IActionResult`) so it works in both Minimal APIs
 (`Results.Redirect(url)`) and MVC (`return Redirect(url);`). It requires an absolute HTTPS `targetLoginUrl`
-and throws `ArgumentException` otherwise — the STT is a live credential, so the target must be app-controlled.
+and throws `ArgumentException` otherwise - the STT is a live credential, so the target must be app-controlled.
 
 ### Target: redeem the STT at login
 
@@ -921,8 +937,16 @@ var actor = http.User.FindFirst("act")?.Value; // JSON: {"sub":"<agent>"}
 ```
 
 > **Notes:**
-> - The agent must be logged in on the initiator app — that session is the actor source.
+> - The agent must be logged in on the initiator app - that session is the actor source.
 > - The STT is single-use and short-lived (~60s); never persist it.
+> - **Do not call this concurrently for the same session.** When the actor is auto-sourced and the
+>   id_token is stale, this method refreshes and re-signs the session exactly as `GetAccessTokenAsync`
+>   does, so it carries the same hazard: with refresh-token rotation enabled, two concurrent calls
+>   exchange the same refresh token and the second can trip reuse detection and **invalidate the agent's
+>   whole session**. An admin console firing a few impersonation requests at once is enough. Serialize
+>   them, plug in a server-side session store via `WithSessionStore(...)`, or pass an explicit
+>   `ActorToken` to skip the refresh path. `GetAccessTokenAsync` and `GetAccessTokenForConnectionAsync`
+>   count toward the same limit - they share the session's token slots.
 > - Branch on `result.IssuedTokenType` (`Auth0Constants.SessionTransferTokenType`), never on
 >   `result.TokenType`, if the token
 >   endpoint returns 200 without `issued_token_type` set to the session-transfer URN, `RequestSessionTransferTokenAsync`
@@ -934,7 +958,7 @@ var actor = http.User.FindFirst("act")?.Value; // JSON: {"sub":"<agent>"}
 
 When the actor is auto-sourced and the agent's session ID token has expired, the SDK refreshes it. If
 your tenant requires step-up MFA on that refresh, `RequestSessionTransferTokenAsync` throws
-`MfaRequiredException` rather than collapsing it into `ActorUnavailable` — the session is fine, it
+`MfaRequiredException` rather than collapsing it into `ActorUnavailable` - the session is fine, it
 just needs a challenge completed.
 
 The refresh requests the `openid` scope, which is bound into the `mfa_token` blob, so the MFA grant
@@ -962,15 +986,14 @@ catch (MfaRequiredException ex)
 }
 catch (CustomTokenExchangeException ex) when (ex.Code == CustomTokenExchangeErrorCode.ActorUnavailable)
 {
-    // No usable ID token and no refresh token — the agent must log in again.
-    // Note `UseRefreshTokens` defaults to false; enable it via
-    // .WithAccessToken(o => o.UseRefreshTokens = true) so a stale ID token can be refreshed at all.
+    // No usable ID token and no refresh token - the agent must log in again.
+    // If they are logged in, check `UseRefreshTokens` (see the warning above).
     return Challenge();
 }
 ```
 
-> :information_source: A transport failure reaching the token endpoint — on either the actor refresh
-> or the exchange — surfaces as `CustomTokenExchangeException` with the original
+> :information_source: A transport failure reaching the token endpoint - on either the actor refresh
+> or the exchange - surfaces as `CustomTokenExchangeException` with the original
 > `HttpRequestException` / `TaskCanceledException` on `InnerException`, so a timeout stays
 > distinguishable from a rejection.
 
@@ -1242,7 +1265,7 @@ Rule of thumb: set `maxSize` to cover the number of distinct domains a single pr
 
 #### NullConfigurationManagerCache
 
-Disables caching entirely — a new configuration manager is created on every request (not recommended for production):
+Disables caching entirely - a new configuration manager is created on every request (not recommended for production):
 
 ```csharp
 .WithCustomDomains(options =>

--- a/src/Auth0.AspNetCore.Authentication/AccessTokenResponse.cs
+++ b/src/Auth0.AspNetCore.Authentication/AccessTokenResponse.cs
@@ -36,5 +36,18 @@ namespace Auth0.AspNetCore.Authentication
         /// </summary>
         [JsonPropertyName("scope")]
         public string? Scope { get; set; }
+
+        /// <summary>
+        /// The RFC 8693 <c>issued_token_type</c>. For a Session Transfer Token exchange this is
+        /// <see cref="Auth0Constants.SessionTransferTokenType"/>. Null for ordinary exchanges.
+        /// </summary>
+        [JsonPropertyName("issued_token_type")]
+        public string? IssuedTokenType { get; set; }
+
+        /// <summary>
+        /// The <c>token_type</c>; informational only (typically <c>Bearer</c> or <c>N_A</c> for STTs).
+        /// </summary>
+        [JsonPropertyName("token_type")]
+        public string? TokenType { get; set; }
     }
 }

--- a/src/Auth0.AspNetCore.Authentication/ActClaimReader.cs
+++ b/src/Auth0.AspNetCore.Authentication/ActClaimReader.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Text;
 using System.Text.Json;
+using Microsoft.IdentityModel.Tokens;
 
 namespace Auth0.AspNetCore.Authentication
 {
@@ -26,7 +27,7 @@ namespace Auth0.AspNetCore.Authentication
                     return null;
                 }
 
-                var payloadJson = Encoding.UTF8.GetString(Base64UrlDecode(parts[1]));
+                var payloadJson = Encoding.UTF8.GetString(Base64UrlEncoder.DecodeBytes(parts[1]));
                 using var document = JsonDocument.Parse(payloadJson);
 
                 if (!document.RootElement.TryGetProperty("act", out var actElement) ||
@@ -61,17 +62,6 @@ namespace Auth0.AspNetCore.Authentication
             }
 
             return claim;
-        }
-
-        private static byte[] Base64UrlDecode(string input)
-        {
-            var output = input.Replace('-', '+').Replace('_', '/');
-            switch (output.Length % 4)
-            {
-                case 2: output += "=="; break;
-                case 3: output += "="; break;
-            }
-            return Convert.FromBase64String(output);
         }
     }
 }

--- a/src/Auth0.AspNetCore.Authentication/Auth0Constants.cs
+++ b/src/Auth0.AspNetCore.Authentication/Auth0Constants.cs
@@ -46,5 +46,16 @@
         /// No real seconds value is this large (10,000,000,000 seconds is the year 2286).
         /// </summary>
         internal static readonly long SessionExpiryMaxSeconds = 10_000_000_000;
+        /// The <c>issued_token_type</c> value that identifies a response as carrying a
+        /// Session Transfer Token (STT). Branch on this value — never on <c>token_type</c>,
+        /// which is the informational <c>N_A</c> for STT responses.
+        /// </summary>
+        public const string SessionTransferTokenType = "urn:auth0:params:oauth:token-type:session_transfer_token";
+
+        /// <summary>
+        /// The RFC 8693 token-type URI for an ID token. Used as the default
+        /// <c>actor_token_type</c> when the actor is auto-sourced from the agent's session id_token.
+        /// </summary>
+        internal const string IdTokenType = "urn:ietf:params:oauth:token-type:id_token";
     }
 }

--- a/src/Auth0.AspNetCore.Authentication/Auth0Constants.cs
+++ b/src/Auth0.AspNetCore.Authentication/Auth0Constants.cs
@@ -46,16 +46,18 @@
         /// No real seconds value is this large (10,000,000,000 seconds is the year 2286).
         /// </summary>
         internal static readonly long SessionExpiryMaxSeconds = 10_000_000_000;
+
+        /// <summary>
         /// The <c>issued_token_type</c> value that identifies a response as carrying a
         /// Session Transfer Token (STT). Branch on this value — never on <c>token_type</c>,
         /// which is the informational <c>N_A</c> for STT responses.
         /// </summary>
-        public const string SessionTransferTokenType = "urn:auth0:params:oauth:token-type:session_transfer_token";
+        public static readonly string SessionTransferTokenType = "urn:auth0:params:oauth:token-type:session_transfer_token";
 
         /// <summary>
         /// The RFC 8693 token-type URI for an ID token. Used as the default
         /// <c>actor_token_type</c> when the actor is auto-sourced from the agent's session id_token.
         /// </summary>
-        internal const string IdTokenType = "urn:ietf:params:oauth:token-type:id_token";
+        internal static readonly string IdTokenType = "urn:ietf:params:oauth:token-type:id_token";
     }
 }

--- a/src/Auth0.AspNetCore.Authentication/Auth0WebAppWithAccessTokenOptions.cs
+++ b/src/Auth0.AspNetCore.Authentication/Auth0WebAppWithAccessTokenOptions.cs
@@ -35,6 +35,12 @@ namespace Auth0.AspNetCore.Authentication
         /// already expired, so that a refresh is triggered proactively rather than the token
         /// lapsing mid-request. Applies to both the primary (login-time) token and additional
         /// audience/scope tokens retrieved on demand (MRRT). Defaults to 60 seconds.
+        /// <para>
+        /// It also governs the stored
+        /// <c>id_token</c>: it decides when
+        /// <see cref="HttpContextExtensions.RequestSessionTransferTokenAsync"/> considers an
+        /// auto-sourced actor id_token stale enough to refresh.
+        /// </para>
         /// </summary>
         public TimeSpan AccessTokenExpirationLeeway { get; set; } = TimeSpan.FromSeconds(60);
 

--- a/src/Auth0.AspNetCore.Authentication/AuthenticationApi/Models/TokenBase.cs
+++ b/src/Auth0.AspNetCore.Authentication/AuthenticationApi/Models/TokenBase.cs
@@ -14,4 +14,15 @@ public abstract class TokenBase
     /// <summary>The type of token (typically <c>Bearer</c>).</summary>
     [JsonPropertyName("token_type")]
     public string? TokenType { get; set; }
+
+    /// <summary>
+    /// The ID token, when the completed grant requested the <c>openid</c> scope.
+    /// <para>
+    /// The MFA verify grants answer with the same payload as the password grant, which includes
+    /// <c>id_token</c>; without this property it was deserialized away. It is <c>null</c> whenever
+    /// <c>openid</c> was not among the scopes bound to the originating request.
+    /// </para>
+    /// </summary>
+    [JsonPropertyName("id_token")]
+    public string? IdToken { get; set; }
 }

--- a/src/Auth0.AspNetCore.Authentication/CustomTokenExchangeErrorCode.cs
+++ b/src/Auth0.AspNetCore.Authentication/CustomTokenExchangeErrorCode.cs
@@ -2,8 +2,6 @@ namespace Auth0.AspNetCore.Authentication
 {
     /// <summary>
     /// Machine-readable error codes carried on <see cref="CustomTokenExchangeException.Code"/>.
-    /// Constant names are C#-idiomatic PascalCase; values are the spec's snake_case, matching how
-    /// nextjs-auth0 and auth0-server-python represent them.
     /// </summary>
     public static class CustomTokenExchangeErrorCode
     {
@@ -16,11 +14,24 @@ namespace Auth0.AspNetCore.Authentication
         public const string InvalidTokenFormat = "invalid_token_format";
 
         /// <summary>The token endpoint rejected the exchange because <c>setActor</c> is required
-        /// for a session-transfer exchange. Documented; surfaced via the raw server error.</summary>
+        /// for a session-transfer exchange.
+        /// </summary>
         public const string SetActorRequired = "setactor_required";
 
         /// <summary>The token endpoint rejected the exchange because session transfer is disabled
-        /// for the client. Documented; surfaced via the raw server error.</summary>
+        /// for the client.
+        /// </summary>
         public const string SessionTransferDisabled = "session_transfer_disabled";
+
+        /// <summary>
+        /// Maps a token-endpoint <c>error</c> value onto one of the session-transfer codes,
+        /// returning <c>null</c> when it is not one of them.
+        /// </summary>
+        internal static string? MapServerError(string? error) => error?.ToLowerInvariant() switch
+        {
+            SetActorRequired => SetActorRequired,
+            SessionTransferDisabled => SessionTransferDisabled,
+            _ => null
+        };
     }
 }

--- a/src/Auth0.AspNetCore.Authentication/CustomTokenExchangeErrorCode.cs
+++ b/src/Auth0.AspNetCore.Authentication/CustomTokenExchangeErrorCode.cs
@@ -1,0 +1,26 @@
+namespace Auth0.AspNetCore.Authentication
+{
+    /// <summary>
+    /// Machine-readable error codes carried on <see cref="CustomTokenExchangeException.Code"/>.
+    /// Constant names are C#-idiomatic PascalCase; values are the spec's snake_case, matching how
+    /// nextjs-auth0 and auth0-server-python represent them.
+    /// </summary>
+    public static class CustomTokenExchangeErrorCode
+    {
+        /// <summary>No actor could be resolved (no explicit actor, no usable session id_token,
+        /// no refreshable session). Raised client-side, before any network call.</summary>
+        public const string ActorUnavailable = "actor_unavailable";
+
+        /// <summary>An explicit actor token was supplied but was blank/whitespace-only.
+        /// Raised client-side (matches the auth0-server-python PoC).</summary>
+        public const string InvalidTokenFormat = "invalid_token_format";
+
+        /// <summary>The token endpoint rejected the exchange because <c>setActor</c> is required
+        /// for a session-transfer exchange. Documented; surfaced via the raw server error.</summary>
+        public const string SetActorRequired = "setactor_required";
+
+        /// <summary>The token endpoint rejected the exchange because session transfer is disabled
+        /// for the client. Documented; surfaced via the raw server error.</summary>
+        public const string SessionTransferDisabled = "session_transfer_disabled";
+    }
+}

--- a/src/Auth0.AspNetCore.Authentication/CustomTokenExchangeException.cs
+++ b/src/Auth0.AspNetCore.Authentication/CustomTokenExchangeException.cs
@@ -20,8 +20,9 @@ namespace Auth0.AspNetCore.Authentication
 
         /// <summary>
         /// A machine-readable SDK error code (see <see cref="CustomTokenExchangeErrorCode"/>) for
-        /// failures the SDK raises itself before or around the network call. Null for the existing
-        /// message-only and token-endpoint-rejection constructors.
+        /// failures the SDK raises itself before or around the network call, and for token-endpoint
+        /// rejections whose <c>error</c> field maps onto a known code. Inspect <see cref="Error"/> and
+        /// <see cref="ErrorDescription"/> when this is null.
         /// </summary>
         public string? Code { get; }
 
@@ -47,11 +48,22 @@ namespace Auth0.AspNetCore.Authentication
 
         /// <summary>Creates an exception for a token-endpoint rejection.</summary>
         public CustomTokenExchangeException(int? statusCode, string? error, string? errorDescription)
+            : this(statusCode, error, errorDescription, null)
+        {
+        }
+
+        /// <summary>
+        /// Creates an exception for a token-endpoint rejection, additionally carrying a machine-readable
+        /// SDK <paramref name="code"/> mapped from the server's <c>error</c> field. <see cref="Error"/>
+        /// and <see cref="ErrorDescription"/> still carry the server's own values verbatim.
+        /// </summary>
+        public CustomTokenExchangeException(int? statusCode, string? error, string? errorDescription, string? code)
             : base(BuildMessage(statusCode, error, errorDescription))
         {
             StatusCode = statusCode;
             Error = error;
             ErrorDescription = errorDescription;
+            Code = code;
         }
 
         private static string BuildMessage(int? statusCode, string? error, string? errorDescription)

--- a/src/Auth0.AspNetCore.Authentication/CustomTokenExchangeException.cs
+++ b/src/Auth0.AspNetCore.Authentication/CustomTokenExchangeException.cs
@@ -18,9 +18,22 @@ namespace Auth0.AspNetCore.Authentication
         /// <summary>The <c>error_description</c> from the token endpoint's error body, when present.</summary>
         public string? ErrorDescription { get; }
 
+        /// <summary>
+        /// A machine-readable SDK error code (see <see cref="CustomTokenExchangeErrorCode"/>) for
+        /// failures the SDK raises itself before or around the network call. Null for the existing
+        /// message-only and token-endpoint-rejection constructors.
+        /// </summary>
+        public string? Code { get; }
+
         /// <summary>Creates an exception for a client-side validation failure.</summary>
         public CustomTokenExchangeException(string message) : base(message)
         {
+        }
+
+        /// <summary>Creates an exception carrying a machine-readable SDK error code.</summary>
+        public CustomTokenExchangeException(string code, string message) : base(message)
+        {
+            Code = code;
         }
 
         /// <summary>Creates an exception for a token-endpoint rejection.</summary>

--- a/src/Auth0.AspNetCore.Authentication/CustomTokenExchangeException.cs
+++ b/src/Auth0.AspNetCore.Authentication/CustomTokenExchangeException.cs
@@ -36,6 +36,15 @@ namespace Auth0.AspNetCore.Authentication
             Code = code;
         }
 
+        /// <summary>
+        /// Creates an exception wrapping an underlying failure — typically a transport error from the
+        /// token endpoint call. The original exception is preserved on
+        /// <see cref="Exception.InnerException"/> so callers can still distinguish, say, a timeout.
+        /// </summary>
+        public CustomTokenExchangeException(string message, Exception innerException) : base(message, innerException)
+        {
+        }
+
         /// <summary>Creates an exception for a token-endpoint rejection.</summary>
         public CustomTokenExchangeException(int? statusCode, string? error, string? errorDescription)
             : base(BuildMessage(statusCode, error, errorDescription))

--- a/src/Auth0.AspNetCore.Authentication/HttpContextExtensions.cs
+++ b/src/Auth0.AspNetCore.Authentication/HttpContextExtensions.cs
@@ -527,7 +527,6 @@ namespace Auth0.AspNetCore.Authentication
 
             var response = result.Response!;
 
-
             // A CTE profile that is not set up for session transfer
             // returns an ordinary, long-lived, multi-use access token through this exact path.
             // A tenant misconfiguration must surface as an error.

--- a/src/Auth0.AspNetCore.Authentication/HttpContextExtensions.cs
+++ b/src/Auth0.AspNetCore.Authentication/HttpContextExtensions.cs
@@ -398,6 +398,12 @@ namespace Auth0.AspNetCore.Authentication
         /// id_token cannot be refreshed and this method throws
         /// <see cref="CustomTokenExchangeErrorCode.ActorUnavailable"/>.
         /// </para>
+        /// <para>
+        /// <b>Enable <see cref="Auth0WebAppWithAccessTokenOptions.UseRefreshTokens"/>.</b> It defaults to
+        /// <c>false</c>, and without it the session carries no <c>.Token.refresh_token</c>, so a stale
+        /// id_token cannot be refreshed and this method throws
+        /// <see cref="CustomTokenExchangeErrorCode.ActorUnavailable"/>.
+        /// </para>
         /// </summary>
         /// <remarks>
         /// This method is not safe to call concurrently for the same session. When the actor is

--- a/src/Auth0.AspNetCore.Authentication/HttpContextExtensions.cs
+++ b/src/Auth0.AspNetCore.Authentication/HttpContextExtensions.cs
@@ -378,6 +378,389 @@ namespace Auth0.AspNetCore.Authentication
         }
 
         /// <summary>
+        /// Requests a Session Transfer Token (STT) via Custom Token Exchange: exchanges the customer
+        /// <see cref="SessionTransferTokenRequest.SubjectToken"/> for a short-lived, single-use STT
+        /// that can be placed on a redirect to a target app (see
+        /// <see cref="BuildSessionTransferRedirect"/>). The actor (the agent) is auto-sourced from the
+        /// current session's id_token unless an explicit <see cref="SessionTransferTokenRequest.ActorToken"/>
+        /// is supplied. The audience is set by the SDK to <c>urn:{resolved-domain}:session_transfer</c>.
+        /// <para>
+        /// The STT is <b>never persisted</b>. Auto-sourcing the actor may, however, refresh and persist
+        /// the agent's session id_token when it is stale - identical to
+        /// <see cref="GetAccessTokenAsync"/> and required for refresh-token rotation safety. How close to
+        /// its <c>exp</c> the id_token must be to count as stale is governed by
+        /// <see cref="Auth0WebAppWithAccessTokenOptions.AccessTokenExpirationLeeway"/>, which the SDK uses
+        /// as its single expiry margin rather than exposing a separate id_token setting.
+        /// </para>
+        /// <para>
+        /// <b>Enable <see cref="Auth0WebAppWithAccessTokenOptions.UseRefreshTokens"/>.</b> It defaults to
+        /// <c>false</c>, and without it the session carries no <c>.Token.refresh_token</c>, so a stale
+        /// id_token cannot be refreshed and this method throws
+        /// <see cref="CustomTokenExchangeErrorCode.ActorUnavailable"/>.
+        /// </para>
+        /// </summary>
+        /// <remarks>
+        /// This method is not safe to call concurrently for the same session. When the actor is
+        /// auto-sourced and the session id_token is stale, it performs the same read, refresh and
+        /// <see cref="AuthenticationHttpContextExtensions.SignInAsync(HttpContext, string?, System.Security.Claims.ClaimsPrincipal, AuthenticationProperties?)"/>
+        /// sequence as <see cref="GetAccessTokenAsync"/>, and carries the same hazard.
+        /// <para>
+        /// To avoid it, ensure only one call that may refresh the session is in flight per session at a
+        /// time - counting <see cref="GetAccessTokenAsync"/> and
+        /// <see cref="GetAccessTokenForConnectionAsync"/> as well, since they share the same session
+        /// slots. Either don't issue such requests in parallel, or plug in a server-side session store via
+        /// <see cref="Auth0WebAppAuthenticationBuilder.WithSessionStore(Microsoft.AspNetCore.Authentication.Cookies.ITicketStore)"/>
+        /// whose <c>ITicketStore</c> serializes concurrent access per session. Passing an explicit
+        /// <see cref="SessionTransferTokenRequest.ActorToken"/> skips the refresh path entirely and avoids
+        /// the hazard.
+        /// </para>
+        /// </remarks>
+        /// <param name="context">The current <see cref="HttpContext"/>.</param>
+        /// <param name="request">The session-transfer request (subject token + type, optional explicit
+        /// actor pair, organization, scope).</param>
+        /// <param name="scheme">The Auth0 authentication scheme. Defaults to <see cref="Auth0Constants.AuthenticationScheme"/>.</param>
+        /// <returns>The issued Session Transfer Token and metadata.</returns>
+        /// <exception cref="CustomTokenExchangeException">
+        /// Thrown on client-side validation failure; when an explicit actor is blank, untrimmed or
+        /// <c>"Bearer "</c>-prefixed, or when <see cref="SessionTransferTokenRequest.ActorTokenType"/> is
+        /// set without an <see cref="SessionTransferTokenRequest.ActorToken"/>
+        /// (<see cref="CustomTokenExchangeErrorCode.InvalidTokenFormat"/>); when no actor can be
+        /// resolved (<see cref="CustomTokenExchangeErrorCode.ActorUnavailable"/>); when the token
+        /// endpoint rejects the exchange (carrying the raw status/error/error_description, plus
+        /// <see cref="CustomTokenExchangeException.Code"/> when the server's <c>error</c> maps onto
+        /// <see cref="CustomTokenExchangeErrorCode.SetActorRequired"/> or
+        /// <see cref="CustomTokenExchangeErrorCode.SessionTransferDisabled"/> - Auth0 reports both as a
+        /// generic <c>invalid_request</c> today, so match on
+        /// <see cref="CustomTokenExchangeException.ErrorDescription"/> for now); or when it
+        /// returns 200 without <c>issued_token_type</c> set to
+        /// <see cref="Auth0Constants.SessionTransferTokenType"/> (<see cref="CustomTokenExchangeException.Error"/>
+        /// is <c>invalid_issued_token_type</c>), which indicates the CTE profile or client is not
+        /// configured for session transfer. Also thrown when a transport error prevents reaching the
+        /// token endpoint - either on the actor refresh or on the exchange itself - with the original
+        /// <see cref="System.Net.Http.HttpRequestException"/> / <see cref="System.Threading.Tasks.TaskCanceledException"/>
+        /// preserved on <see cref="System.Exception.InnerException"/>.
+        /// </exception>
+        /// <exception cref="MfaRequiredException">
+        /// Thrown when auto-sourcing the actor requires refreshing a stale session id_token and that
+        /// refresh returns <c>mfa_required</c> with an <c>mfa_token</c>. This is a recoverable step-up
+        /// challenge rather than an unresolvable actor: drive the challenge/verify flow with
+        /// <see cref="AuthenticationApi.IAuthenticationApiClient"/> using the
+        /// <see cref="MfaRequiredException.MfaToken"/> blob, then pass the <c>id_token</c> from the
+        /// completed grant back as <see cref="SessionTransferTokenRequest.ActorToken"/> and retry.
+        /// The actor refresh binds the <c>openid</c> scope into the blob so the MFA grant returns one.
+        /// An <c>mfa_required</c> response with no <c>mfa_token</c> cannot drive the flow and falls
+        /// through to <see cref="CustomTokenExchangeErrorCode.ActorUnavailable"/> instead.
+        /// </exception>
+        /// <exception cref="System.InvalidOperationException">
+        /// Thrown when auto-sourcing the actor refreshes a stale session id_token but the rotated
+        /// session cannot be persisted because the response has already started. Persisting calls
+        /// <see cref="AuthenticationHttpContextExtensions.SignInAsync(HttpContext, string?, System.Security.Claims.ClaimsPrincipal, AuthenticationProperties?)"/>,
+        /// which writes the authentication cookie; if the headers have already been sent, this throws
+        /// and the exception propagates out of this method (identical to <see cref="GetAccessTokenAsync"/>).
+        /// </exception>
+        public static async Task<SessionTransferTokenResult> RequestSessionTransferTokenAsync(this HttpContext context, SessionTransferTokenRequest request, string? scheme = null)
+        {
+            scheme ??= Auth0Constants.AuthenticationScheme;
+
+            // Reuse the existing CTE subject-token validation (empty / whitespace / "Bearer " prefix).
+            CustomTokenExchangeRequestValidator.Validate(new CustomTokenExchangeRequest
+            {
+                SubjectToken = request.SubjectToken,
+                SubjectTokenType = request.SubjectTokenType
+            });
+
+            var options = context.RequestServices.GetRequiredService<IOptionsSnapshot<Auth0WebAppOptions>>().Get(scheme);
+            var optionsWithAccessToken = context.RequestServices.GetRequiredService<IOptionsSnapshot<Auth0WebAppWithAccessTokenOptions>>().Get(scheme);
+
+            var (actorToken, actorTokenType) = await ResolveActorTokenAsync(context, request, options, optionsWithAccessToken).ConfigureAwait(false);
+
+            var resolvedDomain = context.GetResolvedDomain();
+
+            // The audience must carry the bare host. A DomainResolver may return either a bare host
+            // ("tenant.custom.com") or a full issuer ("https://tenant.custom.com/") - both shapes are
+            // supported and Auth0CustomDomainStartupFilter stores whichever it gets verbatim in
+            // HttpContext.Items - so interpolating the raw value would yield
+            // urn:https://tenant.custom.com:session_transfer. Normalizing through Utils.ToAuthority
+            // first is how the rest of the SDK consumes this value (see
+            // Auth0CustomDomainsOpenIdConnectConfigurationManager and BackchannelLogoutHandler).
+            var audienceHost = new Uri(Utils.ToAuthority(resolvedDomain ?? options.Domain)).Host;
+            var audience = $"urn:{audienceHost}:session_transfer";
+
+            var httpClient = options.Backchannel ?? context.RequestServices.GetRequiredService<IHttpClientFactory>().CreateClient();
+            var tokenClient = new TokenClient(httpClient);
+
+            TokenRefreshResult result;
+            try
+            {
+                result = await tokenClient.ExchangeCustomToken(
+                    options,
+                    request.SubjectToken,
+                    request.SubjectTokenType,
+                    audience,
+                    request.Scope,
+                    actorToken,
+                    actorTokenType,
+                    request.Organization,
+                    resolvedDomain).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                // Keep a single failure protocol: a transport error reaching the token endpoint is
+                // reported the same way as a rejection by it, with the original exception preserved
+                // on InnerException.
+                throw new CustomTokenExchangeException(
+                    "The session transfer token exchange could not reach the token endpoint.", ex);
+            }
+
+            if (!result.IsSuccess)
+            {
+                // The raw error/error_description are always preserved; Code is additionally set when
+                // the server's error field is one the SDK recognises, so a caller can match on
+                // CustomTokenExchangeErrorCode instead of parsing text. Null today - Auth0 reports both
+                // session-transfer rejections as a generic invalid_request.
+                throw new CustomTokenExchangeException(
+                    result.StatusCode,
+                    result.Error,
+                    result.ErrorDescription,
+                    CustomTokenExchangeErrorCode.MapServerError(result.Error));
+            }
+
+            var response = result.Response!;
+
+
+            // A CTE profile that is not set up for session transfer
+            // returns an ordinary, long-lived, multi-use access token through this exact path.
+            // A tenant misconfiguration must surface as an error.
+            if (!string.Equals(response.IssuedTokenType, Auth0Constants.SessionTransferTokenType, StringComparison.Ordinal))
+            {
+                throw new CustomTokenExchangeException(
+                    result.StatusCode,
+                    "invalid_issued_token_type",
+                    $"The token endpoint did not return a session transfer token.");
+            }
+
+            // The STT is returned in the access_token field. It is surfaced to the caller and never persisted.
+            return new SessionTransferTokenResult
+            {
+                SessionTransferToken = response.AccessToken,
+                IssuedTokenType = response.IssuedTokenType!,
+                ExpiresIn = response.ExpiresIn,
+                TokenType = response.TokenType,
+                Scope = response.Scope
+            };
+        }
+
+        /// <summary>
+        /// Resolves the actor token for a session-transfer exchange. Explicit actor wins; otherwise the
+        /// session id_token is used when fresh, refreshed when stale (persisting the rotated session),
+        /// and <see cref="CustomTokenExchangeErrorCode.ActorUnavailable"/> is thrown when nothing is
+        /// resolvable - before any STT exchange call.
+        /// </summary>
+        private static async Task<(string ActorToken, string ActorTokenType)> ResolveActorTokenAsync(
+            HttpContext context,
+            SessionTransferTokenRequest request,
+            Auth0WebAppOptions options,
+            Auth0WebAppWithAccessTokenOptions optionsWithAccessToken)
+        {
+            if (request.ActorToken != null)
+            {
+                return SessionTransferActorResolver.ResolveExplicitActor(request.ActorToken, request.ActorTokenType);
+            }
+
+            // An ActorTokenType with no ActorToken cannot be honoured
+            if (!string.IsNullOrWhiteSpace(request.ActorTokenType))
+            {
+                throw new CustomTokenExchangeException(
+                    CustomTokenExchangeErrorCode.InvalidTokenFormat,
+                    "ActorTokenType was provided without an ActorToken. Supply both to use an explicit actor");
+            }
+
+            var authenticateResult = await context.AuthenticateAsync(options.CookieAuthenticationScheme).ConfigureAwait(false);
+            if (!authenticateResult.Succeeded || authenticateResult.Properties == null)
+            {
+                throw new CustomTokenExchangeException(
+                    CustomTokenExchangeErrorCode.ActorUnavailable,
+                    "No authenticated session is available to source the actor token.");
+            }
+
+            var properties = authenticateResult.Properties;
+            properties.Items.TryGetValue(".Token.id_token", out var idToken);
+
+            // AccessTokenExpirationLeeway is reused for the id_token deliberately, rather than given a
+            // dedicated option.
+            // AuthenticationBuilderExtensions.RefreshTokenIfNeccesary applies it to a refresh that
+            // rotates the stored id_token alongside the access token, so it governs id_token freshness
+            // on the cookie-validation path too. If a caller ever needs them to differ, they can pass an explicit ActorToken.
+            var leeway = optionsWithAccessToken.AccessTokenExpirationLeeway;
+            if (SessionTransferActorResolver.IsIdTokenFresh(idToken, leeway))
+            {
+                return (idToken!, Auth0Constants.IdTokenType);
+            }
+
+            // Stale/missing id_token - try to refresh via the session refresh token (rotation-safe).
+            if (properties.Items.TryGetValue(".Token.refresh_token", out var refreshToken) && !string.IsNullOrWhiteSpace(refreshToken))
+            {
+                var httpClient = options.Backchannel ?? context.RequestServices.GetRequiredService<IHttpClientFactory>().CreateClient();
+                var tokenClient = new TokenClient(httpClient);
+                var resolvedDomain = context.GetResolvedDomain();
+
+                const string actorRefreshScope = "openid";
+
+                TokenRefreshResult refreshResult;
+                try
+                {
+                    refreshResult = await tokenClient.Refresh(options, refreshToken!, resolvedDomain, scope: actorRefreshScope).ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    // Transport errors (HttpRequestException, TaskCanceledException) would otherwise
+                    // escape raw from a method documented to fail via CustomTokenExchangeException.
+                    // ActorUnavailable would be a lie here - the session is fine, the network was not.
+                    throw new CustomTokenExchangeException(
+                        "Failed to refresh the session id_token needed to source the actor token.", ex);
+                }
+
+                // A step-up challenge is a recoverable case distinct from "no usable actor": collapsing
+                // it into ActorUnavailable would tell the agent its session has no refresh token, which
+                // is false, and leave no path to complete MFA and retry.
+                if (!refreshResult.IsSuccess &&
+                    refreshResult.Error == "mfa_required" &&
+                    !string.IsNullOrEmpty(refreshResult.MfaToken))
+                {
+                    var protector = context.RequestServices.GetRequiredService<IMfaTokenProtector>();
+                    var blob = protector.Protect(new MfaTokenContext
+                    {
+                        MfaToken = refreshResult.MfaToken!,
+                        Audience = null,
+                        Scope = actorRefreshScope,
+                        MfaRequirements = refreshResult.MfaRequirements
+                    });
+
+                    throw new MfaRequiredException(
+                        blob,
+                        refreshResult.MfaRequirements,
+                        (HttpStatusCode)(refreshResult.StatusCode ?? (int)HttpStatusCode.Forbidden),
+                        new Exceptions.ApiError { Error = refreshResult.Error, Message = refreshResult.ErrorDescription ?? string.Empty });
+                }
+
+                if (refreshResult.IsSuccess && !string.IsNullOrEmpty(refreshResult.Response!.IdToken))
+                {
+                    var response = refreshResult.Response!;
+
+                    // Only the id_token (and a rotated refresh token) are persisted. The primary
+                    // .Token.access_token / .Token.expires_at slots are deliberately left alone:
+                    // this refresh requests no audience or scope, so the access token it returns is
+                    // for the tenant default rather than the application's configured audience -
+                    // exactly the contract MatchesPrimaryToken and IsPrimaryExpired rely on.
+                    // Writing it (and resetting expires_at to a full fresh lifetime) would make the
+                    // next GetAccessTokenAsync serve a wrong-audience token from cache, and the reset
+                    // expiry would keep it doing so for that whole lifetime.
+                    //
+                    // Assigned directly rather than via UpdateTokenValue, which only writes a key
+                    // that is already present: a session with no stored id_token would otherwise
+                    // no-op here and persist nothing, burning a refresh-token rotation per call.
+                    properties.Items[".Token.id_token"] = response.IdToken;
+
+                    if (!string.IsNullOrEmpty(response.RefreshToken))
+                    {
+                        properties.UpdateTokenValue("refresh_token", response.RefreshToken);
+                    }
+
+                    await context.SignInAsync(options.CookieAuthenticationScheme, authenticateResult.Principal!, properties).ConfigureAwait(false);
+
+                    return (response.IdToken, Auth0Constants.IdTokenType);
+                }
+            }
+
+            // UseRefreshTokens defaults to false, so "no refresh token" is the SDK's out-of-the-box
+            // state rather than an unusual one. Naming the option here means the exception explains
+            // its own most likely cause instead of reading as an unrecoverable session problem.
+            throw new CustomTokenExchangeException(
+                CustomTokenExchangeErrorCode.ActorUnavailable,
+                "Could not source an actor token: the session has no usable id_token and no refresh token to obtain one. " +
+                "Enable refresh tokens with .WithAccessToken(o => o.UseRefreshTokens = true) so a stale id_token can be " +
+                "refreshed, or pass an explicit ActorToken on the request.");
+        }
+
+        /// <summary>
+        /// Builds the redirect URL that carries a Session Transfer Token to a target app's login
+        /// endpoint. Appends <c>session_transfer_token</c> (URL-encoded) to <paramref name="targetLoginUrl"/>,
+        /// preserving any existing query, and appends <c>organization</c> when supplied. Performs no
+        /// network call and writes nothing.
+        /// </summary>
+        /// <remarks>
+        /// Returns a <see cref="string"/> rather than an <c>IActionResult</c> so the same helper works
+        /// in Minimal APIs (<c>Results.Redirect(url)</c>) and MVC (<c>Redirect(url)</c>) - an
+        /// <c>IActionResult</c> would not compose with a Minimal API endpoint return.
+        /// <para>
+        /// <b>Security:</b> <paramref name="targetLoginUrl"/> must be app-controlled - the STT is a live
+        /// credential. The URL must be absolute HTTPS; a relative or non-HTTPS target throws.
+        /// </para>
+        /// This is kept as an <see cref="HttpContext"/> extension (though it does not read the context)
+        /// so it sits discoverably alongside <see cref="RequestSessionTransferTokenAsync"/>.
+        /// </remarks>
+        /// <param name="context">The current <see cref="HttpContext"/> (unused; present for a consistent surface).</param>
+        /// <param name="targetLoginUrl">The target app's login URL. Must be an absolute HTTPS URI.</param>
+        /// <param name="result">The result from <see cref="RequestSessionTransferTokenAsync"/>.</param>
+        /// <param name="organization">Optional organization ID/name to forward to the target.</param>
+        /// <returns>The absolute redirect URL carrying the STT.</returns>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="targetLoginUrl"/> is not an absolute HTTPS URI.</exception>
+        public static string BuildSessionTransferRedirect(this HttpContext context, string targetLoginUrl, SessionTransferTokenResult result, string? organization = null)
+        {
+            if (!Uri.TryCreate(targetLoginUrl, UriKind.Absolute, out var uri) || uri.Scheme != Uri.UriSchemeHttps)
+            {
+                throw new ArgumentException(
+                    "targetLoginUrl must be an absolute HTTPS URL.", nameof(targetLoginUrl));
+            }
+
+            // Split off any fragment so the query is inserted before it. Appending to the raw
+            // string would place session_transfer_token after '#', where the browser never
+            // transmits it and the STT silently never reaches the target.
+            var hashIndex = targetLoginUrl.IndexOf('#');
+            var baseUrl = hashIndex >= 0 ? targetLoginUrl.Substring(0, hashIndex) : targetLoginUrl;
+            var fragment = hashIndex >= 0 ? targetLoginUrl.Substring(hashIndex) : string.Empty;
+
+            var separator = string.IsNullOrEmpty(uri.Query) ? "?" : "&";
+            var builder = new System.Text.StringBuilder(baseUrl);
+            builder.Append(separator);
+            builder.Append("session_transfer_token=");
+            builder.Append(Uri.EscapeDataString(result.SessionTransferToken));
+
+            if (!string.IsNullOrWhiteSpace(organization))
+            {
+                builder.Append("&organization=");
+                builder.Append(Uri.EscapeDataString(organization!));
+            }
+
+            builder.Append(fragment);
+
+            return builder.ToString();
+        }
+
+        /// <summary>
+        /// Builds the redirect URL that carries a Session Transfer Token to a target app's login
+        /// endpoint, taking the <c>organization</c> from the same <paramref name="request"/> that was
+        /// exchanged. Prefer this overload when the exchange was organization-scoped: the request stays
+        /// the single source of truth, so the redirect cannot silently disagree with the exchange.
+        /// </summary>
+        /// <param name="context">The current <see cref="HttpContext"/> (unused; present for a consistent surface).</param>
+        /// <param name="targetLoginUrl">The target app's login URL. Must be an absolute HTTPS URI.</param>
+        /// <param name="result">The result from <see cref="RequestSessionTransferTokenAsync"/>.</param>
+        /// <param name="request">The request that produced <paramref name="result"/>; its
+        /// <see cref="SessionTransferTokenRequest.Organization"/> is forwarded to the target.</param>
+        /// <returns>The absolute redirect URL carrying the STT.</returns>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="targetLoginUrl"/> is not an absolute HTTPS URI.</exception>
+        public static string BuildSessionTransferRedirect(this HttpContext context, string targetLoginUrl, SessionTransferTokenResult result, SessionTransferTokenRequest request)
+        {
+            if (request == null)
+            {
+                throw new ArgumentNullException(nameof(request));
+            }
+
+            return context.BuildSessionTransferRedirect(targetLoginUrl, result, request.Organization);
+        }
+
+        /// <summary>
         /// Retrieves the resolved domain from the <see cref="HttpContext.Items"/> collection.
         /// </summary>
         /// <param name="httpContext">The current HTTP context.</param>

--- a/src/Auth0.AspNetCore.Authentication/HttpContextExtensions.cs
+++ b/src/Auth0.AspNetCore.Authentication/HttpContextExtensions.cs
@@ -113,7 +113,7 @@ namespace Auth0.AspNetCore.Authentication
                 }
             }
 
-            // 2. No usable token cached — we need the refresh token to obtain one.
+            // 2. No usable token cached - we need the refresh token to obtain one.
             if (!properties.Items.TryGetValue(".Token.refresh_token", out var refreshToken) || string.IsNullOrWhiteSpace(refreshToken))
             {
                 if (optionsWithAccessToken.Events?.OnMissingRefreshToken != null)
@@ -135,7 +135,7 @@ namespace Auth0.AspNetCore.Authentication
             }
             catch (Exception ex)
             {
-                // Any refresh failure — transport error, malformed response, or misconfiguration —
+                // Any refresh failure - transport error, malformed response, or misconfiguration -
                 // is folded into the same failure path as a token-endpoint rejection, so callers
                 // have a single failure protocol and nothing escapes this method.
                 await FireRefreshFailed(optionsWithAccessToken,
@@ -187,7 +187,7 @@ namespace Auth0.AspNetCore.Authentication
 
         /// <summary>
         /// Retrieves a federated connection (Token Vault) access token for the audience/connection
-        /// described by <paramref name="request"/> — a third-party API token (e.g. Google, GitHub)
+        /// described by <paramref name="request"/> - a third-party API token (e.g. Google, GitHub)
         /// for the logged-in user. Reuses a cached token from the session when one is present and not
         /// expired; otherwise exchanges the session's refresh token for a new connection token and
         /// persists it.
@@ -290,7 +290,7 @@ namespace Auth0.AspNetCore.Authentication
         /// <summary>
         /// Performs a Custom Token Exchange : exchanges the external token described by
         /// <paramref name="request"/> for Auth0 tokens, without a browser redirect. This is the
-        /// stateless utility — it has <b>no session side-effects</b> (it does not sign the user in or
+        /// stateless utility - it has <b>no session side-effects</b> (it does not sign the user in or
         /// write any cookie); the caller decides what to persist. Use it for delegation/impersonation
         /// and agent-identity scenarios.
         /// </summary>
@@ -787,7 +787,7 @@ namespace Auth0.AspNetCore.Authentication
 
         /// <summary>
         /// Determines whether the requested audience/scope matches the application's primary
-        /// (login-time) token — the one stored in the <c>.Token.access_token</c> slot — rather
+        /// (login-time) token - the one stored in the <c>.Token.access_token</c> slot - rather
         /// than an additional MRRT audience/scope kept in the access-token sets.
         /// </summary>
         private static bool MatchesPrimaryToken(string? audience, string? mergedScope, Auth0WebAppWithAccessTokenOptions options)

--- a/src/Auth0.AspNetCore.Authentication/HttpContextExtensions.cs
+++ b/src/Auth0.AspNetCore.Authentication/HttpContextExtensions.cs
@@ -398,12 +398,6 @@ namespace Auth0.AspNetCore.Authentication
         /// id_token cannot be refreshed and this method throws
         /// <see cref="CustomTokenExchangeErrorCode.ActorUnavailable"/>.
         /// </para>
-        /// <para>
-        /// <b>Enable <see cref="Auth0WebAppWithAccessTokenOptions.UseRefreshTokens"/>.</b> It defaults to
-        /// <c>false</c>, and without it the session carries no <c>.Token.refresh_token</c>, so a stale
-        /// id_token cannot be refreshed and this method throws
-        /// <see cref="CustomTokenExchangeErrorCode.ActorUnavailable"/>.
-        /// </para>
         /// </summary>
         /// <remarks>
         /// This method is not safe to call concurrently for the same session. When the actor is
@@ -532,6 +526,7 @@ namespace Auth0.AspNetCore.Authentication
             }
 
             var response = result.Response!;
+
 
             // A CTE profile that is not set up for session transfer
             // returns an ordinary, long-lived, multi-use access token through this exact path.

--- a/src/Auth0.AspNetCore.Authentication/SessionTransferActorResolver.cs
+++ b/src/Auth0.AspNetCore.Authentication/SessionTransferActorResolver.cs
@@ -5,20 +5,19 @@ using System.Text.Json;
 namespace Auth0.AspNetCore.Authentication
 {
     /// <summary>
-    /// Resolves the actor token for a Session Transfer Token exchange. Precedence:
-    /// an explicit actor wins; otherwise the caller sources the session id_token and, if stale,
-    /// refreshes it. Freshness is a lightweight <c>exp</c>-only decode — the token is our own session
-    /// token obtained over backchannel TLS and the server validates it anyway, so no JWKS signature
-    /// check is performed (consistent with <see cref="ActClaimReader"/>).
+    /// Resolves the actor token for a Session Transfer Token exchange.
+    /// An explicit actor wins; otherwise the caller sources the session id_token and, if stale,
+    /// refreshes it.
     /// </summary>
     internal static class SessionTransferActorResolver
     {
         /// <summary>
         /// Validates and normalizes an explicit actor token supplied on the request.
-        /// A blank/whitespace-only or <c>"Bearer "</c>-prefixed token throws
-        /// <see cref="CustomTokenExchangeException"/> with <see cref="CustomTokenExchangeErrorCode.InvalidTokenFormat"/>
-        /// (matching the auth0-server-python PoC). Returns the token paired with its type, defaulting
-        /// the type to <see cref="Auth0Constants.IdTokenType"/> when not supplied.
+        /// A blank/whitespace-only token, one carrying leading or trailing whitespace, or a
+        /// <c>"Bearer "</c>-prefixed one throws <see cref="CustomTokenExchangeException"/> with
+        /// <see cref="CustomTokenExchangeErrorCode.InvalidTokenFormat"/>.
+        /// Returns the token paired with its type, defaulting the type to
+        /// <see cref="Auth0Constants.IdTokenType"/> when not supplied.
         /// </summary>
         public static (string ActorToken, string ActorTokenType) ResolveExplicitActor(string actorToken, string? actorTokenType)
         {
@@ -27,6 +26,13 @@ namespace Auth0.AspNetCore.Authentication
                 throw new CustomTokenExchangeException(
                     CustomTokenExchangeErrorCode.InvalidTokenFormat,
                     "actor_token was provided but is blank.");
+            }
+
+            if (actorToken != actorToken.Trim())
+            {
+                throw new CustomTokenExchangeException(
+                    CustomTokenExchangeErrorCode.InvalidTokenFormat,
+                    "actor_token must not include leading or trailing whitespace.");
             }
 
             if (actorToken.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase))

--- a/src/Auth0.AspNetCore.Authentication/SessionTransferActorResolver.cs
+++ b/src/Auth0.AspNetCore.Authentication/SessionTransferActorResolver.cs
@@ -1,0 +1,92 @@
+using System;
+using System.Text;
+using System.Text.Json;
+
+namespace Auth0.AspNetCore.Authentication
+{
+    /// <summary>
+    /// Resolves the actor token for a Session Transfer Token exchange. Precedence:
+    /// an explicit actor wins; otherwise the caller sources the session id_token and, if stale,
+    /// refreshes it. Freshness is a lightweight <c>exp</c>-only decode — the token is our own session
+    /// token obtained over backchannel TLS and the server validates it anyway, so no JWKS signature
+    /// check is performed (consistent with <see cref="ActClaimReader"/>).
+    /// </summary>
+    internal static class SessionTransferActorResolver
+    {
+        /// <summary>
+        /// Validates and normalizes an explicit actor token supplied on the request.
+        /// A blank/whitespace-only or <c>"Bearer "</c>-prefixed token throws
+        /// <see cref="CustomTokenExchangeException"/> with <see cref="CustomTokenExchangeErrorCode.InvalidTokenFormat"/>
+        /// (matching the auth0-server-python PoC). Returns the token paired with its type, defaulting
+        /// the type to <see cref="Auth0Constants.IdTokenType"/> when not supplied.
+        /// </summary>
+        public static (string ActorToken, string ActorTokenType) ResolveExplicitActor(string actorToken, string? actorTokenType)
+        {
+            if (string.IsNullOrWhiteSpace(actorToken))
+            {
+                throw new CustomTokenExchangeException(
+                    CustomTokenExchangeErrorCode.InvalidTokenFormat,
+                    "actor_token was provided but is blank.");
+            }
+
+            if (actorToken.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase))
+            {
+                throw new CustomTokenExchangeException(
+                    CustomTokenExchangeErrorCode.InvalidTokenFormat,
+                    "actor_token must not include a \"Bearer \" prefix.");
+            }
+
+            return (actorToken, string.IsNullOrWhiteSpace(actorTokenType) ? Auth0Constants.IdTokenType : actorTokenType!);
+        }
+
+        /// <summary>
+        /// Returns true when the id_token's own <c>exp</c> claim is beyond <c>now + leeway</c>.
+        /// A malformed token, a missing/unparseable <c>exp</c>, or a decode failure yields false
+        /// (treated as stale) so the caller falls through to a refresh.
+        /// </summary>
+        public static bool IsIdTokenFresh(string? idToken, TimeSpan leeway)
+        {
+            if (string.IsNullOrEmpty(idToken))
+            {
+                return false;
+            }
+
+            try
+            {
+                var parts = idToken.Split('.');
+                if (parts.Length != 3)
+                {
+                    return false;
+                }
+
+                var payloadJson = Encoding.UTF8.GetString(Base64UrlDecode(parts[1]));
+                using var document = JsonDocument.Parse(payloadJson);
+
+                if (!document.RootElement.TryGetProperty("exp", out var expElement) ||
+                    !expElement.TryGetInt64(out var exp))
+                {
+                    return false;
+                }
+
+                var expiresAt = DateTimeOffset.FromUnixTimeSeconds(exp);
+                return DateTimeOffset.Compare(expiresAt, DateTimeOffset.UtcNow.Add(leeway)) > 0;
+            }
+            catch (Exception)
+            {
+                // A decode/parse hiccup is treated as stale rather than throwing out of resolution.
+                return false;
+            }
+        }
+
+        private static byte[] Base64UrlDecode(string input)
+        {
+            var output = input.Replace('-', '+').Replace('_', '/');
+            switch (output.Length % 4)
+            {
+                case 2: output += "=="; break;
+                case 3: output += "="; break;
+            }
+            return Convert.FromBase64String(output);
+        }
+    }
+}

--- a/src/Auth0.AspNetCore.Authentication/SessionTransferActorResolver.cs
+++ b/src/Auth0.AspNetCore.Authentication/SessionTransferActorResolver.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Text;
 using System.Text.Json;
+using Microsoft.IdentityModel.Tokens;
 
 namespace Auth0.AspNetCore.Authentication
 {
@@ -65,7 +66,7 @@ namespace Auth0.AspNetCore.Authentication
                     return false;
                 }
 
-                var payloadJson = Encoding.UTF8.GetString(Base64UrlDecode(parts[1]));
+                var payloadJson = Encoding.UTF8.GetString(Base64UrlEncoder.DecodeBytes(parts[1]));
                 using var document = JsonDocument.Parse(payloadJson);
 
                 if (!document.RootElement.TryGetProperty("exp", out var expElement) ||
@@ -82,17 +83,6 @@ namespace Auth0.AspNetCore.Authentication
                 // A decode/parse hiccup is treated as stale rather than throwing out of resolution.
                 return false;
             }
-        }
-
-        private static byte[] Base64UrlDecode(string input)
-        {
-            var output = input.Replace('-', '+').Replace('_', '/');
-            switch (output.Length % 4)
-            {
-                case 2: output += "=="; break;
-                case 3: output += "="; break;
-            }
-            return Convert.FromBase64String(output);
         }
     }
 }

--- a/src/Auth0.AspNetCore.Authentication/SessionTransferTokenRequest.cs
+++ b/src/Auth0.AspNetCore.Authentication/SessionTransferTokenRequest.cs
@@ -22,13 +22,16 @@ namespace Auth0.AspNetCore.Authentication
 
         /// <summary>
         /// Optional explicit actor token (the agent). When omitted, the actor is auto-sourced from
-        /// the current session's id_token. When supplied, it must be non-blank.
+        /// the current session's id_token. When supplied, it must be non-blank, carry no leading or
+        /// trailing whitespace, and have no <c>"Bearer "</c> prefix.
         /// </summary>
         public string? ActorToken { get; set; }
 
         /// <summary>
         /// Actor token type URI. Paired with <see cref="ActorToken"/>; defaults to the id_token URI
-        /// (<see cref="Auth0Constants.IdTokenType"/>) when an actor is auto-sourced.
+        /// (<see cref="Auth0Constants.IdTokenType"/>) when an actor is auto-sourced. Setting this
+        /// without an <see cref="ActorToken"/> throws - the auto-sourced actor is always a session
+        /// id_token, so the type cannot be overridden on its own.
         /// </summary>
         public string? ActorTokenType { get; set; }
 

--- a/src/Auth0.AspNetCore.Authentication/SessionTransferTokenRequest.cs
+++ b/src/Auth0.AspNetCore.Authentication/SessionTransferTokenRequest.cs
@@ -1,0 +1,41 @@
+namespace Auth0.AspNetCore.Authentication
+{
+    /// <summary>
+    /// Describes a request for a Session Transfer Token (STT): a Custom Token Exchange that yields
+    /// a short-lived, single-use handle for redirecting an agent's browser into a target app as the
+    /// customer. The audience is set by the SDK to <c>urn:{resolved-domain}:session_transfer</c>;
+    /// there is deliberately no <c>Audience</c> property.
+    /// </summary>
+    public class SessionTransferTokenRequest
+    {
+        /// <summary>
+        /// The external/customer token to exchange (the impersonation subject). Required; opaque to
+        /// the SDK. Must not be empty/whitespace and must not include a <c>"Bearer "</c> prefix.
+        /// </summary>
+        public string SubjectToken { get; set; } = null!;
+
+        /// <summary>
+        /// A custom URI identifying the subject token type; routes to the Custom Token Exchange
+        /// Profile. Required.
+        /// </summary>
+        public string SubjectTokenType { get; set; } = null!;
+
+        /// <summary>
+        /// Optional explicit actor token (the agent). When omitted, the actor is auto-sourced from
+        /// the current session's id_token. When supplied, it must be non-blank.
+        /// </summary>
+        public string? ActorToken { get; set; }
+
+        /// <summary>
+        /// Actor token type URI. Paired with <see cref="ActorToken"/>; defaults to the id_token URI
+        /// (<see cref="Auth0Constants.IdTokenType"/>) when an actor is auto-sourced.
+        /// </summary>
+        public string? ActorTokenType { get; set; }
+
+        /// <summary>Organization ID or name for multi-tenant scenarios. Optional.</summary>
+        public string? Organization { get; set; }
+
+        /// <summary>Space-delimited OAuth 2.0 scopes. Optional.</summary>
+        public string? Scope { get; set; }
+    }
+}

--- a/src/Auth0.AspNetCore.Authentication/SessionTransferTokenResult.cs
+++ b/src/Auth0.AspNetCore.Authentication/SessionTransferTokenResult.cs
@@ -1,0 +1,33 @@
+namespace Auth0.AspNetCore.Authentication
+{
+    /// <summary>
+    /// The result of a Session Transfer Token exchange. The STT is opaque, single-use, and
+    /// short-lived (~60s) — never persist it. It is meant to be placed on a redirect to the target
+    /// app immediately (see <c>HttpContext.BuildSessionTransferRedirect</c>).
+    /// </summary>
+    /// <remarks>
+    /// There is deliberately no <c>Act</c> claim here: <c>act</c> appears only on the target's session
+    /// after the STT is redeemed at <c>/authorize</c>, not on the initiator's exchange response.
+    /// </remarks>
+    public class SessionTransferTokenResult
+    {
+        /// <summary>The opaque, single-use session transfer token. Never persist it.</summary>
+        public string SessionTransferToken { get; set; } = null!;
+
+        /// <summary>
+        /// The <c>issued_token_type</c>; for an STT this is
+        /// <see cref="Auth0Constants.SessionTransferTokenType"/>. Branch on this, not on
+        /// <see cref="TokenType"/>.
+        /// </summary>
+        public string IssuedTokenType { get; set; } = null!;
+
+        /// <summary>The token lifetime in seconds (typically ~60).</summary>
+        public int ExpiresIn { get; set; }
+
+        /// <summary>The <c>token_type</c>; informational only (typically <c>N_A</c>). Never branch on it.</summary>
+        public string? TokenType { get; set; }
+
+        /// <summary>The granted scopes, when returned.</summary>
+        public string? Scope { get; set; }
+    }
+}

--- a/tests/Auth0.AspNetCore.Authentication.IntegrationTests/ActClaimReaderTests.cs
+++ b/tests/Auth0.AspNetCore.Authentication.IntegrationTests/ActClaimReaderTests.cs
@@ -32,6 +32,33 @@ namespace Auth0.AspNetCore.Authentication.IntegrationTests
             ActClaimReader.TryRead("only.two").Should().BeNull();
         }
 
+        // The cases above are rejected by the 3-segment check before any decoding. These are JWT-shaped
+        // but carry an undecodable payload, so they exercise the decoder throwing and the catch that
+        // turns that into null - the contract relied on by using Base64UrlEncoder.DecodeBytes.
+        [Theory]
+        [InlineData("header.not!valid!base64.sig")]
+        [InlineData("header.a.sig")]              // 1 char - never a valid base64url length
+        [InlineData("header.====.sig")]
+        [InlineData("header..sig")]               // empty payload decodes to zero bytes, then JSON fails
+        public void Returns_Null_When_Payload_Cannot_Be_Decoded(string jwt)
+        {
+            ActClaimReader.TryRead(jwt).Should().BeNull();
+        }
+
+        // Base64url payloads need 0, 1 or 2 '=' of padding restored depending on length % 4. Each case
+        // below lands on a different remainder, so all padding branches are covered.
+        [Theory]
+        [InlineData("{\"act\":{\"sub\":\"a\"}}", "a")]
+        [InlineData("{\"act\":{\"sub\":\"ab\"}}", "ab")]
+        [InlineData("{\"act\":{\"sub\":\"abc\"}}", "abc")]
+        [InlineData("{\"act\":{\"sub\":\"abcd\"}}", "abcd")]
+        public void Decodes_Payloads_Of_Every_Padding_Length(string payloadJson, string expectedSub)
+        {
+            var jwt = JwtWithPayload(payloadJson);
+
+            ActClaimReader.TryRead(jwt)!.Sub.Should().Be(expectedSub);
+        }
+
         [Fact]
         public void Returns_Null_When_No_Act_Claim()
         {

--- a/tests/Auth0.AspNetCore.Authentication.IntegrationTests/AuthenticationApi/MfaModelSerializationTests.cs
+++ b/tests/Auth0.AspNetCore.Authentication.IntegrationTests/AuthenticationApi/MfaModelSerializationTests.cs
@@ -32,6 +32,40 @@ namespace Auth0.AspNetCore.Authentication.IntegrationTests.AuthenticationApi
             result.ExpiresIn.Should().Be(86400);
         }
 
+        // The MFA verify grants answer with the same payload as the password grant, which includes
+        // id_token when openid is among the bound scopes. Without IdToken on TokenBase it was
+        // deserialized away, leaving no way to source an actor token after completing step-up.
+        [Fact]
+        public void MfaOtpTokenResponse_Deserializes_IdToken()
+        {
+            var json = "{\"access_token\":\"at\",\"id_token\":\"the-id-token\",\"token_type\":\"Bearer\",\"expires_in\":86400}";
+
+            var result = JsonSerializer.Deserialize<MfaOtpTokenResponse>(json);
+
+            result!.IdToken.Should().Be("the-id-token");
+        }
+
+        [Fact]
+        public void MfaOobTokenResponse_Deserializes_IdToken()
+        {
+            var json = "{\"access_token\":\"at\",\"id_token\":\"the-id-token\",\"token_type\":\"Bearer\",\"expires_in\":86400}";
+
+            var result = JsonSerializer.Deserialize<MfaOobTokenResponse>(json);
+
+            result!.IdToken.Should().Be("the-id-token");
+        }
+
+        // Absent id_token (openid not requested) must be null rather than empty.
+        [Fact]
+        public void MfaOtpTokenResponse_IdTokenIsNull_WhenAbsent()
+        {
+            var json = "{\"access_token\":\"at\",\"token_type\":\"Bearer\",\"expires_in\":86400}";
+
+            var result = JsonSerializer.Deserialize<MfaOtpTokenResponse>(json);
+
+            result!.IdToken.Should().BeNull();
+        }
+
         [Fact]
         public void MfaOobTokenResponse_Deserializes_ErrorFields()
         {

--- a/tests/Auth0.AspNetCore.Authentication.IntegrationTests/SessionTransferTokenTests.cs
+++ b/tests/Auth0.AspNetCore.Authentication.IntegrationTests/SessionTransferTokenTests.cs
@@ -1,5 +1,7 @@
 using FluentAssertions;
 using Xunit;
+using Auth0.AspNetCore.Authentication.AuthenticationApi;
+using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
@@ -92,6 +94,7 @@ namespace Auth0.AspNetCore.Authentication.IntegrationTests
             services.AddSingleton(authService.Object);
             services.AddSingleton(webAppSnapshot.Object);
             services.AddSingleton(withAccessTokenSnapshot.Object);
+            services.AddSingleton<IMfaTokenProtector>(new MfaTokenProtector(new EphemeralDataProtectionProvider()));
 
             var context = new DefaultHttpContext { RequestServices = services.BuildServiceProvider() };
             if (resolvedDomain != null)
@@ -529,6 +532,183 @@ namespace Auth0.AspNetCore.Authentication.IntegrationTests
             result.SessionTransferToken.Should().Be("the-stt");
             properties.Items[".Token.id_token"].Should().Be(freshIdToken);
             properties.Items[".Token.refresh_token"].Should().Be("rotated-rt");
+        }
+
+        // A step-up challenge on the actor refresh is recoverable and distinct from "no usable actor".
+        // Collapsing it into ActorUnavailable would claim the session has no refresh token — false —
+        // and leave the agent no way to complete MFA and retry.
+        [Fact]
+        public async Task RequestSessionTransferTokenAsync_ThrowsMfaRequired_WhenActorRefreshNeedsStepUp()
+        {
+            var handler = new Mock<HttpMessageHandler>();
+            handler
+                .Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>())
+                .ReturnsAsync(new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.Forbidden,
+                    Content = new StringContent(
+                        "{\"error\":\"mfa_required\",\"error_description\":\"Multifactor authentication required\",\"mfa_token\":\"raw-mfa-token\"}")
+                });
+
+            // Stale id_token, refresh token present — the refresh is attempted and hits step-up.
+            var properties = new AuthenticationProperties();
+            properties.Items[".Token.id_token"] = IdTokenExpiringIn(-5);
+            properties.Items[".Token.refresh_token"] = "rt";
+
+            var context = BuildContext(handler.Object, properties, out _);
+
+            var act = () => context.RequestSessionTransferTokenAsync(new SessionTransferTokenRequest
+            {
+                SubjectToken = "customer-token",
+                SubjectTokenType = "urn:acme:customer"
+            });
+
+            var ex = (await act.Should().ThrowAsync<MfaRequiredException>()).Which;
+            ex.MfaToken.Should().NotBeNullOrEmpty();
+            // The blob is encrypted — the raw mfa_token must never be handed out in plaintext.
+            ex.MfaToken.Should().NotBe("raw-mfa-token");
+
+            // openid must be bound into the blob so the MFA grant replays it and returns an id_token
+            // the caller can pass back as ActorToken. Without it there is no way to finish the loop.
+            var protector = context.RequestServices.GetRequiredService<IMfaTokenProtector>();
+            var mfaContext = protector.Unprotect(ex.MfaToken!);
+            mfaContext.MfaToken.Should().Be("raw-mfa-token");
+            mfaContext.Scope.Should().Be("openid");
+            // This refresh targets no API, so no audience is bound.
+            mfaContext.Audience.Should().BeNull();
+        }
+
+        // A malformed mfa_required with no mfa_token cannot drive the challenge flow, so it must fall
+        // through to ActorUnavailable rather than yielding a blob that can never be unprotected.
+        [Fact]
+        public async Task RequestSessionTransferTokenAsync_FallsBackToActorUnavailable_WhenMfaRequiredHasNoMfaToken()
+        {
+            var handler = new Mock<HttpMessageHandler>();
+            handler
+                .Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>())
+                .ReturnsAsync(new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.Forbidden,
+                    Content = new StringContent(
+                        "{\"error\":\"mfa_required\",\"error_description\":\"Multifactor authentication required\"}")
+                });
+
+            var properties = new AuthenticationProperties();
+            properties.Items[".Token.id_token"] = IdTokenExpiringIn(-5);
+            properties.Items[".Token.refresh_token"] = "rt";
+
+            var context = BuildContext(handler.Object, properties, out _);
+
+            var act = () => context.RequestSessionTransferTokenAsync(new SessionTransferTokenRequest
+            {
+                SubjectToken = "customer-token",
+                SubjectTokenType = "urn:acme:customer"
+            });
+
+            (await act.Should().ThrowAsync<CustomTokenExchangeException>())
+                .Where(e => e.Code == CustomTokenExchangeErrorCode.ActorUnavailable);
+        }
+
+        // The actor refresh requests openid (and no audience) — it exists only to obtain an id_token.
+        [Fact]
+        public async Task RequestSessionTransferTokenAsync_ActorRefresh_RequestsOpenIdScope()
+        {
+            var freshIdToken = IdTokenExpiringIn(60);
+            var capturedBodies = new System.Collections.Generic.List<string>();
+
+            var responses = new System.Collections.Generic.Queue<HttpResponseMessage>();
+            responses.Enqueue(new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = new StringContent(
+                    $"{{\"access_token\":\"at\",\"id_token\":\"{freshIdToken}\",\"expires_in\":86400}}")
+            });
+            responses.Enqueue(new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = new StringContent(
+                    "{\"access_token\":\"the-stt\",\"issued_token_type\":\"urn:auth0:params:oauth:token-type:session_transfer_token\",\"token_type\":\"N_A\",\"expires_in\":60}")
+            });
+
+            var handler = new Mock<HttpMessageHandler>();
+            handler
+                .Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>())
+                .Callback<HttpRequestMessage, CancellationToken>((req, _) =>
+                    capturedBodies.Add(req.Content!.ReadAsStringAsync().GetAwaiter().GetResult()))
+                .ReturnsAsync(() => responses.Dequeue());
+
+            var properties = new AuthenticationProperties();
+            properties.Items[".Token.id_token"] = IdTokenExpiringIn(-5);
+            properties.Items[".Token.refresh_token"] = "rt";
+
+            var context = BuildContext(handler.Object, properties, out _);
+
+            await context.RequestSessionTransferTokenAsync(new SessionTransferTokenRequest
+            {
+                SubjectToken = "customer-token",
+                SubjectTokenType = "urn:acme:customer"
+            });
+
+            capturedBodies.Should().HaveCount(2);
+            capturedBodies[0].Should().Contain("grant_type=refresh_token");
+            capturedBodies[0].Should().Contain("scope=openid");
+            capturedBodies[0].Should().NotContain("audience=");
+        }
+
+        // Transport errors must not escape raw from a method documented to fail via
+        // CustomTokenExchangeException — on either the actor refresh or the exchange.
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task RequestSessionTransferTokenAsync_WrapsTransportErrors(bool failOnActorRefresh)
+        {
+            var handler = new Mock<HttpMessageHandler>();
+            var setup = handler
+                .Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>());
+
+            var properties = new AuthenticationProperties();
+            var request = new SessionTransferTokenRequest
+            {
+                SubjectToken = "customer-token",
+                SubjectTokenType = "urn:acme:customer"
+            };
+
+            if (failOnActorRefresh)
+            {
+                // Stale id_token + refresh token, so the actor refresh runs and is the call that dies.
+                properties.Items[".Token.id_token"] = IdTokenExpiringIn(-5);
+                properties.Items[".Token.refresh_token"] = "rt";
+                setup.ThrowsAsync(new HttpRequestException("connection reset"));
+            }
+            else
+            {
+                // Explicit actor skips the refresh entirely, so the exchange is the only call.
+                request.ActorToken = "agent-jwt";
+                setup.ThrowsAsync(new HttpRequestException("connection reset"));
+            }
+
+            var context = BuildContext(handler.Object, properties, out _);
+
+            var act = () => context.RequestSessionTransferTokenAsync(request);
+
+            var ex = (await act.Should().ThrowAsync<CustomTokenExchangeException>()).Which;
+            ex.InnerException.Should().BeOfType<HttpRequestException>();
         }
 
         [Fact]

--- a/tests/Auth0.AspNetCore.Authentication.IntegrationTests/SessionTransferTokenTests.cs
+++ b/tests/Auth0.AspNetCore.Authentication.IntegrationTests/SessionTransferTokenTests.cs
@@ -159,6 +159,22 @@ namespace Auth0.AspNetCore.Authentication.IntegrationTests
                 .Where(e => e.Code == CustomTokenExchangeErrorCode.InvalidTokenFormat);
         }
 
+        // Mirrors CustomTokenExchangeRequestValidator's subject-token rule: surrounding whitespace is
+        // rejected rather than trimmed, so a copy-pasted token fails the same way in either slot.
+        [Theory]
+        [InlineData("actor-jwt\n")]
+        [InlineData(" actor-jwt")]
+        [InlineData("actor-jwt ")]
+        [InlineData("\tactor-jwt\t")]
+        public void ResolveExplicitActor_Throws_InvalidTokenFormat_WhenUntrimmed(string untrimmed)
+        {
+            var act = () => SessionTransferActorResolver.ResolveExplicitActor(untrimmed, null);
+
+            act.Should().Throw<CustomTokenExchangeException>()
+                .Where(e => e.Code == CustomTokenExchangeErrorCode.InvalidTokenFormat
+                            && e.Message.Contains("whitespace"));
+        }
+
         [Fact]
         public void IsIdTokenFresh_ReturnsFalse_ForMalformedToken()
         {
@@ -759,6 +775,53 @@ namespace Auth0.AspNetCore.Authentication.IntegrationTests
 
             (await act.Should().ThrowAsync<CustomTokenExchangeException>())
                 .Where(e => e.Code == CustomTokenExchangeErrorCode.InvalidTokenFormat);
+        }
+
+        [Fact]
+        public async Task RequestSessionTransferTokenAsync_Throws_InvalidTokenFormat_WhenExplicitActorUntrimmed()
+        {
+            var handler = SttHandler();
+            var context = BuildContext(handler.Object, new AuthenticationProperties(), out _);
+
+            var act = () => context.RequestSessionTransferTokenAsync(new SessionTransferTokenRequest
+            {
+                SubjectToken = "customer-token",
+                SubjectTokenType = "urn:acme:customer",
+                ActorToken = "actor-jwt\n"
+            });
+
+            (await act.Should().ThrowAsync<CustomTokenExchangeException>())
+                .Where(e => e.Code == CustomTokenExchangeErrorCode.InvalidTokenFormat);
+
+            // Rejected before any network call, like the subject-token rules.
+            handler.Protected().Verify("SendAsync", Times.Never(),
+                ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>());
+        }
+
+        // An ActorTokenType with no ActorToken is unhonourable - the auto-sourced actor is always a
+        // session id_token - so it must not silently fall through to auto-sourcing.
+        [Fact]
+        public async Task RequestSessionTransferTokenAsync_Throws_WhenActorTokenTypeSetWithoutActorToken()
+        {
+            var handler = SttHandler();
+            var properties = new AuthenticationProperties();
+            properties.Items[".Token.id_token"] = JwtWithExp(DateTimeOffset.UtcNow.AddHours(1).ToUnixTimeSeconds());
+            var context = BuildContext(handler.Object, properties, out _);
+
+            var act = () => context.RequestSessionTransferTokenAsync(new SessionTransferTokenRequest
+            {
+                SubjectToken = "customer-token",
+                SubjectTokenType = "urn:acme:customer",
+                ActorTokenType = "urn:acme:actor"    // no ActorToken
+            });
+
+            (await act.Should().ThrowAsync<CustomTokenExchangeException>())
+                .Where(e => e.Code == CustomTokenExchangeErrorCode.InvalidTokenFormat
+                            && e.Message.Contains("ActorTokenType")
+                            && e.Message.Contains("ActorToken"));
+
+            handler.Protected().Verify("SendAsync", Times.Never(),
+                ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>());
         }
 
         [Fact]

--- a/tests/Auth0.AspNetCore.Authentication.IntegrationTests/SessionTransferTokenTests.cs
+++ b/tests/Auth0.AspNetCore.Authentication.IntegrationTests/SessionTransferTokenTests.cs
@@ -1102,6 +1102,60 @@ namespace Auth0.AspNetCore.Authentication.IntegrationTests
             url.Should().Be("https://target.example.com/login?returnTo=%2Fhome&session_transfer_token=stt123&organization=org_ABC");
         }
 
+        // The STT must land in the query, never after '#' - a browser does not transmit the fragment, so
+        // the token would silently never reach the target. The fragment is preserved and stays last.
+        [Theory]
+        [InlineData("https://target.example.com/login#section",
+                    "https://target.example.com/login?session_transfer_token=stt123#section")]
+        [InlineData("https://target.example.com/login?returnTo=%2Fhome#section",
+                    "https://target.example.com/login?returnTo=%2Fhome&session_transfer_token=stt123#section")]
+        // A fragment containing its own '?' or '&' must not be mistaken for the query.
+        [InlineData("https://target.example.com/login#/route?a=1",
+                    "https://target.example.com/login?session_transfer_token=stt123#/route?a=1")]
+        public void BuildSessionTransferRedirect_PreservesFragment_AndKeepsSttInQuery(string target, string expected)
+        {
+            var context = BuildContext(SttHandler().Object, new AuthenticationProperties(), out _);
+
+            var url = context.BuildSessionTransferRedirect(target, SttResult("stt123"));
+
+            url.Should().Be(expected);
+        }
+
+        [Fact]
+        public void BuildSessionTransferRedirect_PreservesFragment_WithOrganization()
+        {
+            var context = BuildContext(SttHandler().Object, new AuthenticationProperties(), out _);
+
+            var url = context.BuildSessionTransferRedirect(
+                "https://target.example.com/login#section", SttResult("stt123"), organization: "org_ABC");
+
+            // organization joins the query, ahead of the fragment.
+            url.Should().Be("https://target.example.com/login?session_transfer_token=stt123&organization=org_ABC#section");
+        }
+
+        // A targetLoginUrl ending in a bare '?' - Uri.Query returns "?" rather than "", so '&' is chosen
+        // and the result is "login?&session_transfer_token=...". Verified to parse correctly with
+        // Microsoft.AspNetCore.WebUtilities.QueryHelpers (single key, value intact), so this is pinned
+        // as intended behaviour rather than the "login??..." double-'?' it might look like.
+        [Theory]
+        [InlineData("https://target.example.com/login?",
+                    "https://target.example.com/login?&session_transfer_token=stt123")]
+        [InlineData("https://target.example.com/login?#section",
+                    "https://target.example.com/login?&session_transfer_token=stt123#section")]
+        public void BuildSessionTransferRedirect_HandlesBareQuestionMark(string target, string expected)
+        {
+            var context = BuildContext(SttHandler().Object, new AuthenticationProperties(), out _);
+
+            var url = context.BuildSessionTransferRedirect(target, SttResult("stt123"));
+
+            url.Should().Be(expected);
+            url.Should().NotContain("??");
+
+            // The STT is retrievable by a target app using the framework's own query parser.
+            var query = Microsoft.AspNetCore.WebUtilities.QueryHelpers.ParseQuery(new Uri(url).Query);
+            query["session_transfer_token"].ToString().Should().Be("stt123");
+        }
+
         [Fact]
         public void BuildSessionTransferRedirect_RequestOverload_ForwardsOrganizationFromRequest()
         {

--- a/tests/Auth0.AspNetCore.Authentication.IntegrationTests/SessionTransferTokenTests.cs
+++ b/tests/Auth0.AspNetCore.Authentication.IntegrationTests/SessionTransferTokenTests.cs
@@ -57,7 +57,8 @@ namespace Auth0.AspNetCore.Authentication.IntegrationTests
             HttpMessageHandler backchannelHandler,
             AuthenticationProperties properties,
             out Mock<IAuthenticationService> authService,
-            string? resolvedDomain = null)
+            string? resolvedDomain = null,
+            string? audience = null)
         {
             var webAppOptions = new Auth0WebAppOptions
             {
@@ -68,7 +69,7 @@ namespace Auth0.AspNetCore.Authentication.IntegrationTests
                 CookieAuthenticationScheme = CookieScheme
             };
 
-            var withAccessTokenOptions = new Auth0WebAppWithAccessTokenOptions();
+            var withAccessTokenOptions = new Auth0WebAppWithAccessTokenOptions { Audience = audience };
 
             var principal = new ClaimsPrincipal(new ClaimsIdentity("Cookies"));
             var ticket = new AuthenticationTicket(principal, properties, CookieScheme);
@@ -317,6 +318,175 @@ namespace Auth0.AspNetCore.Authentication.IntegrationTests
             // The rotated refresh token was persisted (rotation-safe).
             persisted.Should().NotBeNull();
             persisted!.Items[".Token.refresh_token"].Should().Be("rotated-rt");
+        }
+
+        [Fact]
+        public async Task RequestSessionTransferTokenAsync_ActorRefresh_LeavesPrimaryAccessTokenSlotUntouched()
+        {
+            var staleIdToken = IdTokenExpiringIn(-5);
+            var freshIdToken = IdTokenExpiringIn(60);
+
+            var responses = new System.Collections.Generic.Queue<HttpResponseMessage>();
+            // The actor refresh requests no audience/scope, so its access token is for the
+            // tenant default — it must never land in the primary slot.
+            responses.Enqueue(new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = new StringContent(
+                    $"{{\"access_token\":\"tenant-default-at\",\"id_token\":\"{freshIdToken}\",\"refresh_token\":\"rotated-rt\",\"expires_in\":86400}}")
+            });
+            responses.Enqueue(new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = new StringContent(
+                    "{\"access_token\":\"the-stt\",\"issued_token_type\":\"urn:auth0:params:oauth:token-type:session_transfer_token\",\"token_type\":\"N_A\",\"expires_in\":60}")
+            });
+
+            var handler = new Mock<HttpMessageHandler>();
+            handler
+                .Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>())
+                .ReturnsAsync(() => responses.Dequeue());
+
+            var originalExpiresAt = DateTimeOffset.UtcNow.AddMinutes(-10).ToString("o");
+            var properties = new AuthenticationProperties();
+            properties.Items[".Token.id_token"] = staleIdToken;
+            properties.Items[".Token.refresh_token"] = "rt";
+            properties.Items[".Token.access_token"] = "primary-audience-at";
+            properties.Items[".Token.expires_at"] = originalExpiresAt;
+
+            var context = BuildContext(handler.Object, properties, out _, audience: "https://api.example.com");
+
+            await context.RequestSessionTransferTokenAsync(new SessionTransferTokenRequest
+            {
+                SubjectToken = "customer-token",
+                SubjectTokenType = "urn:acme:customer"
+            });
+
+            // The refreshed id_token and the rotated refresh token are persisted...
+            properties.Items[".Token.id_token"].Should().Be(freshIdToken);
+            properties.Items[".Token.refresh_token"].Should().Be("rotated-rt");
+            // ...but the primary access-token slot and its expiry are left exactly as they were.
+            // Overwriting them would make GetAccessTokenAsync serve a wrong-audience token from
+            // cache, and resetting expires_at would keep it doing so for a full token lifetime.
+            properties.Items[".Token.access_token"].Should().Be("primary-audience-at");
+            properties.Items[".Token.expires_at"].Should().Be(originalExpiresAt);
+        }
+
+        [Fact]
+        public async Task GetAccessTokenAsync_AfterSessionTransfer_DoesNotServePoisonedCachedToken()
+        {
+            var staleIdToken = IdTokenExpiringIn(-5);
+            var freshIdToken = IdTokenExpiringIn(60);
+
+            var capturedBodies = new System.Collections.Generic.List<string>();
+            var responses = new System.Collections.Generic.Queue<HttpResponseMessage>();
+            // 1. actor refresh (no audience/scope)
+            responses.Enqueue(new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = new StringContent(
+                    $"{{\"access_token\":\"tenant-default-at\",\"id_token\":\"{freshIdToken}\",\"refresh_token\":\"rotated-rt\",\"expires_in\":86400}}")
+            });
+            // 2. the STT exchange
+            responses.Enqueue(new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = new StringContent(
+                    "{\"access_token\":\"the-stt\",\"issued_token_type\":\"urn:auth0:params:oauth:token-type:session_transfer_token\",\"token_type\":\"N_A\",\"expires_in\":60}")
+            });
+            // 3. the refresh GetAccessTokenAsync must perform for the app's own audience
+            responses.Enqueue(new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = new StringContent(
+                    $"{{\"access_token\":\"correct-audience-at\",\"id_token\":\"{freshIdToken}\",\"expires_in\":3600}}")
+            });
+
+            var handler = new Mock<HttpMessageHandler>();
+            handler
+                .Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>())
+                .Callback<HttpRequestMessage, CancellationToken>((req, _) =>
+                    capturedBodies.Add(req.Content!.ReadAsStringAsync().GetAwaiter().GetResult()))
+                .ReturnsAsync(() => responses.Dequeue());
+
+            // An already-expired primary access token, as a real session would have when the
+            // id_token is stale too.
+            var properties = new AuthenticationProperties();
+            properties.Items[".Token.id_token"] = staleIdToken;
+            properties.Items[".Token.refresh_token"] = "rt";
+            properties.Items[".Token.access_token"] = "expired-primary-at";
+            properties.Items[".Token.expires_at"] = DateTimeOffset.UtcNow.AddMinutes(-10).ToString("o");
+
+            var context = BuildContext(handler.Object, properties, out _, audience: "https://api.example.com");
+
+            await context.RequestSessionTransferTokenAsync(new SessionTransferTokenRequest
+            {
+                SubjectToken = "customer-token",
+                SubjectTokenType = "urn:acme:customer"
+            });
+
+            var accessToken = await context.GetAccessTokenAsync(new AccessTokenRequest());
+
+            // The STT call must not have left a token that looks fresh in the primary slot:
+            // GetAccessTokenAsync has to refresh for the configured audience and return that.
+            accessToken.Should().Be("correct-audience-at");
+            accessToken.Should().NotBe("tenant-default-at");
+            capturedBodies.Should().HaveCount(3);
+            capturedBodies[2].Should().Contain("audience=https%3A%2F%2Fapi.example.com");
+        }
+
+        [Fact]
+        public async Task RequestSessionTransferTokenAsync_PersistsRefreshedIdToken_WhenSessionHadNone()
+        {
+            var freshIdToken = IdTokenExpiringIn(60);
+
+            var responses = new System.Collections.Generic.Queue<HttpResponseMessage>();
+            responses.Enqueue(new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = new StringContent(
+                    $"{{\"access_token\":\"at\",\"id_token\":\"{freshIdToken}\",\"refresh_token\":\"rotated-rt\",\"expires_in\":86400}}")
+            });
+            responses.Enqueue(new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = new StringContent(
+                    "{\"access_token\":\"the-stt\",\"issued_token_type\":\"urn:auth0:params:oauth:token-type:session_transfer_token\",\"token_type\":\"N_A\",\"expires_in\":60}")
+            });
+
+            var handler = new Mock<HttpMessageHandler>();
+            handler
+                .Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>())
+                .ReturnsAsync(() => responses.Dequeue());
+
+            // No .Token.id_token at all. UpdateTokenValue only writes keys that already exist,
+            // so persisting via it would silently no-op and burn a refresh-token rotation per call.
+            var properties = new AuthenticationProperties();
+            properties.Items[".Token.refresh_token"] = "rt";
+
+            var context = BuildContext(handler.Object, properties, out _);
+
+            var result = await context.RequestSessionTransferTokenAsync(new SessionTransferTokenRequest
+            {
+                SubjectToken = "customer-token",
+                SubjectTokenType = "urn:acme:customer"
+            });
+
+            result.SessionTransferToken.Should().Be("the-stt");
+            properties.Items[".Token.id_token"].Should().Be(freshIdToken);
+            properties.Items[".Token.refresh_token"].Should().Be("rotated-rt");
         }
 
         [Fact]

--- a/tests/Auth0.AspNetCore.Authentication.IntegrationTests/SessionTransferTokenTests.cs
+++ b/tests/Auth0.AspNetCore.Authentication.IntegrationTests/SessionTransferTokenTests.cs
@@ -732,8 +732,13 @@ namespace Auth0.AspNetCore.Authentication.IntegrationTests
                 SubjectTokenType = "urn:acme:customer"
             });
 
+            // UseRefreshTokens defaults to false, so this is the SDK's out-of-the-box state once the
+            // agent's id_token expires. The message must name the option rather than leave the developer
+            // reading it as an unrecoverable session problem.
             (await act.Should().ThrowAsync<CustomTokenExchangeException>())
-                .Where(e => e.Code == CustomTokenExchangeErrorCode.ActorUnavailable);
+                .Where(e => e.Code == CustomTokenExchangeErrorCode.ActorUnavailable
+                    && e.Message.Contains("UseRefreshTokens")
+                    && e.Message.Contains("ActorToken"));
 
             handler.Protected().Verify("SendAsync", Times.Never(),
                 ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>());

--- a/tests/Auth0.AspNetCore.Authentication.IntegrationTests/SessionTransferTokenTests.cs
+++ b/tests/Auth0.AspNetCore.Authentication.IntegrationTests/SessionTransferTokenTests.cs
@@ -36,9 +36,10 @@ namespace Auth0.AspNetCore.Authentication.IntegrationTests
             return B64UrlPayload($"{{\"sub\":\"agent|1\",\"exp\":{exp}}}");
         }
 
-        private static Mock<HttpMessageHandler> SttHandler(string capturedBodyReceiver = null!)
+        // Success handler returning an STT response. Tests that need the request body add their own
+        // Callback to the returned mock rather than getting it back from here.
+        private static Mock<HttpMessageHandler> SttHandler()
         {
-            // Success handler returning an STT response. Body capture is done via a Callback the caller adds.
             var handler = new Mock<HttpMessageHandler>();
             handler
                 .Protected()
@@ -186,6 +187,19 @@ namespace Auth0.AspNetCore.Authentication.IntegrationTests
             SessionTransferActorResolver.IsIdTokenFresh("not-a-jwt", System.TimeSpan.Zero).Should().BeFalse();
         }
 
+        // "not-a-jwt" above is rejected by the 3-segment check before decoding. These are JWT-shaped with
+        // an undecodable payload, so they exercise the decoder throwing and being treated as stale -
+        // the contract relied on by using Base64UrlEncoder.DecodeBytes.
+        [Theory]
+        [InlineData("header.not!valid!base64.sig")]
+        [InlineData("header.a.sig")]
+        [InlineData("header.====.sig")]
+        [InlineData("header..sig")]
+        public void IsIdTokenFresh_ReturnsFalse_WhenPayloadCannotBeDecoded(string jwt)
+        {
+            SessionTransferActorResolver.IsIdTokenFresh(jwt, System.TimeSpan.Zero).Should().BeFalse();
+        }
+
         [Fact]
         public void IsIdTokenFresh_ReturnsTrue_ForUnexpiredExp()
         {
@@ -325,6 +339,57 @@ namespace Auth0.AspNetCore.Authentication.IntegrationTests
             capturedBody.Should().Contain("actor_token_type=urn%3Aietf%3Aparams%3Aoauth%3Atoken-type%3Aid_token");
         }
 
+        // request.Scope reaches the exchange body, and is omitted entirely rather than sent empty when
+        // unset — TokenClient.ExchangeCustomToken skips whitespace scopes, and sending "scope=" would
+        // ask the endpoint for an empty scope instead of letting it apply the profile default.
+        [Theory]
+        [InlineData(null, false)]
+        [InlineData("", false)]
+        [InlineData("   ", false)]
+        [InlineData("openid profile", true)]
+        public async Task RequestSessionTransferTokenAsync_SendsRequestedScope(string? scope, bool expectSent)
+        {
+            string capturedBody = string.Empty;
+            var handler = new Mock<HttpMessageHandler>();
+            handler
+                .Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>())
+                .Callback<HttpRequestMessage, CancellationToken>((req, _) =>
+                    capturedBody = req.Content!.ReadAsStringAsync().GetAwaiter().GetResult())
+                .ReturnsAsync(new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = new StringContent(
+                        "{\"access_token\":\"the-stt\",\"issued_token_type\":\"urn:auth0:params:oauth:token-type:session_transfer_token\",\"token_type\":\"N_A\",\"expires_in\":60,\"scope\":\"openid profile\"}")
+                });
+
+            var context = BuildContext(handler.Object, new AuthenticationProperties(), out _);
+
+            var result = await context.RequestSessionTransferTokenAsync(new SessionTransferTokenRequest
+            {
+                SubjectToken = "customer-token",
+                SubjectTokenType = "urn:acme:customer",
+                ActorToken = "agent-jwt",
+                Scope = scope
+            });
+
+            if (expectSent)
+            {
+                // FormUrlEncodedContent encodes the separating space as '+', not %20.
+                capturedBody.Should().Contain("scope=openid+profile");
+            }
+            else
+            {
+                capturedBody.Should().NotContain("scope=");
+            }
+
+            // The granted scope comes back from the response, independent of what was requested.
+            result.Scope.Should().Be("openid profile");
+        }
+
         [Fact]
         public async Task RequestSessionTransferTokenAsync_RefreshesStaleIdToken_AndPersists()
         {
@@ -384,6 +449,52 @@ namespace Auth0.AspNetCore.Authentication.IntegrationTests
             // The rotated refresh token was persisted (rotation-safe).
             persisted.Should().NotBeNull();
             persisted!.Items[".Token.refresh_token"].Should().Be("rotated-rt");
+        }
+
+        // Persisting the rotated session writes the auth cookie, so SignInAsync throws
+        // InvalidOperationException once the response has started (the mock stands in for that
+        // framework throw). The documented contract is that it propagates as-is: wrapping it in
+        // CustomTokenExchangeException would report a caller ordering bug as a token-exchange failure.
+        [Fact]
+        public async Task RequestSessionTransferTokenAsync_PropagatesInvalidOperationException_WhenResponseHasStarted()
+        {
+            var freshIdToken = IdTokenExpiringIn(60);
+
+            var handler = new Mock<HttpMessageHandler>();
+            handler
+                .Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>())
+                .ReturnsAsync(() => new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = new StringContent(
+                        $"{{\"access_token\":\"new-at\",\"id_token\":\"{freshIdToken}\",\"expires_in\":86400}}")
+                });
+
+            var properties = new AuthenticationProperties();
+            properties.Items[".Token.id_token"] = IdTokenExpiringIn(-5);   // stale, so the refresh runs
+            properties.Items[".Token.refresh_token"] = "rt";
+
+            var context = BuildContext(handler.Object, properties, out var authService);
+            authService
+                .Setup(s => s.SignInAsync(It.IsAny<HttpContext>(), It.IsAny<string>(),
+                    It.IsAny<ClaimsPrincipal>(), It.IsAny<AuthenticationProperties>()))
+                .ThrowsAsync(new InvalidOperationException("The response has already started."));
+
+            var act = () => context.RequestSessionTransferTokenAsync(new SessionTransferTokenRequest
+            {
+                SubjectToken = "customer-token",
+                SubjectTokenType = "urn:acme:customer"
+            });
+
+            await act.Should().ThrowAsync<InvalidOperationException>();
+
+            // Persistence precedes the exchange, so the STT call never went out: only the actor refresh did.
+            handler.Protected().Verify("SendAsync", Times.Once(),
+                ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>());
         }
 
         // AccessTokenExpirationLeeway is deliberately reused as the id_token freshness margin, so tuning

--- a/tests/Auth0.AspNetCore.Authentication.IntegrationTests/SessionTransferTokenTests.cs
+++ b/tests/Auth0.AspNetCore.Authentication.IntegrationTests/SessionTransferTokenTests.cs
@@ -799,10 +799,77 @@ namespace Auth0.AspNetCore.Authentication.IntegrationTests
                 ActorToken = "agent-jwt"
             });
 
+            // Code stays null: the mapping keys off the machine-readable `error` field only, and Auth0
+            // reports this today as a generic invalid_request with the detail in error_description.
+            // Matching that text to remap the failure is deliberately not done, so ErrorDescription is
+            // the working predicate for now.
             (await act.Should().ThrowAsync<CustomTokenExchangeException>())
                 .Where(e => e.StatusCode == 400
                     && e.Error == "invalid_request"
-                    && e.ErrorDescription!.Contains("setActor is required"));
+                    && e.ErrorDescription!.Contains("setActor is required")
+                    && e.Code == null);
+        }
+
+        // The named constants exist for the day the platform returns a machine-readable error code.
+        // When it does, the mapping fires with no further change — this is that contract, pinned.
+        [Theory]
+        [InlineData("setactor_required", CustomTokenExchangeErrorCode.SetActorRequired)]
+        [InlineData("session_transfer_disabled", CustomTokenExchangeErrorCode.SessionTransferDisabled)]
+        [InlineData("SetActor_Required", CustomTokenExchangeErrorCode.SetActorRequired)]
+        public async Task RequestSessionTransferTokenAsync_MapsServerErrorOntoCode(string serverError, string expectedCode)
+        {
+            var handler = new Mock<HttpMessageHandler>();
+            handler
+                .Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>())
+                .ReturnsAsync(new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.BadRequest,
+                    Content = new StringContent(
+                        $"{{\"error\":\"{serverError}\",\"error_description\":\"the server's own words\"}}")
+                });
+
+            var context = BuildContext(handler.Object, new AuthenticationProperties(), out _);
+
+            var act = () => context.RequestSessionTransferTokenAsync(new SessionTransferTokenRequest
+            {
+                SubjectToken = "customer-token",
+                SubjectTokenType = "urn:acme:customer",
+                ActorToken = "agent-jwt"
+            });
+
+            // The raw server values survive the mapping — Code is additive, not a replacement.
+            (await act.Should().ThrowAsync<CustomTokenExchangeException>())
+                .Where(e => e.Code == expectedCode
+                    && e.Error == serverError
+                    && e.ErrorDescription == "the server's own words"
+                    && e.StatusCode == 400);
+        }
+
+        // An unrecognised error must not be forced onto a session-transfer code.
+        [Theory]
+        [InlineData("invalid_request")]
+        [InlineData("invalid_grant")]
+        [InlineData("access_denied")]
+        public void MapServerError_ReturnsNull_ForUnrelatedErrors(string serverError)
+        {
+            CustomTokenExchangeErrorCode.MapServerError(serverError).Should().BeNull();
+            CustomTokenExchangeErrorCode.MapServerError(null).Should().BeNull();
+        }
+
+        [Fact]
+        public void CustomTokenExchangeException_CodeCarryingRejectionConstructor_KeepsRawServerValues()
+        {
+            var ex = new CustomTokenExchangeException(400, "session_transfer_disabled", "desc",
+                CustomTokenExchangeErrorCode.SessionTransferDisabled);
+
+            ex.Code.Should().Be("session_transfer_disabled");
+            ex.Error.Should().Be("session_transfer_disabled");
+            ex.ErrorDescription.Should().Be("desc");
+            ex.StatusCode.Should().Be(400);
         }
 
         // A DomainResolver may return a bare host or a full issuer, and Auth0CustomDomainStartupFilter

--- a/tests/Auth0.AspNetCore.Authentication.IntegrationTests/SessionTransferTokenTests.cs
+++ b/tests/Auth0.AspNetCore.Authentication.IntegrationTests/SessionTransferTokenTests.cs
@@ -1,0 +1,524 @@
+using FluentAssertions;
+using Xunit;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Moq;
+using Moq.Protected;
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Security.Claims;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Auth0.AspNetCore.Authentication.IntegrationTests
+{
+    public class SessionTransferTokenTests
+    {
+        private const string CookieScheme = "Cookies";
+        private const string Domain = "test.auth0.com";
+
+        private static string B64UrlPayload(string json)
+        {
+            var bytes = System.Text.Encoding.UTF8.GetBytes(json);
+            var b64 = Convert.ToBase64String(bytes).TrimEnd('=').Replace('+', '-').Replace('/', '_');
+            return $"eyJhbGciOiJSUzI1NiJ9.{b64}.sig";
+        }
+
+        // A JWT-shaped id_token whose exp is `minutesFromNow` in the future.
+        private static string IdTokenExpiringIn(int minutesFromNow)
+        {
+            var exp = DateTimeOffset.UtcNow.AddMinutes(minutesFromNow).ToUnixTimeSeconds();
+            return B64UrlPayload($"{{\"sub\":\"agent|1\",\"exp\":{exp}}}");
+        }
+
+        private static Mock<HttpMessageHandler> SttHandler(string capturedBodyReceiver = null!)
+        {
+            // Success handler returning an STT response. Body capture is done via a Callback the caller adds.
+            var handler = new Mock<HttpMessageHandler>();
+            handler
+                .Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>())
+                .ReturnsAsync(new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = new StringContent(
+                        "{\"access_token\":\"the-stt\",\"issued_token_type\":\"urn:auth0:params:oauth:token-type:session_transfer_token\",\"token_type\":\"N_A\",\"expires_in\":60,\"scope\":\"openid\"}")
+                });
+            return handler;
+        }
+
+        private static HttpContext BuildContext(
+            HttpMessageHandler backchannelHandler,
+            AuthenticationProperties properties,
+            out Mock<IAuthenticationService> authService,
+            string? resolvedDomain = null)
+        {
+            var webAppOptions = new Auth0WebAppOptions
+            {
+                Domain = Domain,
+                ClientId = "cid",
+                ClientSecret = "secret",
+                Backchannel = new HttpClient(backchannelHandler),
+                CookieAuthenticationScheme = CookieScheme
+            };
+
+            var withAccessTokenOptions = new Auth0WebAppWithAccessTokenOptions();
+
+            var principal = new ClaimsPrincipal(new ClaimsIdentity("Cookies"));
+            var ticket = new AuthenticationTicket(principal, properties, CookieScheme);
+
+            authService = new Mock<IAuthenticationService>();
+            authService
+                .Setup(s => s.AuthenticateAsync(It.IsAny<HttpContext>(), CookieScheme))
+                .ReturnsAsync(AuthenticateResult.Success(ticket));
+            authService
+                .Setup(s => s.SignInAsync(It.IsAny<HttpContext>(), It.IsAny<string>(),
+                    It.IsAny<ClaimsPrincipal>(), It.IsAny<AuthenticationProperties>()))
+                .Returns(Task.CompletedTask);
+
+            var webAppSnapshot = new Mock<IOptionsSnapshot<Auth0WebAppOptions>>();
+            webAppSnapshot.Setup(s => s.Get(It.IsAny<string>())).Returns(webAppOptions);
+            var withAccessTokenSnapshot = new Mock<IOptionsSnapshot<Auth0WebAppWithAccessTokenOptions>>();
+            withAccessTokenSnapshot.Setup(s => s.Get(It.IsAny<string>())).Returns(withAccessTokenOptions);
+
+            var services = new ServiceCollection();
+            services.AddSingleton(authService.Object);
+            services.AddSingleton(webAppSnapshot.Object);
+            services.AddSingleton(withAccessTokenSnapshot.Object);
+
+            var context = new DefaultHttpContext { RequestServices = services.BuildServiceProvider() };
+            if (resolvedDomain != null)
+            {
+                context.Items[Auth0Constants.ResolvedDomainKey] = resolvedDomain;
+            }
+            return context;
+        }
+
+        [Fact]
+        public void CustomTokenExchangeException_CodeConstructor_SetsCodeAndMessage()
+        {
+            var ex = new CustomTokenExchangeException(CustomTokenExchangeErrorCode.ActorUnavailable, "no actor");
+
+            ex.Code.Should().Be("actor_unavailable");
+            ex.Message.Should().Be("no actor");
+            ex.StatusCode.Should().BeNull();
+        }
+
+        [Fact]
+        public void CustomTokenExchangeException_ExistingConstructors_LeaveCodeNull()
+        {
+            new CustomTokenExchangeException("validation failed").Code.Should().BeNull();
+            new CustomTokenExchangeException(400, "err", "desc").Code.Should().BeNull();
+        }
+
+        [Fact]
+        public void ResolveExplicitActor_ReturnsPair_WithDefaultTypeWhenTypeOmitted()
+        {
+            var (token, type) = SessionTransferActorResolver.ResolveExplicitActor("actor-jwt", null);
+
+            token.Should().Be("actor-jwt");
+            type.Should().Be(Auth0Constants.IdTokenType);
+        }
+
+        [Fact]
+        public void ResolveExplicitActor_HonorsExplicitType()
+        {
+            var (token, type) = SessionTransferActorResolver.ResolveExplicitActor("actor-jwt", "urn:acme:actor");
+
+            token.Should().Be("actor-jwt");
+            type.Should().Be("urn:acme:actor");
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("   ")]
+        public void ResolveExplicitActor_Throws_InvalidTokenFormat_WhenBlank(string blank)
+        {
+            var act = () => SessionTransferActorResolver.ResolveExplicitActor(blank, null);
+
+            act.Should().Throw<CustomTokenExchangeException>()
+                .Where(e => e.Code == CustomTokenExchangeErrorCode.InvalidTokenFormat);
+        }
+
+        [Fact]
+        public void ResolveExplicitActor_Throws_WhenBearerPrefixed()
+        {
+            var act = () => SessionTransferActorResolver.ResolveExplicitActor("Bearer actor-jwt", null);
+
+            act.Should().Throw<CustomTokenExchangeException>()
+                .Where(e => e.Code == CustomTokenExchangeErrorCode.InvalidTokenFormat);
+        }
+
+        [Fact]
+        public void IsIdTokenFresh_ReturnsFalse_ForMalformedToken()
+        {
+            SessionTransferActorResolver.IsIdTokenFresh("not-a-jwt", System.TimeSpan.Zero).Should().BeFalse();
+        }
+
+        [Fact]
+        public void IsIdTokenFresh_ReturnsTrue_ForUnexpiredExp()
+        {
+            var exp = System.DateTimeOffset.UtcNow.AddMinutes(10).ToUnixTimeSeconds();
+            var jwt = JwtWithExp(exp);
+
+            SessionTransferActorResolver.IsIdTokenFresh(jwt, System.TimeSpan.FromMinutes(1)).Should().BeTrue();
+        }
+
+        [Fact]
+        public void IsIdTokenFresh_ReturnsFalse_WhenExpiredWithinLeeway()
+        {
+            var exp = System.DateTimeOffset.UtcNow.AddSeconds(30).ToUnixTimeSeconds();
+            var jwt = JwtWithExp(exp);
+
+            // 60s leeway means a token expiring in 30s is treated as stale.
+            SessionTransferActorResolver.IsIdTokenFresh(jwt, System.TimeSpan.FromSeconds(60)).Should().BeFalse();
+        }
+
+        [Fact]
+        public async Task RequestSessionTransferTokenAsync_UsesExplicitActor_AndReturnsStt()
+        {
+            string capturedBody = string.Empty;
+            var handler = new Mock<HttpMessageHandler>();
+            handler
+                .Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>())
+                .Callback<HttpRequestMessage, CancellationToken>((req, _) =>
+                    capturedBody = req.Content!.ReadAsStringAsync().GetAwaiter().GetResult())
+                .ReturnsAsync(new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = new StringContent(
+                        "{\"access_token\":\"the-stt\",\"issued_token_type\":\"urn:auth0:params:oauth:token-type:session_transfer_token\",\"token_type\":\"N_A\",\"expires_in\":60}")
+                });
+
+            var context = BuildContext(handler.Object, new AuthenticationProperties(), out _);
+
+            var result = await context.RequestSessionTransferTokenAsync(new SessionTransferTokenRequest
+            {
+                SubjectToken = "customer-token",
+                SubjectTokenType = "urn:acme:customer",
+                ActorToken = "agent-jwt",
+                ActorTokenType = "urn:ietf:params:oauth:token-type:id_token"
+            });
+
+            result.SessionTransferToken.Should().Be("the-stt");
+            result.IssuedTokenType.Should().Be(Auth0Constants.SessionTransferTokenType);
+            result.ExpiresIn.Should().Be(60);
+            result.TokenType.Should().Be("N_A");
+
+            capturedBody.Should().Contain("subject_token=customer-token");
+            capturedBody.Should().Contain("actor_token=agent-jwt");
+            // Audience is built from the configured domain when no resolved domain is set.
+            capturedBody.Should().Contain("audience=urn%3Atest.auth0.com%3Asession_transfer");
+        }
+
+        [Fact]
+        public async Task RequestSessionTransferTokenAsync_AutoSourcesActor_FromFreshSessionIdToken()
+        {
+            string capturedBody = string.Empty;
+            var handler = new Mock<HttpMessageHandler>();
+            handler
+                .Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>())
+                .Callback<HttpRequestMessage, CancellationToken>((req, _) =>
+                    capturedBody = req.Content!.ReadAsStringAsync().GetAwaiter().GetResult())
+                .ReturnsAsync(new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = new StringContent(
+                        "{\"access_token\":\"the-stt\",\"issued_token_type\":\"urn:auth0:params:oauth:token-type:session_transfer_token\",\"token_type\":\"N_A\",\"expires_in\":60}")
+                });
+
+            var freshIdToken = IdTokenExpiringIn(10);
+            var properties = new AuthenticationProperties();
+            properties.Items[".Token.id_token"] = freshIdToken;
+
+            var context = BuildContext(handler.Object, properties, out _);
+
+            var result = await context.RequestSessionTransferTokenAsync(new SessionTransferTokenRequest
+            {
+                SubjectToken = "customer-token",
+                SubjectTokenType = "urn:acme:customer"
+            });
+
+            result.SessionTransferToken.Should().Be("the-stt");
+            capturedBody.Should().Contain($"actor_token={Uri.EscapeDataString(freshIdToken)}");
+            capturedBody.Should().Contain("actor_token_type=urn%3Aietf%3Aparams%3Aoauth%3Atoken-type%3Aid_token");
+        }
+
+        [Fact]
+        public async Task RequestSessionTransferTokenAsync_RefreshesStaleIdToken_AndPersists()
+        {
+            var staleIdToken = IdTokenExpiringIn(-5);   // already expired
+            var freshIdToken = IdTokenExpiringIn(60);
+
+            // First response = refresh (returns a fresh id_token + access_token); second = STT exchange.
+            var responses = new System.Collections.Generic.Queue<HttpResponseMessage>();
+            responses.Enqueue(new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = new StringContent(
+                    $"{{\"access_token\":\"new-at\",\"id_token\":\"{freshIdToken}\",\"refresh_token\":\"rotated-rt\",\"expires_in\":86400}}")
+            });
+            responses.Enqueue(new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = new StringContent(
+                    "{\"access_token\":\"the-stt\",\"issued_token_type\":\"urn:auth0:params:oauth:token-type:session_transfer_token\",\"token_type\":\"N_A\",\"expires_in\":60}")
+            });
+
+            var capturedBodies = new System.Collections.Generic.List<string>();
+            var handler = new Mock<HttpMessageHandler>();
+            handler
+                .Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>())
+                .Callback<HttpRequestMessage, CancellationToken>((req, _) =>
+                    capturedBodies.Add(req.Content!.ReadAsStringAsync().GetAwaiter().GetResult()))
+                .ReturnsAsync(() => responses.Dequeue());
+
+            var properties = new AuthenticationProperties();
+            properties.Items[".Token.id_token"] = staleIdToken;
+            properties.Items[".Token.refresh_token"] = "rt";
+
+            AuthenticationProperties? persisted = null;
+            var context = BuildContext(handler.Object, properties, out var authService);
+            authService
+                .Setup(s => s.SignInAsync(It.IsAny<HttpContext>(), It.IsAny<string>(),
+                    It.IsAny<ClaimsPrincipal>(), It.IsAny<AuthenticationProperties>()))
+                .Callback<HttpContext, string, ClaimsPrincipal, AuthenticationProperties>((_, _, _, p) => persisted = p)
+                .Returns(Task.CompletedTask);
+
+            var result = await context.RequestSessionTransferTokenAsync(new SessionTransferTokenRequest
+            {
+                SubjectToken = "customer-token",
+                SubjectTokenType = "urn:acme:customer"
+            });
+
+            result.SessionTransferToken.Should().Be("the-stt");
+            // Refresh happened first, then the STT exchange used the fresh id_token as the actor.
+            capturedBodies.Should().HaveCount(2);
+            capturedBodies[0].Should().Contain("grant_type=refresh_token");
+            capturedBodies[1].Should().Contain($"actor_token={Uri.EscapeDataString(freshIdToken)}");
+            // The rotated refresh token was persisted (rotation-safe).
+            persisted.Should().NotBeNull();
+            persisted!.Items[".Token.refresh_token"].Should().Be("rotated-rt");
+        }
+
+        [Fact]
+        public async Task RequestSessionTransferTokenAsync_Throws_ActorUnavailable_WhenNoActorAndNoRefreshToken()
+        {
+            // Backchannel must never be called on this path.
+            var handler = new Mock<HttpMessageHandler>();
+            handler
+                .Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>())
+                .ReturnsAsync(new HttpResponseMessage { StatusCode = HttpStatusCode.OK });
+
+            var context = BuildContext(handler.Object, new AuthenticationProperties(), out _);
+
+            var act = () => context.RequestSessionTransferTokenAsync(new SessionTransferTokenRequest
+            {
+                SubjectToken = "customer-token",
+                SubjectTokenType = "urn:acme:customer"
+            });
+
+            (await act.Should().ThrowAsync<CustomTokenExchangeException>())
+                .Where(e => e.Code == CustomTokenExchangeErrorCode.ActorUnavailable);
+
+            handler.Protected().Verify("SendAsync", Times.Never(),
+                ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>());
+        }
+
+        [Fact]
+        public async Task RequestSessionTransferTokenAsync_Throws_InvalidTokenFormat_WhenExplicitActorBlank()
+        {
+            var handler = SttHandler();
+            var context = BuildContext(handler.Object, new AuthenticationProperties(), out _);
+
+            var act = () => context.RequestSessionTransferTokenAsync(new SessionTransferTokenRequest
+            {
+                SubjectToken = "customer-token",
+                SubjectTokenType = "urn:acme:customer",
+                ActorToken = "   "
+            });
+
+            (await act.Should().ThrowAsync<CustomTokenExchangeException>())
+                .Where(e => e.Code == CustomTokenExchangeErrorCode.InvalidTokenFormat);
+        }
+
+        [Fact]
+        public async Task RequestSessionTransferTokenAsync_Throws_WhenSubjectTokenInvalid()
+        {
+            var handler = SttHandler();
+            var context = BuildContext(handler.Object, new AuthenticationProperties(), out _);
+
+            var act = () => context.RequestSessionTransferTokenAsync(new SessionTransferTokenRequest
+            {
+                SubjectToken = "",
+                SubjectTokenType = "urn:acme:customer",
+                ActorToken = "agent-jwt"
+            });
+
+            (await act.Should().ThrowAsync<CustomTokenExchangeException>())
+                .WithMessage("*subject_token*");
+        }
+
+        [Fact]
+        public async Task RequestSessionTransferTokenAsync_Surfaces_ServerRejection_Raw()
+        {
+            var handler = new Mock<HttpMessageHandler>();
+            handler
+                .Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>())
+                .ReturnsAsync(new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.BadRequest,
+                    Content = new StringContent(
+                        "{\"error\":\"invalid_request\",\"error_description\":\"setActor is required when requesting a session transfer token via token exchange.\"}")
+                });
+
+            var context = BuildContext(handler.Object, new AuthenticationProperties(), out _);
+
+            var act = () => context.RequestSessionTransferTokenAsync(new SessionTransferTokenRequest
+            {
+                SubjectToken = "customer-token",
+                SubjectTokenType = "urn:acme:customer",
+                ActorToken = "agent-jwt"
+            });
+
+            (await act.Should().ThrowAsync<CustomTokenExchangeException>())
+                .Where(e => e.StatusCode == 400
+                    && e.Error == "invalid_request"
+                    && e.ErrorDescription!.Contains("setActor is required"));
+        }
+
+        [Fact]
+        public async Task RequestSessionTransferTokenAsync_BuildsAudience_FromResolvedDomain_ForMcd()
+        {
+            string capturedBody = string.Empty;
+            var handler = new Mock<HttpMessageHandler>();
+            handler
+                .Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>())
+                .Callback<HttpRequestMessage, CancellationToken>((req, _) =>
+                    capturedBody = req.Content!.ReadAsStringAsync().GetAwaiter().GetResult())
+                .ReturnsAsync(new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = new StringContent(
+                        "{\"access_token\":\"the-stt\",\"issued_token_type\":\"urn:auth0:params:oauth:token-type:session_transfer_token\",\"token_type\":\"N_A\",\"expires_in\":60}")
+                });
+
+            var context = BuildContext(handler.Object, new AuthenticationProperties(), out _, resolvedDomain: "tenant.custom.com");
+
+            await context.RequestSessionTransferTokenAsync(new SessionTransferTokenRequest
+            {
+                SubjectToken = "customer-token",
+                SubjectTokenType = "urn:acme:customer",
+                ActorToken = "agent-jwt"
+            });
+
+            capturedBody.Should().Contain("audience=urn%3Atenant.custom.com%3Asession_transfer");
+        }
+
+        [Fact]
+        public async Task RequestSessionTransferTokenAsync_DoesNotPersist_TheStt()
+        {
+            var handler = SttHandler();
+            var properties = new AuthenticationProperties();
+            properties.Items[".Token.id_token"] = IdTokenExpiringIn(10);
+
+            var context = BuildContext(handler.Object, properties, out var authService);
+
+            await context.RequestSessionTransferTokenAsync(new SessionTransferTokenRequest
+            {
+                SubjectToken = "customer-token",
+                SubjectTokenType = "urn:acme:customer"
+            });
+
+            // No STT written anywhere in the session, and (no refresh needed) no SignInAsync.
+            properties.Items.Values.Should().NotContain("the-stt");
+            authService.Verify(s => s.SignInAsync(
+                It.IsAny<HttpContext>(), It.IsAny<string>(),
+                It.IsAny<ClaimsPrincipal>(), It.IsAny<AuthenticationProperties>()), Times.Never());
+        }
+
+        private static SessionTransferTokenResult SttResult(string stt = "s t t/value") => new SessionTransferTokenResult
+        {
+            SessionTransferToken = stt,
+            IssuedTokenType = Auth0Constants.SessionTransferTokenType,
+            ExpiresIn = 60
+        };
+
+        [Fact]
+        public void BuildSessionTransferRedirect_AppendsUrlEncodedStt()
+        {
+            var context = BuildContext(SttHandler().Object, new AuthenticationProperties(), out _);
+
+            var url = context.BuildSessionTransferRedirect("https://target.example.com/login", SttResult("s t t/value"));
+
+            url.Should().Be("https://target.example.com/login?session_transfer_token=s%20t%20t%2Fvalue");
+        }
+
+        [Fact]
+        public void BuildSessionTransferRedirect_PreservesExistingQuery_AndAppendsOrganization()
+        {
+            var context = BuildContext(SttHandler().Object, new AuthenticationProperties(), out _);
+
+            var url = context.BuildSessionTransferRedirect(
+                "https://target.example.com/login?returnTo=%2Fhome",
+                SttResult("stt123"),
+                organization: "org_ABC");
+
+            url.Should().Be("https://target.example.com/login?returnTo=%2Fhome&session_transfer_token=stt123&organization=org_ABC");
+        }
+
+        [Theory]
+        [InlineData("http://target.example.com/login")]   // not https
+        [InlineData("/relative/login")]                    // relative
+        [InlineData("not a url")]
+        public void BuildSessionTransferRedirect_Throws_ForNonAbsoluteHttps(string target)
+        {
+            var context = BuildContext(SttHandler().Object, new AuthenticationProperties(), out _);
+
+            var act = () => context.BuildSessionTransferRedirect(target, SttResult());
+
+            act.Should().Throw<ArgumentException>();
+        }
+
+        // Builds a JWT-shaped string (header.payload.signature) whose payload carries the given exp.
+        private static string JwtWithExp(long exp)
+        {
+            string B64Url(string s)
+            {
+                var bytes = System.Text.Encoding.UTF8.GetBytes(s);
+                return System.Convert.ToBase64String(bytes).TrimEnd('=').Replace('+', '-').Replace('/', '_');
+            }
+            return $"{B64Url("{\"alg\":\"RS256\"}")}.{B64Url($"{{\"exp\":{exp}}}")}.signature";
+        }
+    }
+}

--- a/tests/Auth0.AspNetCore.Authentication.IntegrationTests/SessionTransferTokenTests.cs
+++ b/tests/Auth0.AspNetCore.Authentication.IntegrationTests/SessionTransferTokenTests.cs
@@ -971,6 +971,50 @@ namespace Auth0.AspNetCore.Authentication.IntegrationTests
             url.Should().Be("https://target.example.com/login?returnTo=%2Fhome&session_transfer_token=stt123&organization=org_ABC");
         }
 
+        [Fact]
+        public void BuildSessionTransferRedirect_RequestOverload_ForwardsOrganizationFromRequest()
+        {
+            var context = BuildContext(SttHandler().Object, new AuthenticationProperties(), out _);
+            var request = new SessionTransferTokenRequest
+            {
+                SubjectToken = "subject",
+                SubjectTokenType = "urn:acme:token",
+                Organization = "org_ABC"
+            };
+
+            var url = context.BuildSessionTransferRedirect(
+                "https://target.example.com/login", SttResult("stt123"), request);
+
+            url.Should().Be("https://target.example.com/login?session_transfer_token=stt123&organization=org_ABC");
+        }
+
+        [Fact]
+        public void BuildSessionTransferRedirect_RequestOverload_OmitsOrganization_WhenRequestHasNone()
+        {
+            var context = BuildContext(SttHandler().Object, new AuthenticationProperties(), out _);
+            var request = new SessionTransferTokenRequest
+            {
+                SubjectToken = "subject",
+                SubjectTokenType = "urn:acme:token"
+            };
+
+            var url = context.BuildSessionTransferRedirect(
+                "https://target.example.com/login", SttResult("stt123"), request);
+
+            url.Should().Be("https://target.example.com/login?session_transfer_token=stt123");
+        }
+
+        [Fact]
+        public void BuildSessionTransferRedirect_RequestOverload_Throws_ForNullRequest()
+        {
+            var context = BuildContext(SttHandler().Object, new AuthenticationProperties(), out _);
+
+            var act = () => context.BuildSessionTransferRedirect(
+                "https://target.example.com/login", SttResult(), (SessionTransferTokenRequest)null!);
+
+            act.Should().Throw<ArgumentNullException>().WithParameterName("request");
+        }
+
         [Theory]
         [InlineData("http://target.example.com/login")]   // not https
         [InlineData("/relative/login")]                    // relative

--- a/tests/Auth0.AspNetCore.Authentication.IntegrationTests/SessionTransferTokenTests.cs
+++ b/tests/Auth0.AspNetCore.Authentication.IntegrationTests/SessionTransferTokenTests.cs
@@ -222,6 +222,50 @@ namespace Auth0.AspNetCore.Authentication.IntegrationTests
             capturedBody.Should().Contain("audience=urn%3Atest.auth0.com%3Asession_transfer");
         }
 
+        // A CTE profile that is not configured for session transfer returns an ordinary access token
+        // on this exact path — TokenClient.Send only checks that access_token is non-empty. If the SDK
+        // filled in the STT URN itself, that long-lived multi-use token would be handed to
+        // BuildSessionTransferRedirect and end up in a query string, and the documented
+        // "branch on IssuedTokenType" check would silently pass.
+        [Theory]
+        // issued_token_type absent entirely
+        [InlineData("{\"access_token\":\"a-real-access-token\",\"token_type\":\"Bearer\",\"expires_in\":86400}", "(missing)")]
+        // present but an ordinary access token
+        [InlineData("{\"access_token\":\"a-real-access-token\",\"issued_token_type\":\"urn:ietf:params:oauth:token-type:access_token\",\"token_type\":\"Bearer\",\"expires_in\":86400}", "urn:ietf:params:oauth:token-type:access_token")]
+        // present but empty
+        [InlineData("{\"access_token\":\"a-real-access-token\",\"issued_token_type\":\"\",\"token_type\":\"Bearer\",\"expires_in\":86400}", "")]
+        public async Task RequestSessionTransferTokenAsync_Throws_WhenIssuedTokenTypeIsNotStt(string body, string reportedType)
+        {
+            var handler = new Mock<HttpMessageHandler>();
+            handler
+                .Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>())
+                .ReturnsAsync(new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = new StringContent(body)
+                });
+
+            var context = BuildContext(handler.Object, new AuthenticationProperties(), out _);
+
+            var act = async () => await context.RequestSessionTransferTokenAsync(new SessionTransferTokenRequest
+            {
+                SubjectToken = "customer-token",
+                SubjectTokenType = "urn:acme:customer",
+                ActorToken = "agent-jwt"
+            });
+
+            var ex = (await act.Should().ThrowAsync<CustomTokenExchangeException>()).Which;
+            ex.Error.Should().Be("invalid_issued_token_type");
+            // Quoted so the empty-string case still asserts something (Contain("") is rejected).
+            ex.Message.Should().Contain($"was \"{reportedType}\"");
+            // The access token must never leak into the exception message — it would land in logs.
+            ex.Message.Should().NotContain("a-real-access-token");
+        }
+
         [Fact]
         public async Task RequestSessionTransferTokenAsync_AutoSourcesActor_FromFreshSessionIdToken()
         {

--- a/tests/Auth0.AspNetCore.Authentication.IntegrationTests/SessionTransferTokenTests.cs
+++ b/tests/Auth0.AspNetCore.Authentication.IntegrationTests/SessionTransferTokenTests.cs
@@ -229,12 +229,12 @@ namespace Auth0.AspNetCore.Authentication.IntegrationTests
         // "branch on IssuedTokenType" check would silently pass.
         [Theory]
         // issued_token_type absent entirely
-        [InlineData("{\"access_token\":\"a-real-access-token\",\"token_type\":\"Bearer\",\"expires_in\":86400}", "(missing)")]
+        [InlineData("{\"access_token\":\"a-real-access-token\",\"token_type\":\"Bearer\",\"expires_in\":86400}")]
         // present but an ordinary access token
-        [InlineData("{\"access_token\":\"a-real-access-token\",\"issued_token_type\":\"urn:ietf:params:oauth:token-type:access_token\",\"token_type\":\"Bearer\",\"expires_in\":86400}", "urn:ietf:params:oauth:token-type:access_token")]
+        [InlineData("{\"access_token\":\"a-real-access-token\",\"issued_token_type\":\"urn:ietf:params:oauth:token-type:access_token\",\"token_type\":\"Bearer\",\"expires_in\":86400}")]
         // present but empty
-        [InlineData("{\"access_token\":\"a-real-access-token\",\"issued_token_type\":\"\",\"token_type\":\"Bearer\",\"expires_in\":86400}", "")]
-        public async Task RequestSessionTransferTokenAsync_Throws_WhenIssuedTokenTypeIsNotStt(string body, string reportedType)
+        [InlineData("{\"access_token\":\"a-real-access-token\",\"issued_token_type\":\"\",\"token_type\":\"Bearer\",\"expires_in\":86400}")]
+        public async Task RequestSessionTransferTokenAsync_Throws_WhenIssuedTokenTypeIsNotStt(string body)
         {
             var handler = new Mock<HttpMessageHandler>();
             handler
@@ -260,8 +260,6 @@ namespace Auth0.AspNetCore.Authentication.IntegrationTests
 
             var ex = (await act.Should().ThrowAsync<CustomTokenExchangeException>()).Which;
             ex.Error.Should().Be("invalid_issued_token_type");
-            // Quoted so the empty-string case still asserts something (Contain("") is rejected).
-            ex.Message.Should().Contain($"was \"{reportedType}\"");
             // The access token must never leak into the exception message — it would land in logs.
             ex.Message.Should().NotContain("a-real-access-token");
         }
@@ -627,8 +625,16 @@ namespace Auth0.AspNetCore.Authentication.IntegrationTests
                     && e.ErrorDescription!.Contains("setActor is required"));
         }
 
-        [Fact]
-        public async Task RequestSessionTransferTokenAsync_BuildsAudience_FromResolvedDomain_ForMcd()
+        // A DomainResolver may return a bare host or a full issuer, and Auth0CustomDomainStartupFilter
+        // stores whichever it gets verbatim in HttpContext.Items (see
+        // Auth0CustomDomainStartupFilterTests, which resolves "https://custom.domain.com"). The
+        // audience must carry the bare host for every shape — interpolating the raw value would build
+        // urn:https://custom.domain.com:session_transfer, which the token endpoint rejects.
+        [Theory]
+        [InlineData("tenant.custom.com")]
+        [InlineData("https://tenant.custom.com")]
+        [InlineData("https://tenant.custom.com/")]
+        public async Task RequestSessionTransferTokenAsync_BuildsAudience_FromResolvedDomain_ForMcd(string resolvedDomain)
         {
             string capturedBody = string.Empty;
             var handler = new Mock<HttpMessageHandler>();
@@ -647,7 +653,7 @@ namespace Auth0.AspNetCore.Authentication.IntegrationTests
                         "{\"access_token\":\"the-stt\",\"issued_token_type\":\"urn:auth0:params:oauth:token-type:session_transfer_token\",\"token_type\":\"N_A\",\"expires_in\":60}")
                 });
 
-            var context = BuildContext(handler.Object, new AuthenticationProperties(), out _, resolvedDomain: "tenant.custom.com");
+            var context = BuildContext(handler.Object, new AuthenticationProperties(), out _, resolvedDomain: resolvedDomain);
 
             await context.RequestSessionTransferTokenAsync(new SessionTransferTokenRequest
             {
@@ -657,6 +663,8 @@ namespace Auth0.AspNetCore.Authentication.IntegrationTests
             });
 
             capturedBody.Should().Contain("audience=urn%3Atenant.custom.com%3Asession_transfer");
+            // Guard against the scheme leaking into the URN for the issuer-shaped inputs.
+            capturedBody.Should().NotContain("https%3A%2F%2Ftenant.custom.com");
         }
 
         [Fact]

--- a/tests/Auth0.AspNetCore.Authentication.IntegrationTests/SessionTransferTokenTests.cs
+++ b/tests/Auth0.AspNetCore.Authentication.IntegrationTests/SessionTransferTokenTests.cs
@@ -60,7 +60,8 @@ namespace Auth0.AspNetCore.Authentication.IntegrationTests
             AuthenticationProperties properties,
             out Mock<IAuthenticationService> authService,
             string? resolvedDomain = null,
-            string? audience = null)
+            string? audience = null,
+            TimeSpan? accessTokenExpirationLeeway = null)
         {
             var webAppOptions = new Auth0WebAppOptions
             {
@@ -72,6 +73,10 @@ namespace Auth0.AspNetCore.Authentication.IntegrationTests
             };
 
             var withAccessTokenOptions = new Auth0WebAppWithAccessTokenOptions { Audience = audience };
+            if (accessTokenExpirationLeeway.HasValue)
+            {
+                withAccessTokenOptions.AccessTokenExpirationLeeway = accessTokenExpirationLeeway.Value;
+            }
 
             var principal = new ClaimsPrincipal(new ClaimsIdentity("Cookies"));
             var ticket = new AuthenticationTicket(principal, properties, CookieScheme);
@@ -379,6 +384,69 @@ namespace Auth0.AspNetCore.Authentication.IntegrationTests
             // The rotated refresh token was persisted (rotation-safe).
             persisted.Should().NotBeNull();
             persisted!.Items[".Token.refresh_token"].Should().Be("rotated-rt");
+        }
+
+        // AccessTokenExpirationLeeway is deliberately reused as the id_token freshness margin, so tuning
+        // it must actually move the actor-refresh boundary. The same id_token (2 minutes from exp) is
+        // fresh under a 30s leeway and stale under a 5m one.
+        [Theory]
+        [InlineData(30, 1)]    // leeway 30s  -> still fresh -> STT exchange only
+        [InlineData(300, 2)]   // leeway 5m   -> stale       -> refresh, then STT exchange
+        public async Task RequestSessionTransferTokenAsync_ActorFreshness_HonorsAccessTokenExpirationLeeway(
+            int leewaySeconds, int expectedRequestCount)
+        {
+            var idToken = IdTokenExpiringIn(2);
+            var refreshedIdToken = IdTokenExpiringIn(60);
+
+            var responses = new System.Collections.Generic.Queue<HttpResponseMessage>();
+            if (expectedRequestCount == 2)
+            {
+                responses.Enqueue(new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = new StringContent(
+                        $"{{\"access_token\":\"new-at\",\"id_token\":\"{refreshedIdToken}\",\"expires_in\":86400}}")
+                });
+            }
+            responses.Enqueue(new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = new StringContent(
+                    "{\"access_token\":\"the-stt\",\"issued_token_type\":\"urn:auth0:params:oauth:token-type:session_transfer_token\",\"token_type\":\"N_A\",\"expires_in\":60}")
+            });
+
+            var capturedBodies = new System.Collections.Generic.List<string>();
+            var handler = new Mock<HttpMessageHandler>();
+            handler
+                .Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>())
+                .Callback<HttpRequestMessage, CancellationToken>((req, _) =>
+                    capturedBodies.Add(req.Content!.ReadAsStringAsync().GetAwaiter().GetResult()))
+                .ReturnsAsync(() => responses.Dequeue());
+
+            var properties = new AuthenticationProperties();
+            properties.Items[".Token.id_token"] = idToken;
+            properties.Items[".Token.refresh_token"] = "rt";
+
+            var context = BuildContext(handler.Object, properties, out _,
+                accessTokenExpirationLeeway: TimeSpan.FromSeconds(leewaySeconds));
+
+            var result = await context.RequestSessionTransferTokenAsync(new SessionTransferTokenRequest
+            {
+                SubjectToken = "customer-token",
+                SubjectTokenType = "urn:acme:customer"
+            });
+
+            result.SessionTransferToken.Should().Be("the-stt");
+            capturedBodies.Should().HaveCount(expectedRequestCount);
+
+            // Whichever id_token the leeway selected is the one sent as the actor.
+            var expectedActor = expectedRequestCount == 2 ? refreshedIdToken : idToken;
+            capturedBodies[expectedRequestCount - 1].Should()
+                .Contain($"actor_token={Uri.EscapeDataString(expectedActor)}");
         }
 
         [Fact]

--- a/tests/Auth0.AspNetCore.Authentication.IntegrationTests/TokenClientTests.cs
+++ b/tests/Auth0.AspNetCore.Authentication.IntegrationTests/TokenClientTests.cs
@@ -675,5 +675,32 @@ namespace Auth0.AspNetCore.Authentication.IntegrationTests
             result.Error.Should().Be("invalid_request");
             result.ErrorDescription.Should().Be("bad profile");
         }
+
+        [Fact]
+        public async Task ExchangeCustomToken_ParsesIssuedTokenType_WhenPresent()
+        {
+            var mockHandler = new Mock<HttpMessageHandler>();
+            mockHandler
+                .Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>())
+                .ReturnsAsync(new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = new StringContent(
+                        "{\"access_token\":\"stt-value\",\"issued_token_type\":\"urn:auth0:params:oauth:token-type:session_transfer_token\",\"token_type\":\"N_A\",\"expires_in\":60}")
+                });
+
+            var client = new TokenClient(new HttpClient(mockHandler.Object));
+            var result = await client.ExchangeCustomToken(
+                new Auth0WebAppOptions { Domain = "local.auth0.com", ClientId = "cid", ClientSecret = "secret" },
+                subjectToken: "ext-token",
+                subjectTokenType: "urn:acme:legacy-token");
+
+            result.IsSuccess.Should().BeTrue();
+            result.Response!.IssuedTokenType.Should().Be("urn:auth0:params:oauth:token-type:session_transfer_token");
+        }
     }
 }


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

This PR adds **Impersonation via Session Transfer**, an additive initiator-side surface built on top of the existing Custom Token Exchange (CTE) support.

Session Transfer lets an initiator app (e.g. a support/admin console - the *actor*) start an authenticated web session in a target app *as a customer* (the *subject*), with the agent recorded in the `act` claim. The initiator requests a short-lived, single-use **Session Transfer Token (STT)** and redirects the agent's browser to the target app's login URL carrying that STT; the target redeems it at `/authorize`.

New public API on `HttpContext`:

- **`RequestSessionTransferTokenAsync(SessionTransferTokenRequest)`** - performs the CTE exchange and returns an STT. The actor is auto-sourced from the current session's `id_token` (refreshed automatically, rotation-safe, if stale), unless an explicit `ActorToken` is supplied. The audience is set by the SDK to `urn:{resolved-domain}:session_transfer`. The STT is **never persisted**.
- **`BuildSessionTransferRedirect(targetLoginUrl, result, organization?)`** - builds the redirect URL that carries the STT (URL-encoded) to the target's login endpoint, preserving any existing query and fragment.

### References

### Testing

Unit/integration tests were added in `SessionTransferTokenTests.cs` (and extended in `TokenClientTests.cs`).
- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `main`
