### PR TITLE
feat: Adds mTLS support

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -1360,7 +1360,7 @@ mTLS requires tenant-side configuration that is only available on specific plans
 
 ### Configuration
 
-Build an `HttpClient` that presents the client certificate, then pass it to `WithMtls`. The SDK never reads or stores the certificate — it only uses the client you supply.
+Build an `HttpClient` that presents the client certificate, then pass it to `WithMtls`. The SDK never reads or stores the certificate - it only uses the client you supply.
 
 ```csharp
 using System.Net.Http;
@@ -1406,10 +1406,10 @@ builder.Services
 
 - **Call `WithMtls` before `WithAccessToken`.** When combining with custom domains, the order is `WithCustomDomains` → `WithMtls` → `WithAccessToken`. A wrong order throws at startup.
 - **Leave `ResponseType` at its default.** Do not pre-set it to `code` or `code id_token` in `AddAuth0WebAppAuthentication`: registration-time validation runs before `WithMtls` and would otherwise reject the certificate-only configuration as missing a credential.
-- **The certificate is the sole credential.** Do not also set `ClientSecret`, `ClientAssertionSecurityKey`, or `Backchannel` — each throws at startup.
+- **The certificate is the sole credential.** Do not also set `ClientSecret`, `ClientAssertionSecurityKey`, or `Backchannel` - each throws at startup.
 - **Keep the `HttpClient` long-lived.** A per-request client would defeat connection pooling and repeat the TLS handshake on every call.
 
-Once configured, every client-authenticated back-channel request — the code exchange, token refresh, MRRT and Token Vault exchanges, session-transfer, MFA challenge, and Pushed Authorization Requests — is routed through the tenant's `mtls_endpoint_aliases` and sends the certificate instead of a secret. Bearer-token endpoints (MFA associate/list) continue to use the standard host.
+Once configured, every client-authenticated back-channel request - the code exchange, token refresh, MRRT and Token Vault exchanges, session-transfer, MFA challenge, and Pushed Authorization Requests - is routed through the tenant's `mtls_endpoint_aliases` and sends the certificate instead of a secret. Bearer-token endpoints (MFA associate/list) continue to use the standard host.
 
 ### Combining with custom domains
 
@@ -1417,7 +1417,7 @@ Once configured, every client-authenticated back-channel request — the code ex
 
 ### Limitations
 
-- **The SDK does not own the certificate.** You supply and manage the `HttpClient` (loading, storage, and rotation are yours). Because `HttpClient` does not expose its handler, the SDK cannot verify a certificate is actually attached — it only checks that an `HttpClient` was provided.
+- **The SDK does not own the certificate.** You supply and manage the `HttpClient` (loading, storage, and rotation are yours). Because `HttpClient` does not expose its handler, the SDK cannot verify a certificate is actually attached - it only checks that an `HttpClient` was provided.
 - **No thumbprint verification.** When mTLS is enabled and an access token issued on a `cnf`-bearing grant (authorization code or refresh) is **not** certificate-bound, the SDK logs a one-time warning per client (`cnf.x5t#S256` is absent). It checks the claim's *presence* only; it does not compare the thumbprint to your certificate.
 
 ## Backchannel Logout

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -26,6 +26,7 @@
 - [Extra parameters](#extra-parameters)
 - [Roles](#roles)
 - [Multiple Custom Domain (MCD) Support](#multiple-custom-domain-mcd-support)
+- [Mutual TLS (mTLS)](#mutual-tls-mtls)
 - [Backchannel Logout](#backchannel-logout)
 - [Blazor Server](#blazor-server)
 
@@ -1343,6 +1344,81 @@ public class MyCustomConfigurationManagerCache : IConfigurationManagerCache
     options.ConfigurationManagerCache = new MyCustomConfigurationManagerCache();
 });
 ```
+
+## Mutual TLS (mTLS)
+
+Mutual TLS (mTLS) authenticates your application to Auth0 with a **client certificate** instead of a client secret or client assertion. Access tokens can additionally be **certificate-bound** (sender-constrained), so a stolen token cannot be replayed without the private key.
+
+### Prerequisites
+
+mTLS requires tenant-side configuration that is only available on specific plans:
+
+- An Enterprise plan with **Highly Regulated Identity**.
+- A custom domain of type `self_managed_certs`, with mTLS endpoint aliases enabled (`enable_endpoint_aliases`).
+- A client-certificate credential registered for your application.
+- For certificate-bound tokens, an API with **Token Sender-Constraining** set to mTLS.
+
+### Configuration
+
+Build an `HttpClient` that presents the client certificate, then pass it to `WithMtls`. The SDK never reads or stores the certificate — it only uses the client you supply.
+
+```csharp
+using System.Net.Http;
+using System.Net.Security;
+using System.Security.Cryptography.X509Certificates;
+
+var certificate = X509Certificate2.CreateFromPemFile(
+    "certs/client.crt", "certs/client.key");
+
+// On Windows, a certificate created from PEM has an ephemeral key that Schannel cannot use for a
+// TLS handshake. Round-tripping through PFX gives it a usable key. Harmless on Linux and macOS.
+certificate = new X509Certificate2(certificate.Export(X509ContentType.Pfx));
+
+var handler = new SocketsHttpHandler
+{
+    SslOptions = new SslClientAuthenticationOptions
+    {
+        ClientCertificates = new X509Certificate2Collection(certificate)
+    }
+};
+
+var mtlsHttpClient = new HttpClient(handler);
+
+builder.Services
+    .AddAuth0WebAppAuthentication(options =>
+    {
+        options.Domain = builder.Configuration["Auth0:Domain"];   // self_managed_certs custom domain
+        options.ClientId = builder.Configuration["Auth0:ClientId"];
+        // No ClientSecret: the certificate is the credential.
+    })
+    .WithMtls(options =>
+    {
+        options.HttpClient = mtlsHttpClient;
+    })
+    .WithAccessToken(options =>
+    {
+        options.Audience = builder.Configuration["Auth0:Audience"];   // required for a JWT with cnf
+        options.UseRefreshTokens = true;
+    });
+```
+
+### Important notes
+
+- **Call `WithMtls` before `WithAccessToken`.** When combining with custom domains, the order is `WithCustomDomains` → `WithMtls` → `WithAccessToken`. A wrong order throws at startup.
+- **Leave `ResponseType` at its default.** Do not pre-set it to `code` or `code id_token` in `AddAuth0WebAppAuthentication`: registration-time validation runs before `WithMtls` and would otherwise reject the certificate-only configuration as missing a credential.
+- **The certificate is the sole credential.** Do not also set `ClientSecret`, `ClientAssertionSecurityKey`, or `Backchannel` — each throws at startup.
+- **Keep the `HttpClient` long-lived.** A per-request client would defeat connection pooling and repeat the TLS handshake on every call.
+
+Once configured, every client-authenticated back-channel request — the code exchange, token refresh, MRRT and Token Vault exchanges, session-transfer, MFA challenge, and Pushed Authorization Requests — is routed through the tenant's `mtls_endpoint_aliases` and sends the certificate instead of a secret. Bearer-token endpoints (MFA associate/list) continue to use the standard host.
+
+### Combining with custom domains
+
+`WithMtls` composes with [Multiple Custom Domain (MCD) Support](#multiple-custom-domain-mcd-support). Call `WithCustomDomains` first, then `WithMtls`, then `WithAccessToken`. Endpoint aliases are resolved per domain.
+
+### Limitations
+
+- **The SDK does not own the certificate.** You supply and manage the `HttpClient` (loading, storage, and rotation are yours). Because `HttpClient` does not expose its handler, the SDK cannot verify a certificate is actually attached — it only checks that an `HttpClient` was provided.
+- **No thumbprint verification.** When mTLS is enabled and an access token issued on a `cnf`-bearing grant (authorization code or refresh) is **not** certificate-bound, the SDK logs a one-time warning per client (`cnf.x5t#S256` is absent). It checks the claim's *presence* only; it does not compare the thumbprint to your certificate.
 
 ## Backchannel Logout
 

--- a/README.md
+++ b/README.md
@@ -141,6 +141,10 @@ services.AddAuth0WebAppAuthentication(options =>
 
 For detailed configuration options, caching strategies, security requirements, and more examples, see the [Multiple Custom Domain (MCD) Examples](EXAMPLES.md#multiple-custom-domain-mcd-support).
 
+## Mutual TLS (mTLS)
+
+Authenticate to Auth0 with a client certificate (RFC 8705) instead of a client secret, and optionally bind access tokens to the certificate. See [Mutual TLS (mTLS) Examples](EXAMPLES.md#mutual-tls-mtls).
+
 ## Multi-Resource Refresh Tokens (MRRT)
 
 Multi-Resource Refresh Tokens (MRRT) let a single session obtain access tokens for additional audiences and scopes on demand, by exchanging the session's refresh token — without forcing the user through another interactive login.

--- a/src/Auth0.AspNetCore.Authentication/Auth0MtlsOptions.cs
+++ b/src/Auth0.AspNetCore.Authentication/Auth0MtlsOptions.cs
@@ -1,0 +1,21 @@
+using System.Net.Http;
+
+namespace Auth0.AspNetCore.Authentication
+{
+    /// <summary>
+    /// Options for configuring Mutual TLS (mTLS) client authentication via
+    /// <see cref="Auth0WebAppAuthenticationBuilder.WithMtls"/>.
+    /// </summary>
+    public class Auth0MtlsOptions
+    {
+        /// <summary>
+        /// The <see cref="System.Net.Http.HttpClient"/> configured with the client certificate. It is
+        /// used for every client-authenticated back-channel request (token endpoint, MFA challenge,
+        /// PAR, and the code exchange performed by the OpenID Connect handler). The SDK never reads or
+        /// stores the certificate itself — attach it to this client's transport
+        /// (for example a <c>SocketsHttpHandler</c> with <c>SslClientAuthenticationOptions</c>).
+        /// The client should be long-lived so the TLS connection pool is reused across requests.
+        /// </summary>
+        public HttpClient? HttpClient { get; set; }
+    }
+}

--- a/src/Auth0.AspNetCore.Authentication/Auth0WebAppAuthenticationBuilder.cs
+++ b/src/Auth0.AspNetCore.Authentication/Auth0WebAppAuthenticationBuilder.cs
@@ -25,6 +25,7 @@ namespace Auth0.AspNetCore.Authentication
         private readonly Auth0WebAppOptions _options;
         private readonly string _authenticationScheme;
         private bool _accessTokenConfigured;
+        private bool _mtlsConfigured;
 
         /// <summary>
         /// Constructs an instance of <see cref="Auth0WebAppAuthenticationBuilder"/>
@@ -154,6 +155,8 @@ namespace Auth0.AspNetCore.Authentication
                     "mTLS cannot be combined with a client secret or client assertion; the certificate is the sole credential.");
             }
 
+            _mtlsConfigured = true;
+
             // Dual-write to both option instances: the builder instance drives oidcOptions.Backchannel
             // (code exchange + PAR) via the ConfigureOpenIdConnect closure, and the DI-registered
             // named instance is what the HttpContextExtensions call sites read via IOptionsSnapshot.
@@ -229,6 +232,17 @@ namespace Auth0.AspNetCore.Authentication
 
         private void EnableCustomDomains(Action<Auth0CustomDomainsOptions> configureOptions)
         {
+            // Custom domains must be configured before mTLS. Both register an
+            // IPostConfigureOptions<OpenIdConnectOptions> that touches ConfigurationManager: custom
+            // domains replaces it, mTLS wraps it. Post-configures run in registration order, so mTLS
+            // only wraps the custom-domains manager if it registers last. If WithMtls ran first, the
+            // custom-domains post-configure would run last and discard the mTLS wrapper, routing the
+            // code exchange and PAR to the non-mTLS endpoints. Fail fast rather than silently.
+            if (_mtlsConfigured)
+            {
+                throw new InvalidOperationException("WithCustomDomains must be called before WithMtls.");
+            }
+
             var customDomainsOptions = new Auth0CustomDomainsOptions();
             configureOptions(customDomainsOptions);
             

--- a/src/Auth0.AspNetCore.Authentication/Auth0WebAppAuthenticationBuilder.cs
+++ b/src/Auth0.AspNetCore.Authentication/Auth0WebAppAuthenticationBuilder.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 using Auth0.AspNetCore.Authentication.BackchannelLogout;
 using Auth0.AspNetCore.Authentication.CustomDomains;
 using Auth0.AspNetCore.Authentication.AuthenticationApi;
+using Auth0.AspNetCore.Authentication.Mtls;
 using System.Net.Http;
 using Microsoft.AspNetCore.Hosting;
 
@@ -23,6 +24,7 @@ namespace Auth0.AspNetCore.Authentication
         private readonly IServiceCollection _services;
         private readonly Auth0WebAppOptions _options;
         private readonly string _authenticationScheme;
+        private bool _accessTokenConfigured;
 
         /// <summary>
         /// Constructs an instance of <see cref="Auth0WebAppAuthenticationBuilder"/>
@@ -92,7 +94,8 @@ namespace Auth0.AspNetCore.Authentication
                     new Uri($"https://{_options.Domain}"),
                     _options,
                     sp.GetRequiredService<IMfaTokenProtector>(),
-                    ownsHttpClient: backchannel == null);
+                    ownsHttpClient: backchannel == null,
+                    mtlsEndpointResolver: sp.GetService<Mtls.Auth0MtlsEndpointResolver>());
             });
             return this;
         }
@@ -105,6 +108,72 @@ namespace Auth0.AspNetCore.Authentication
         public Auth0WebAppAuthenticationBuilder WithCustomDomains(Action<Auth0CustomDomainsOptions> configureOptions)
         {
             EnableCustomDomains(configureOptions);
+            return this;
+        }
+
+        /// <summary>
+        /// Configures Mutual TLS (mTLS) client authentication. The supplied
+        /// <see cref="Auth0MtlsOptions.HttpClient"/> — which must carry the client certificate — is used
+        /// as the backchannel for every client-authenticated request, and requests are routed through
+        /// the tenant's <c>mtls_endpoint_aliases</c>.
+        /// </summary>
+        /// <remarks>
+        /// Must be called <b>before</b> <see cref="WithAccessToken"/> and (when combined) <b>after</b>
+        /// <see cref="WithCustomDomains"/>. The certificate is the sole credential: do not also set
+        /// <see cref="Auth0WebAppOptions.ClientSecret"/>, <see cref="Auth0WebAppOptions.ClientAssertionSecurityKey"/>,
+        /// or <see cref="Auth0WebAppOptions.Backchannel"/>.
+        /// </remarks>
+        /// <param name="configureOptions">A delegate used to configure the <see cref="Auth0MtlsOptions"/>.</param>
+        /// <returns>An instance of <see cref="Auth0WebAppAuthenticationBuilder"/>.</returns>
+        public Auth0WebAppAuthenticationBuilder WithMtls(Action<Auth0MtlsOptions> configureOptions)
+        {
+            var mtlsOptions = new Auth0MtlsOptions();
+            configureOptions(mtlsOptions);
+
+            if (mtlsOptions.HttpClient == null)
+            {
+                throw new InvalidOperationException(
+                    "WithMtls requires an HttpClient configured with the client certificate.");
+            }
+
+            if (_accessTokenConfigured)
+            {
+                throw new InvalidOperationException("WithMtls must be called before WithAccessToken.");
+            }
+
+            if (_options.Backchannel != null)
+            {
+                throw new InvalidOperationException(
+                    "Backchannel cannot be set when WithMtls supplies an HttpClient. Configure a single HttpClient " +
+                    "with both the client certificate and your transport settings, and pass it to WithMtls.");
+            }
+
+            if (!string.IsNullOrWhiteSpace(_options.ClientSecret) || _options.ClientAssertionSecurityKey != null)
+            {
+                throw new InvalidOperationException(
+                    "mTLS cannot be combined with a client secret or client assertion; the certificate is the sole credential.");
+            }
+
+            // Dual-write to both option instances: the builder instance drives oidcOptions.Backchannel
+            // (code exchange + PAR) via the ConfigureOpenIdConnect closure, and the DI-registered
+            // named instance is what the HttpContextExtensions call sites read via IOptionsSnapshot.
+            _options.Backchannel = mtlsOptions.HttpClient;
+            _options.UseMtls = true;
+            _services.Configure<Auth0WebAppOptions>(_authenticationScheme, o =>
+            {
+                o.Backchannel = mtlsOptions.HttpClient;
+                o.UseMtls = true;
+            });
+
+            _services.AddHttpClient();
+            _services.TryAddSingleton<Auth0MtlsEndpointResolver>();
+            _services.TryAddSingleton<MtlsCnfInspector>();
+
+            // Register last so, with WithCustomDomains registered first, this post-configure runs after
+            // the custom-domains one and wraps its ConfigurationManager rather than being overwritten.
+            _services.TryAddEnumerable(
+                ServiceDescriptor.Singleton<IPostConfigureOptions<OpenIdConnectOptions>, MtlsOpenIdConnectPostConfigureOptions>());
+
             return this;
         }
 
@@ -192,6 +261,8 @@ namespace Auth0.AspNetCore.Authentication
 
         private void EnableWithAccessToken(Action<Auth0WebAppWithAccessTokenOptions> configureOptions)
         {
+            _accessTokenConfigured = true;
+
             var auth0WithAccessTokensOptions = new Auth0WebAppWithAccessTokenOptions();
 
             configureOptions(auth0WithAccessTokensOptions);
@@ -255,6 +326,12 @@ namespace Auth0.AspNetCore.Authentication
 
         private static void ValidateOptions(Auth0WebAppOptions options)
         {
+            // Under mTLS the certificate is the credential; WithMtls has already enforced exclusivity.
+            if (options.UseMtls)
+            {
+                return;
+            }
+
             if (string.IsNullOrWhiteSpace(options.ClientSecret) && options.ClientAssertionSecurityKey == null)
             {
                 throw new InvalidOperationException("Both Client Secret and Client Assertion can not be null when requesting an access token, one or the other has to be set.");

--- a/src/Auth0.AspNetCore.Authentication/Auth0WebAppOptions.cs
+++ b/src/Auth0.AspNetCore.Authentication/Auth0WebAppOptions.cs
@@ -105,6 +105,14 @@ namespace Auth0.AspNetCore.Authentication
         public HttpClient? Backchannel { get; set; }
 
         /// <summary>
+        /// When <c>true</c>, the SDK authenticates with a TLS client certificate (mTLS)
+        /// instead of a client secret or client assertion, and routes client-authenticated
+        /// back-channel requests through the <c>mtls_endpoint_aliases</c> from discovery.
+        /// Set by <see cref="Auth0WebAppAuthenticationBuilder.WithMtls"/>; not set directly.
+        /// </summary>
+        internal bool UseMtls { get; set; }
+
+        /// <summary>
         /// If provided, will set the 'max_age' parameter with the authentication request.
         /// If the identity provider has not actively authenticated the user within the length of time specified, 
         /// the user will be prompted to re-authenticate.

--- a/src/Auth0.AspNetCore.Authentication/AuthenticationApi/AuthenticationApiClient.cs
+++ b/src/Auth0.AspNetCore.Authentication/AuthenticationApi/AuthenticationApiClient.cs
@@ -9,6 +9,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Auth0.AspNetCore.Authentication.AuthenticationApi.Models;
 using Auth0.AspNetCore.Authentication.Exceptions;
+using Auth0.AspNetCore.Authentication.Mtls;
 using Microsoft.IdentityModel.Tokens;
 
 namespace Auth0.AspNetCore.Authentication.AuthenticationApi;
@@ -38,6 +39,8 @@ public class AuthenticationApiClient : IAuthenticationApiClient
     private readonly string _domain;
     private readonly bool _ownsHttpClient;
     private readonly IMfaTokenProtector _mfaTokenProtector;
+    private readonly Auth0MtlsEndpointResolver? _mtlsEndpointResolver;
+    private string? _mtlsHost;
 
     private static readonly JsonSerializerOptions SerializerOptions = new JsonSerializerOptions
     {
@@ -50,7 +53,8 @@ public class AuthenticationApiClient : IAuthenticationApiClient
     /// <param name="options">The authentication options.</param>
     /// <param name="mfaTokenProtector">The protector for decrypting MFA token blobs.</param>
     /// <param name="ownsHttpClient">When <c>true</c> (the default), the supplied <see cref="HttpClient"/> is disposed when this client is disposed. Pass <c>false</c> when the <see cref="HttpClient"/> is owned by the caller (for example a shared backchannel client).</param>
-    internal AuthenticationApiClient(HttpClient httpClient, Uri baseUri, Auth0WebAppOptions options, IMfaTokenProtector mfaTokenProtector, bool ownsHttpClient = true)
+    /// <param name="mtlsEndpointResolver">Optional resolver for mTLS endpoint discovery.</param>
+    internal AuthenticationApiClient(HttpClient httpClient, Uri baseUri, Auth0WebAppOptions options, IMfaTokenProtector mfaTokenProtector, bool ownsHttpClient = true, Auth0MtlsEndpointResolver? mtlsEndpointResolver = null)
     {
         _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
         BaseUri = baseUri ?? throw new ArgumentNullException(nameof(baseUri));
@@ -58,6 +62,7 @@ public class AuthenticationApiClient : IAuthenticationApiClient
         _mfaTokenProtector = mfaTokenProtector ?? throw new ArgumentNullException(nameof(mfaTokenProtector));
         _domain = baseUri.Host;
         _ownsHttpClient = ownsHttpClient;
+        _mtlsEndpointResolver = mtlsEndpointResolver;
     }
 
     /// <inheritdoc />
@@ -244,7 +249,30 @@ public class AuthenticationApiClient : IAuthenticationApiClient
         }
     }
 
-    private Uri BuildUri(string path) => new Uri($"https://{_domain}/{path}");
+    private Uri BuildUri(string path)
+    {
+        if (_options.UseMtls && _mtlsEndpointResolver != null &&
+            (path == "oauth/token" || path == "mfa/challenge"))
+        {
+            return new Uri($"https://{ResolveMtlsHost()}/{path}");
+        }
+
+        return new Uri($"https://{_domain}/{path}");
+    }
+
+    // BuildUri is synchronous while discovery is async. The resolver caches per domain, so this
+    // blocks only on the first client-authenticated call for a cold domain; subsequent calls (and
+    // any call after TokenClient has already warmed the same domain) are a dictionary lookup.
+    private string ResolveMtlsHost()
+    {
+        if (_mtlsHost == null)
+        {
+            var tokenEndpoint = _mtlsEndpointResolver!.ResolveTokenEndpointAsync(_domain, _httpClient).GetAwaiter().GetResult();
+            _mtlsHost = new Uri(tokenEndpoint).Host;
+        }
+
+        return _mtlsHost;
+    }
 
     // The grant calls replay the audience/scope bound into the blob so the new token targets the
     // same resource the original refresh did.
@@ -272,6 +300,12 @@ public class AuthenticationApiClient : IAuthenticationApiClient
 
     private void ApplyClientAuthentication(Dictionary<string, string> body)
     {
+        // Under mTLS the client certificate is the sole credential.
+        if (_options.UseMtls)
+        {
+            return;
+        }
+
         if (_options.ClientAssertionSecurityKey != null)
         {
             body.Add("client_assertion", new JwtTokenFactory(

--- a/src/Auth0.AspNetCore.Authentication/AuthenticationApi/AuthenticationApiClient.cs
+++ b/src/Auth0.AspNetCore.Authentication/AuthenticationApi/AuthenticationApiClient.cs
@@ -126,7 +126,7 @@ public class AuthenticationApiClient : IAuthenticationApiClient
         ApplyClientAuthentication(body);
 
         var content = new FormUrlEncodedContent(body.Select(p => new KeyValuePair<string?, string?>(p.Key, p.Value)));
-        using var message = new HttpRequestMessage(HttpMethod.Post, BuildUri("oauth/token")) { Content = content };
+        using var message = new HttpRequestMessage(HttpMethod.Post, await BuildUriAsync("oauth/token", cancellationToken).ConfigureAwait(false)) { Content = content };
         using var response = await _httpClient.SendAsync(message, cancellationToken).ConfigureAwait(false);
 
         // authorization_pending / slow_down arrive as HTTP 400 while the user has not yet approved
@@ -182,7 +182,7 @@ public class AuthenticationApiClient : IAuthenticationApiClient
 
         var bearer = ResolveAssociateToken(request.Token);
 
-        using var message = new HttpRequestMessage(HttpMethod.Post, BuildUri("mfa/associate"))
+        using var message = new HttpRequestMessage(HttpMethod.Post, await BuildUriAsync("mfa/associate", cancellationToken).ConfigureAwait(false))
         {
             Content = new StringContent(JsonSerializer.Serialize(request, SerializerOptions), Encoding.UTF8, "application/json")
         };
@@ -196,7 +196,7 @@ public class AuthenticationApiClient : IAuthenticationApiClient
     {
         if (string.IsNullOrWhiteSpace(accessToken)) throw new ArgumentNullException(nameof(accessToken));
 
-        using var message = new HttpRequestMessage(HttpMethod.Get, BuildUri("mfa/authenticators"));
+        using var message = new HttpRequestMessage(HttpMethod.Get, await BuildUriAsync("mfa/authenticators", cancellationToken).ConfigureAwait(false));
         message.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
 
         return await SendAsync<IList<Authenticator>>(message, cancellationToken).ConfigureAwait(false);
@@ -207,7 +207,7 @@ public class AuthenticationApiClient : IAuthenticationApiClient
     {
         if (request == null) throw new ArgumentNullException(nameof(request));
 
-        using var message = new HttpRequestMessage(HttpMethod.Delete, BuildUri($"mfa/authenticators/{Uri.EscapeDataString(request.AuthenticatorId)}"));
+        using var message = new HttpRequestMessage(HttpMethod.Delete, await BuildUriAsync($"mfa/authenticators/{Uri.EscapeDataString(request.AuthenticatorId)}", cancellationToken).ConfigureAwait(false));
         message.Headers.Authorization = new AuthenticationHeaderValue("Bearer", request.AccessToken);
 
         using var response = await _httpClient.SendAsync(message, cancellationToken).ConfigureAwait(false);
@@ -227,7 +227,7 @@ public class AuthenticationApiClient : IAuthenticationApiClient
     private async Task<T> PostFormAsync<T>(string path, Dictionary<string, string> body, CancellationToken cancellationToken)
     {
         var content = new FormUrlEncodedContent(body.Select(p => new KeyValuePair<string?, string?>(p.Key, p.Value)));
-        using var message = new HttpRequestMessage(HttpMethod.Post, BuildUri(path)) { Content = content };
+        using var message = new HttpRequestMessage(HttpMethod.Post, await BuildUriAsync(path, cancellationToken).ConfigureAwait(false)) { Content = content };
         return await SendAsync<T>(message, cancellationToken).ConfigureAwait(false);
     }
 
@@ -249,25 +249,37 @@ public class AuthenticationApiClient : IAuthenticationApiClient
         }
     }
 
-    private Uri BuildUri(string path)
+    private async Task<Uri> BuildUriAsync(string path, CancellationToken cancellationToken)
     {
-        if (_options.UseMtls && _mtlsEndpointResolver != null &&
-            (path == "oauth/token" || path == "mfa/challenge"))
+        // Only the two client-authenticated paths route through the mTLS alias; the bearer-token paths
+        // (mfa/associate, mfa/authenticators) always use the standard host.
+        if (_options.UseMtls && (path == "oauth/token" || path == "mfa/challenge"))
         {
-            return new Uri($"https://{ResolveMtlsHost()}/{path}");
+            // A missing resolver means mTLS was enabled without the services WithMtls registers. Fail
+            // loudly rather than route a certificate-less request to the standard host, which the edge
+            // would reject as invalid_client.
+            if (_mtlsEndpointResolver == null)
+            {
+                throw new InvalidOperationException(
+                    "mTLS is enabled but no mTLS endpoint resolver is available. Ensure the SDK was configured with WithMtls.");
+            }
+
+            return new Uri($"https://{await ResolveMtlsHostAsync(cancellationToken).ConfigureAwait(false)}/{path}");
         }
 
         return new Uri($"https://{_domain}/{path}");
     }
 
-    // BuildUri is synchronous while discovery is async. The resolver caches per domain, so this
-    // blocks only on the first client-authenticated call for a cold domain; subsequent calls (and
-    // any call after TokenClient has already warmed the same domain) are a dictionary lookup.
-    private string ResolveMtlsHost()
+    // Resolution is awaited rather than blocked on: a synchronous .GetAwaiter().GetResult() here can
+    // deadlock under a captured SynchronizationContext (e.g. Blazor Server) and parks a threadpool
+    // thread on a cold-domain burst. The resolver caches per domain, so discovery is fetched only on
+    // the first client-authenticated call for a cold domain; subsequent calls (and any call after
+    // TokenClient has already warmed the same domain) are a dictionary lookup.
+    private async Task<string> ResolveMtlsHostAsync(CancellationToken cancellationToken)
     {
         if (_mtlsHost == null)
         {
-            var tokenEndpoint = _mtlsEndpointResolver!.ResolveTokenEndpointAsync(_domain, _httpClient).GetAwaiter().GetResult();
+            var tokenEndpoint = await _mtlsEndpointResolver!.ResolveTokenEndpointAsync(_domain, _httpClient, cancellationToken).ConfigureAwait(false);
             _mtlsHost = new Uri(tokenEndpoint).Host;
         }
 

--- a/src/Auth0.AspNetCore.Authentication/AuthenticationBuilderExtensions.cs
+++ b/src/Auth0.AspNetCore.Authentication/AuthenticationBuilderExtensions.cs
@@ -121,6 +121,11 @@ namespace Auth0.AspNetCore.Authentication
 
         private static void ValidateOptions(Auth0WebAppOptions auth0Options)
         {
+            if (auth0Options.UseMtls)
+            {
+                return;
+            }
+
             if (CodeResponseTypes.Contains(auth0Options.ResponseType!))
             {
                 if (string.IsNullOrWhiteSpace(auth0Options.ClientSecret) && auth0Options.ClientAssertionSecurityKey == null)
@@ -298,7 +303,10 @@ namespace Auth0.AspNetCore.Authentication
 
         private static async Task<AccessTokenResponse?> RefreshTokens(HttpContext httpContext, Auth0WebAppOptions options, string refreshToken, HttpClient httpClient)
         {
-            var tokenClient = new TokenClient(httpClient);
+            var tokenClient = new TokenClient(
+                httpClient,
+                httpContext.RequestServices.GetService<Mtls.Auth0MtlsEndpointResolver>(),
+                httpContext.RequestServices.GetService<Mtls.MtlsCnfInspector>());
 
             // Get the resolved domain from HttpContext if available (for multiple custom domains)
             var resolvedDomain = httpContext.GetResolvedDomain();

--- a/src/Auth0.AspNetCore.Authentication/HttpContextExtensions.cs
+++ b/src/Auth0.AspNetCore.Authentication/HttpContextExtensions.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Net;
 using System.Net.Http;
 using System.Text.Json;
@@ -324,16 +325,31 @@ namespace Auth0.AspNetCore.Authentication
                 context.RequestServices.GetService<Auth0.AspNetCore.Authentication.Mtls.MtlsCnfInspector>());
             var resolvedDomain = context.GetResolvedDomain();
 
-            var result = await tokenClient.ExchangeCustomToken(
-                options,
-                request.SubjectToken,
-                request.SubjectTokenType,
-                request.Audience,
-                request.Scope,
-                request.ActorToken,
-                request.ActorTokenType,
-                request.Organization,
-                resolvedDomain).ConfigureAwait(false);
+            TokenRefreshResult result;
+            try
+            {
+                result = await tokenClient.ExchangeCustomToken(
+                    options,
+                    request.SubjectToken,
+                    request.SubjectTokenType,
+                    request.Audience,
+                    request.Scope,
+                    request.ActorToken,
+                    request.ActorTokenType,
+                    request.Organization,
+                    resolvedDomain).ConfigureAwait(false);
+            }
+            catch (Exception ex) when (ex is HttpRequestException || ex is TaskCanceledException || ex is IOException)
+            {
+                throw new CustomTokenExchangeException(
+                    "The custom token exchange could not reach the token endpoint.", ex);
+            }
+            catch (InvalidOperationException ex)
+            {
+                // A mTLS configuration problem (a missing token_endpoint alias, or WithMtls not
+                // registered) surfaces here.
+                throw new CustomTokenExchangeException(ex.Message, ex);
+            }
 
             if (!result.IsSuccess)
             {
@@ -515,13 +531,21 @@ namespace Auth0.AspNetCore.Authentication
                     request.Organization,
                     resolvedDomain).ConfigureAwait(false);
             }
-            catch (Exception ex)
+            catch (Exception ex) when (ex is HttpRequestException || ex is TaskCanceledException || ex is IOException)
             {
                 // Keep a single failure protocol: a transport error reaching the token endpoint is
                 // reported the same way as a rejection by it, with the original exception preserved
                 // on InnerException.
                 throw new CustomTokenExchangeException(
                     "The session transfer token exchange could not reach the token endpoint.", ex);
+            }
+            catch (InvalidOperationException ex)
+            {
+                // A mTLS configuration problem (a missing token_endpoint alias, or WithMtls not
+                // registered) surfaces here. Wrap it in the documented CustomTokenExchangeException,
+                // keeping its actionable message rather than mislabeling a misconfiguration as a
+                // connectivity failure, so no raw exception escapes the public surface.
+                throw new CustomTokenExchangeException(ex.Message, ex);
             }
 
             if (!result.IsSuccess)
@@ -626,13 +650,23 @@ namespace Auth0.AspNetCore.Authentication
                 {
                     refreshResult = await tokenClient.Refresh(options, refreshToken!, resolvedDomain, scope: actorRefreshScope).ConfigureAwait(false);
                 }
-                catch (Exception ex)
+                catch (Exception ex) when (ex is HttpRequestException || ex is TaskCanceledException || ex is IOException)
                 {
-                    // Transport errors (HttpRequestException, TaskCanceledException) would otherwise
-                    // escape raw from a method documented to fail via CustomTokenExchangeException.
-                    // ActorUnavailable would be a lie here - the session is fine, the network was not.
+                    // Transport errors (HttpRequestException, TaskCanceledException, and the IOException
+                    // the OpenID Connect discovery retriever throws when mTLS endpoint resolution fails)
+                    // would otherwise escape raw from a method documented to fail via
+                    // CustomTokenExchangeException. ActorUnavailable would be a lie here - the session is
+                    // fine, the network was not.
                     throw new CustomTokenExchangeException(
                         "Failed to refresh the session id_token needed to source the actor token.", ex);
+                }
+                catch (InvalidOperationException ex)
+                {
+                    // A mTLS configuration problem (a missing token_endpoint alias, or WithMtls not
+                    // registered) surfaces here on the actor-refresh path. Wrap it in the documented
+                    // CustomTokenExchangeException, keeping its actionable message, so no raw
+                    // exception escapes the public surface.
+                    throw new CustomTokenExchangeException(ex.Message, ex);
                 }
 
                 // A step-up challenge is a recoverable case distinct from "no usable actor": collapsing

--- a/src/Auth0.AspNetCore.Authentication/HttpContextExtensions.cs
+++ b/src/Auth0.AspNetCore.Authentication/HttpContextExtensions.cs
@@ -125,7 +125,10 @@ namespace Auth0.AspNetCore.Authentication
             }
 
             var httpClient = options.Backchannel ?? context.RequestServices.GetRequiredService<IHttpClientFactory>().CreateClient();
-            var tokenClient = new TokenClient(httpClient);
+            var tokenClient = new TokenClient(
+                httpClient,
+                context.RequestServices.GetService<Auth0.AspNetCore.Authentication.Mtls.Auth0MtlsEndpointResolver>(),
+                context.RequestServices.GetService<Auth0.AspNetCore.Authentication.Mtls.MtlsCnfInspector>());
             var resolvedDomain = context.GetResolvedDomain();
 
             TokenRefreshResult result;
@@ -249,7 +252,10 @@ namespace Auth0.AspNetCore.Authentication
             }
 
             var httpClient = options.Backchannel ?? context.RequestServices.GetRequiredService<IHttpClientFactory>().CreateClient();
-            var tokenClient = new TokenClient(httpClient);
+            var tokenClient = new TokenClient(
+                httpClient,
+                context.RequestServices.GetService<Auth0.AspNetCore.Authentication.Mtls.Auth0MtlsEndpointResolver>(),
+                context.RequestServices.GetService<Auth0.AspNetCore.Authentication.Mtls.MtlsCnfInspector>());
             var resolvedDomain = context.GetResolvedDomain();
 
             TokenRefreshResult result;
@@ -312,7 +318,10 @@ namespace Auth0.AspNetCore.Authentication
             var options = context.RequestServices.GetRequiredService<IOptionsSnapshot<Auth0WebAppOptions>>().Get(scheme);
 
             var httpClient = options.Backchannel ?? context.RequestServices.GetRequiredService<IHttpClientFactory>().CreateClient();
-            var tokenClient = new TokenClient(httpClient);
+            var tokenClient = new TokenClient(
+                httpClient,
+                context.RequestServices.GetService<Auth0.AspNetCore.Authentication.Mtls.Auth0MtlsEndpointResolver>(),
+                context.RequestServices.GetService<Auth0.AspNetCore.Authentication.Mtls.MtlsCnfInspector>());
             var resolvedDomain = context.GetResolvedDomain();
 
             var result = await tokenClient.ExchangeCustomToken(
@@ -487,7 +496,10 @@ namespace Auth0.AspNetCore.Authentication
             var audience = $"urn:{audienceHost}:session_transfer";
 
             var httpClient = options.Backchannel ?? context.RequestServices.GetRequiredService<IHttpClientFactory>().CreateClient();
-            var tokenClient = new TokenClient(httpClient);
+            var tokenClient = new TokenClient(
+                httpClient,
+                context.RequestServices.GetService<Auth0.AspNetCore.Authentication.Mtls.Auth0MtlsEndpointResolver>(),
+                context.RequestServices.GetService<Auth0.AspNetCore.Authentication.Mtls.MtlsCnfInspector>());
 
             TokenRefreshResult result;
             try
@@ -601,7 +613,10 @@ namespace Auth0.AspNetCore.Authentication
             if (properties.Items.TryGetValue(".Token.refresh_token", out var refreshToken) && !string.IsNullOrWhiteSpace(refreshToken))
             {
                 var httpClient = options.Backchannel ?? context.RequestServices.GetRequiredService<IHttpClientFactory>().CreateClient();
-                var tokenClient = new TokenClient(httpClient);
+                var tokenClient = new TokenClient(
+                    httpClient,
+                    context.RequestServices.GetService<Auth0.AspNetCore.Authentication.Mtls.Auth0MtlsEndpointResolver>(),
+                    context.RequestServices.GetService<Auth0.AspNetCore.Authentication.Mtls.MtlsCnfInspector>());
                 var resolvedDomain = context.GetResolvedDomain();
 
                 const string actorRefreshScope = "openid";

--- a/src/Auth0.AspNetCore.Authentication/Mtls/Auth0MtlsConfigurationManager.cs
+++ b/src/Auth0.AspNetCore.Authentication/Mtls/Auth0MtlsConfigurationManager.cs
@@ -1,0 +1,50 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.IdentityModel.Protocols;
+using Microsoft.IdentityModel.Protocols.OpenIdConnect;
+
+namespace Auth0.AspNetCore.Authentication.Mtls
+{
+    /// <summary>
+    /// Decorates an OpenID Connect <see cref="IConfigurationManager{T}"/> so that, once mTLS is
+    /// enabled, Microsoft's <c>OpenIdConnectHandler</c> and the SDK's PAR handler redeem against the
+    /// <c>mtls_endpoint_aliases</c> hosts. Neither handler routes through SDK code that can substitute
+    /// a URL per request, so the aliases are applied by rewriting the discovered configuration's
+    /// <see cref="OpenIdConnectConfiguration.TokenEndpoint"/> and
+    /// <see cref="OpenIdConnectConfiguration.PushedAuthorizationRequestEndpoint"/>.
+    /// </summary>
+    /// <remarks>
+    /// Rewriting reads the alias from <c>AdditionalData</c> (which discovery never mutates), so
+    /// re-applying it to the same cached configuration object is idempotent.
+    /// </remarks>
+    internal sealed class Auth0MtlsConfigurationManager : IConfigurationManager<OpenIdConnectConfiguration>
+    {
+        private readonly IConfigurationManager<OpenIdConnectConfiguration> _inner;
+
+        public Auth0MtlsConfigurationManager(IConfigurationManager<OpenIdConnectConfiguration> inner)
+        {
+            _inner = inner;
+        }
+
+        public async Task<OpenIdConnectConfiguration> GetConfigurationAsync(CancellationToken cancel)
+        {
+            var configuration = await _inner.GetConfigurationAsync(cancel).ConfigureAwait(false);
+
+            var tokenAlias = MtlsEndpointAliases.TryGetAlias(configuration, "token_endpoint");
+            if (!string.IsNullOrEmpty(tokenAlias))
+            {
+                configuration.TokenEndpoint = tokenAlias;
+            }
+
+            var parAlias = MtlsEndpointAliases.TryGetAlias(configuration, "pushed_authorization_request_endpoint");
+            if (!string.IsNullOrEmpty(parAlias))
+            {
+                configuration.PushedAuthorizationRequestEndpoint = parAlias;
+            }
+
+            return configuration;
+        }
+
+        public void RequestRefresh() => _inner.RequestRefresh();
+    }
+}

--- a/src/Auth0.AspNetCore.Authentication/Mtls/Auth0MtlsConfigurationManager.cs
+++ b/src/Auth0.AspNetCore.Authentication/Mtls/Auth0MtlsConfigurationManager.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.IdentityModel.Protocols;
@@ -17,7 +18,7 @@ namespace Auth0.AspNetCore.Authentication.Mtls
     /// Rewriting reads the alias from <c>AdditionalData</c> (which discovery never mutates), so
     /// re-applying it to the same cached configuration object is idempotent.
     /// </remarks>
-    internal sealed class Auth0MtlsConfigurationManager : IConfigurationManager<OpenIdConnectConfiguration>
+    internal sealed class Auth0MtlsConfigurationManager : IConfigurationManager<OpenIdConnectConfiguration>, IDisposable
     {
         private readonly IConfigurationManager<OpenIdConnectConfiguration> _inner;
 
@@ -30,12 +31,15 @@ namespace Auth0.AspNetCore.Authentication.Mtls
         {
             var configuration = await _inner.GetConfigurationAsync(cancel).ConfigureAwait(false);
 
-            var tokenAlias = MtlsEndpointAliases.TryGetAlias(configuration, "token_endpoint");
-            if (!string.IsNullOrEmpty(tokenAlias))
-            {
-                configuration.TokenEndpoint = tokenAlias;
-            }
+            // token_endpoint is required: the code exchange cannot fall back to the standard host under
+            // mTLS (the edge only forwards the certificate on the mtls alias), so a missing alias must
+            // fail closed with the same actionable error the back-channel resolver raises — not silently
+            // leave the standard endpoint in place and defer to a downstream invalid_client.
+            configuration.TokenEndpoint = MtlsEndpointAliases.GetRequiredAlias(configuration, "token_endpoint");
 
+            // PAR is optional: this rewrite runs on every configuration fetch whether or not PAR is in
+            // use, so a tenant without a PAR alias is not a misconfiguration and must not throw here. The
+            // PAR handler's own resolver fails closed if PAR is actually attempted without an alias.
             var parAlias = MtlsEndpointAliases.TryGetAlias(configuration, "pushed_authorization_request_endpoint");
             if (!string.IsNullOrEmpty(parAlias))
             {
@@ -46,5 +50,7 @@ namespace Auth0.AspNetCore.Authentication.Mtls
         }
 
         public void RequestRefresh() => _inner.RequestRefresh();
+
+        public void Dispose() => (_inner as IDisposable)?.Dispose();
     }
 }

--- a/src/Auth0.AspNetCore.Authentication/Mtls/Auth0MtlsEndpointResolver.cs
+++ b/src/Auth0.AspNetCore.Authentication/Mtls/Auth0MtlsEndpointResolver.cs
@@ -23,10 +23,6 @@ namespace Auth0.AspNetCore.Authentication.Mtls
         public Task<string> ResolveTokenEndpointAsync(string domain, HttpClient httpClient, CancellationToken cancellationToken = default)
             => ResolveAsync(domain, "token_endpoint", httpClient, cancellationToken);
 
-        /// <summary>Resolves the aliased pushed authorization request (PAR) endpoint for <paramref name="domain"/>.</summary>
-        public Task<string> ResolvePushedAuthorizationRequestEndpointAsync(string domain, HttpClient httpClient, CancellationToken cancellationToken = default)
-            => ResolveAsync(domain, "pushed_authorization_request_endpoint", httpClient, cancellationToken);
-
         private async Task<string> ResolveAsync(string domain, string endpointName, HttpClient httpClient, CancellationToken cancellationToken)
         {
             var task = _cache.GetOrAdd(domain, d => OpenIdConnectConfigurationRetriever.GetAsync(

--- a/src/Auth0.AspNetCore.Authentication/Mtls/Auth0MtlsEndpointResolver.cs
+++ b/src/Auth0.AspNetCore.Authentication/Mtls/Auth0MtlsEndpointResolver.cs
@@ -1,5 +1,5 @@
-using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
@@ -39,20 +39,13 @@ namespace Auth0.AspNetCore.Authentication.Mtls
             }
             catch
             {
-                // Do not cache a failed discovery attempt: a transient failure must not poison the domain.
-                _cache.TryRemove(domain, out _);
+                // Do not cache a failed discovery attempt: a transient failure must not poison the
+                // domain.
+                _cache.TryRemove(new KeyValuePair<string, Task<OpenIdConnectConfiguration>>(domain, task));
                 throw;
             }
 
-            var alias = MtlsEndpointAliases.TryGetAlias(configuration, endpointName);
-            if (string.IsNullOrEmpty(alias))
-            {
-                throw new InvalidOperationException(
-                    $"mTLS is enabled but the authorization server discovery document does not advertise " +
-                    $"`mtls_endpoint_aliases.{endpointName}`. Ensure mTLS endpoint aliases are enabled on your Auth0 tenant.");
-            }
-
-            return alias!;
+            return MtlsEndpointAliases.GetRequiredAlias(configuration, endpointName);
         }
     }
 }

--- a/src/Auth0.AspNetCore.Authentication/Mtls/Auth0MtlsEndpointResolver.cs
+++ b/src/Auth0.AspNetCore.Authentication/Mtls/Auth0MtlsEndpointResolver.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Collections.Concurrent;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.IdentityModel.Protocols.OpenIdConnect;
+
+namespace Auth0.AspNetCore.Authentication.Mtls
+{
+    /// <summary>
+    /// Resolves the <c>mtls_endpoint_aliases</c> endpoints from an Auth0 tenant's discovery document.
+    /// Used by the back-channel paths that build their own request URIs (<see cref="TokenClient"/> and
+    /// <see cref="AuthenticationApi.AuthenticationApiClient"/>). Discovery is fetched once per domain
+    /// and cached, so <see cref="AuthenticationApi.AuthenticationApiClient"/> can resolve synchronously
+    /// after the first call without repeated network round-trips. Registered as a singleton.
+    /// </summary>
+    internal sealed class Auth0MtlsEndpointResolver
+    {
+        private readonly ConcurrentDictionary<string, Task<OpenIdConnectConfiguration>> _cache =
+            new ConcurrentDictionary<string, Task<OpenIdConnectConfiguration>>();
+
+        /// <summary>Resolves the aliased token endpoint for <paramref name="domain"/>.</summary>
+        public Task<string> ResolveTokenEndpointAsync(string domain, HttpClient httpClient, CancellationToken cancellationToken = default)
+            => ResolveAsync(domain, "token_endpoint", httpClient, cancellationToken);
+
+        /// <summary>Resolves the aliased pushed authorization request (PAR) endpoint for <paramref name="domain"/>.</summary>
+        public Task<string> ResolvePushedAuthorizationRequestEndpointAsync(string domain, HttpClient httpClient, CancellationToken cancellationToken = default)
+            => ResolveAsync(domain, "pushed_authorization_request_endpoint", httpClient, cancellationToken);
+
+        private async Task<string> ResolveAsync(string domain, string endpointName, HttpClient httpClient, CancellationToken cancellationToken)
+        {
+            var task = _cache.GetOrAdd(domain, d => OpenIdConnectConfigurationRetriever.GetAsync(
+                $"https://{d}/.well-known/openid-configuration", httpClient, cancellationToken));
+
+            OpenIdConnectConfiguration configuration;
+            try
+            {
+                configuration = await task.ConfigureAwait(false);
+            }
+            catch
+            {
+                // Do not cache a failed discovery attempt: a transient failure must not poison the domain.
+                _cache.TryRemove(domain, out _);
+                throw;
+            }
+
+            var alias = MtlsEndpointAliases.TryGetAlias(configuration, endpointName);
+            if (string.IsNullOrEmpty(alias))
+            {
+                throw new InvalidOperationException(
+                    $"mTLS is enabled but the authorization server discovery document does not advertise " +
+                    $"`mtls_endpoint_aliases.{endpointName}`. Ensure mTLS endpoint aliases are enabled on your Auth0 tenant.");
+            }
+
+            return alias!;
+        }
+    }
+}

--- a/src/Auth0.AspNetCore.Authentication/Mtls/CnfClaimReader.cs
+++ b/src/Auth0.AspNetCore.Authentication/Mtls/CnfClaimReader.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Text;
+using System.Text.Json;
+using Microsoft.IdentityModel.Tokens;
+
+namespace Auth0.AspNetCore.Authentication.Mtls
+{
+    /// <summary>
+    /// Best-effort reader for the <c>cnf.x5t#S256</c> certificate-thumbprint confirmation
+    /// claim in an access token's JWT payload. Performs no signature verification — the token comes
+    /// directly from the Auth0 token endpoint over the backchannel TLS connection.
+    /// </summary>
+    internal static class CnfClaimReader
+    {
+        /// <summary>
+        /// Reports whether an access token is certificate-bound.
+        /// <list type="bullet">
+        /// <item><c>true</c>: the token is a JWT carrying a non-empty <c>cnf.x5t#S256</c>.</item>
+        /// <item><c>false</c>: the token is a JWT with no <c>cnf.x5t#S256</c> (not sender-constrained).</item>
+        /// <item><c>null</c>: the token is not an inspectable JWT (opaque, empty, or unparseable);
+        /// its binding cannot be determined and callers should stay silent.</item>
+        /// </list>
+        /// </summary>
+        public static bool? HasThumbprintConfirmation(string? accessToken)
+        {
+            if (string.IsNullOrEmpty(accessToken))
+            {
+                return null;
+            }
+
+            var parts = accessToken.Split('.');
+            if (parts.Length != 3)
+            {
+                return null;
+            }
+
+            try
+            {
+                var payloadJson = Encoding.UTF8.GetString(Base64UrlEncoder.DecodeBytes(parts[1]));
+                using var document = JsonDocument.Parse(payloadJson);
+
+                if (document.RootElement.TryGetProperty("cnf", out var cnf) &&
+                    cnf.ValueKind == JsonValueKind.Object &&
+                    cnf.TryGetProperty("x5t#S256", out var thumbprint) &&
+                    thumbprint.ValueKind == JsonValueKind.String &&
+                    !string.IsNullOrEmpty(thumbprint.GetString()))
+                {
+                    return true;
+                }
+
+                return false;
+            }
+            catch (Exception)
+            {
+                // Best-effort: a decode/parse hiccup must not fail an exchange the endpoint accepted.
+                return null;
+            }
+        }
+    }
+}

--- a/src/Auth0.AspNetCore.Authentication/Mtls/MtlsCnfInspector.cs
+++ b/src/Auth0.AspNetCore.Authentication/Mtls/MtlsCnfInspector.cs
@@ -1,0 +1,45 @@
+using System.Collections.Concurrent;
+using Microsoft.Extensions.Logging;
+
+namespace Auth0.AspNetCore.Authentication.Mtls
+{
+    /// <summary>
+    /// Emits a one-time warning per client when mTLS is enabled but an access token issued on a
+    /// <c>cnf</c>-bearing grant (authorization_code, refresh_token) is not certificate-bound.
+    /// Registered as a singleton so the gate survives refresh loops for the lifetime of the app.
+    /// </summary>
+    internal sealed class MtlsCnfInspector
+    {
+        internal const string Warning =
+            "mTLS is enabled but the access token has no `cnf.x5t#S256` claim; the token is not sender-constrained. " +
+            "Configure Token Sender-Constraining on the API.";
+
+        private readonly ILogger _logger;
+        private readonly ConcurrentDictionary<string, byte> _warned = new ConcurrentDictionary<string, byte>();
+
+        public MtlsCnfInspector(ILoggerFactory loggerFactory)
+        {
+            _logger = loggerFactory.CreateLogger("Auth0");
+        }
+
+        /// <summary>
+        /// Warns (once per <paramref name="clientId"/>) when <paramref name="accessToken"/> is a JWT
+        /// with no <c>cnf.x5t#S256</c>. Silent when the claim is present or the token is not an
+        /// inspectable JWT.
+        /// </summary>
+        public void Inspect(string clientId, string? accessToken)
+        {
+            // Only a JWT that is provably missing the claim warrants a warning; present (true) is fine,
+            // and opaque/unparseable (null) is a different problem the SDK cannot diagnose here.
+            if (CnfClaimReader.HasThumbprintConfirmation(accessToken) != false)
+            {
+                return;
+            }
+
+            if (_warned.TryAdd(clientId, 0))
+            {
+                _logger.LogWarning(Warning);
+            }
+        }
+    }
+}

--- a/src/Auth0.AspNetCore.Authentication/Mtls/MtlsEndpointAliases.cs
+++ b/src/Auth0.AspNetCore.Authentication/Mtls/MtlsEndpointAliases.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Text.Json;
 using Microsoft.IdentityModel.Protocols.OpenIdConnect;
 
@@ -40,6 +41,26 @@ namespace Auth0.AspNetCore.Authentication.Mtls
             }
 
             return null;
+        }
+
+        /// <summary>
+        /// Returns the aliased URL for <paramref name="endpointName"/>, or throws
+        /// <see cref="InvalidOperationException"/> with an actionable message when the alias is absent.
+        /// This is the fail-closed counterpart to <see cref="TryGetAlias"/>: callers that cannot safely
+        /// fall back to the standard (non-mTLS) endpoint use this so the same misconfiguration surfaces
+        /// the same clear error everywhere, rather than a downstream <c>invalid_client</c>.
+        /// </summary>
+        public static string GetRequiredAlias(OpenIdConnectConfiguration? configuration, string endpointName)
+        {
+            var alias = TryGetAlias(configuration, endpointName);
+            if (string.IsNullOrEmpty(alias))
+            {
+                throw new InvalidOperationException(
+                    $"mTLS is enabled but the authorization server discovery document does not advertise " +
+                    $"`mtls_endpoint_aliases.{endpointName}`. Ensure mTLS endpoint aliases are enabled on your Auth0 tenant.");
+            }
+
+            return alias!;
         }
     }
 }

--- a/src/Auth0.AspNetCore.Authentication/Mtls/MtlsEndpointAliases.cs
+++ b/src/Auth0.AspNetCore.Authentication/Mtls/MtlsEndpointAliases.cs
@@ -1,0 +1,45 @@
+using System.Text.Json;
+using Microsoft.IdentityModel.Protocols.OpenIdConnect;
+
+namespace Auth0.AspNetCore.Authentication.Mtls
+{
+    /// <summary>
+    /// Reads a single endpoint out of the <c>mtls_endpoint_aliases</c> object in an
+    /// <see cref="OpenIdConnectConfiguration"/>. Microsoft's configuration model does not deserialize
+    /// <c>mtls_endpoint_aliases</c> into a typed property, so it arrives in
+    /// <see cref="OpenIdConnectConfiguration.AdditionalData"/> as a nested
+    /// <see cref="JsonElement"/> object that must be unwrapped rather than cast.
+    /// </summary>
+    internal static class MtlsEndpointAliases
+    {
+        internal const string AliasesKey = "mtls_endpoint_aliases";
+
+        /// <summary>
+        /// Returns the aliased URL for <paramref name="endpointName"/> (for example
+        /// <c>token_endpoint</c>), or <c>null</c> when <c>mtls_endpoint_aliases</c> is absent,
+        /// is not a JSON object, or does not contain a string value for that endpoint.
+        /// </summary>
+        public static string? TryGetAlias(OpenIdConnectConfiguration? configuration, string endpointName)
+        {
+            if (configuration?.AdditionalData == null)
+            {
+                return null;
+            }
+
+            if (!configuration.AdditionalData.TryGetValue(AliasesKey, out var raw))
+            {
+                return null;
+            }
+
+            if (raw is JsonElement aliases &&
+                aliases.ValueKind == JsonValueKind.Object &&
+                aliases.TryGetProperty(endpointName, out var endpoint) &&
+                endpoint.ValueKind == JsonValueKind.String)
+            {
+                return endpoint.GetString();
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/Auth0.AspNetCore.Authentication/Mtls/MtlsOpenIdConnectPostConfigureOptions.cs
+++ b/src/Auth0.AspNetCore.Authentication/Mtls/MtlsOpenIdConnectPostConfigureOptions.cs
@@ -1,0 +1,42 @@
+using Microsoft.AspNetCore.Authentication.OpenIdConnect;
+using Microsoft.Extensions.Options;
+
+namespace Auth0.AspNetCore.Authentication.Mtls
+{
+    /// <summary>
+    /// Wraps <see cref="OpenIdConnectOptions.ConfigurationManager"/> with
+    /// <see cref="Auth0MtlsConfigurationManager"/> when mTLS is enabled for the scheme. Registered via
+    /// <c>TryAddEnumerable</c> after any other post-configure that replaces the configuration manager
+    /// (for example multiple custom domains), so it wraps the final manager rather than being
+    /// overwritten by it.
+    /// </summary>
+    internal sealed class MtlsOpenIdConnectPostConfigureOptions : IPostConfigureOptions<OpenIdConnectOptions>
+    {
+        private readonly IOptionsMonitor<Auth0WebAppOptions> _auth0OptionsMonitor;
+
+        public MtlsOpenIdConnectPostConfigureOptions(IOptionsMonitor<Auth0WebAppOptions> auth0OptionsMonitor)
+        {
+            _auth0OptionsMonitor = auth0OptionsMonitor;
+        }
+
+        public void PostConfigure(string? name, OpenIdConnectOptions options)
+        {
+            if (string.IsNullOrEmpty(name))
+            {
+                return;
+            }
+
+            if (!_auth0OptionsMonitor.Get(name).UseMtls)
+            {
+                return;
+            }
+
+            if (options.ConfigurationManager == null)
+            {
+                return;
+            }
+
+            options.ConfigurationManager = new Auth0MtlsConfigurationManager(options.ConfigurationManager);
+        }
+    }
+}

--- a/src/Auth0.AspNetCore.Authentication/OpenIdConnectEventsFactory.cs
+++ b/src/Auth0.AspNetCore.Authentication/OpenIdConnectEventsFactory.cs
@@ -211,6 +211,13 @@ namespace Auth0.AspNetCore.Authentication
                     }
                 }
 
+                if (auth0Options.UseMtls)
+                {
+                    var cnfInspector = context.HttpContext.RequestServices
+                        .GetService<Mtls.MtlsCnfInspector>();
+                    cnfInspector?.Inspect(auth0Options.ClientId, context.TokenEndpointResponse?.AccessToken);
+                }
+
                 return Task.CompletedTask;
             };
         }

--- a/src/Auth0.AspNetCore.Authentication/PushedAuthorizationRequest/PushedAuthorizationRequestHandler.cs
+++ b/src/Auth0.AspNetCore.Authentication/PushedAuthorizationRequest/PushedAuthorizationRequestHandler.cs
@@ -3,6 +3,7 @@ using System.Net.Http;
 using System.Net.Http.Json;
 using System.Threading.Tasks;
 using Auth0.AspNetCore.Authentication.Exceptions;
+using Auth0.AspNetCore.Authentication.Mtls;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 using Microsoft.Extensions.DependencyInjection;
@@ -26,37 +27,47 @@ internal static class PushedAuthorizationRequestHandler
         var oidcConfiguration =
             await oidcOptions.ConfigurationManager?.GetConfigurationAsync(default)!;
 
-        // Trying to get the PAR endpoint from the property first, fallback to AdditionalData for older configs.
-        string? parEndpoint = null;
-        if (oidcConfiguration != null)
+        var auth0Options = context.HttpContext.RequestServices
+            .GetRequiredService<IOptionsSnapshot<Auth0WebAppOptions>>()
+            .Get(context.Scheme.Name);
+
+        string? parEndpoint;
+        if (auth0Options.UseMtls)
         {
+            // Under mTLS the PAR request carries the client certificate and no client_secret, so it must
+            // go to the mtls alias host: the standard host does not perform client-certificate
+            // authentication and would reject the request as invalid_client. Resolve the required alias
+            // and fail closed with the same actionable error the token path raises, rather than silently
+            // falling back to the standard endpoint.
+            parEndpoint = MtlsEndpointAliases.GetRequiredAlias(
+                oidcConfiguration, "pushed_authorization_request_endpoint");
+        }
+        else
+        {
+            // Trying to get the PAR endpoint from the property first, fallback to AdditionalData for older configs.
             parEndpoint = oidcConfiguration?.PushedAuthorizationRequestEndpoint;
             if (string.IsNullOrEmpty(parEndpoint))
             {
                 object? rawParEndpoint = string.Empty;
-                oidcConfiguration.AdditionalData?.TryGetValue("pushed_authorization_request_endpoint", out rawParEndpoint);
+                oidcConfiguration?.AdditionalData?.TryGetValue("pushed_authorization_request_endpoint", out rawParEndpoint);
                 parEndpoint = rawParEndpoint as string;
+            }
+
+            // If PAR was enabled in the options, but no `pushed_authorization_request_endpoint` value is found
+            // in the OIDC configuration, we will throw an error.
+            if (string.IsNullOrEmpty(parEndpoint))
+            {
+                throw new InvalidOperationException(
+                    "Trying to use pushed authorization, but no value for 'pushed_authorization_request_endpoint' was found in the open id configuration.");
             }
         }
 
-        // If PAR was enabled in the options, but no `pushed_authorization_request_endpoint` value is found
-        // in the OIDC configuration, we will throw an error.
-        if (string.IsNullOrEmpty(parEndpoint))
-        {
-            throw new InvalidOperationException(
-                "Trying to use pushed authorization, but no value for 'pushed_authorization_request_endpoint' was found in the open id configuration.");
-        }
-        
         var message = context.ProtocolMessage;
         var properties = context.Properties;
         var clientId = message.ClientId;
 
         // As the client_secret isn't sent through the front-channel, we add it for the back-channel
         // request — unless mTLS is enabled, where the client certificate is the sole credential.
-        var auth0Options = context.HttpContext.RequestServices
-            .GetRequiredService<IOptionsSnapshot<Auth0WebAppOptions>>()
-            .Get(context.Scheme.Name);
-
         if (!auth0Options.UseMtls)
         {
             message.SetParameter("client_secret", oidcOptions.ClientSecret);

--- a/src/Auth0.AspNetCore.Authentication/PushedAuthorizationRequest/PushedAuthorizationRequestHandler.cs
+++ b/src/Auth0.AspNetCore.Authentication/PushedAuthorizationRequest/PushedAuthorizationRequestHandler.cs
@@ -5,6 +5,8 @@ using System.Threading.Tasks;
 using Auth0.AspNetCore.Authentication.Exceptions;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using Microsoft.IdentityModel.Protocols.OpenIdConnect;
 
 namespace Auth0.AspNetCore.Authentication.PushedAuthorizationRequest;
@@ -48,10 +50,17 @@ internal static class PushedAuthorizationRequestHandler
         var message = context.ProtocolMessage;
         var properties = context.Properties;
         var clientId = message.ClientId;
-        
-        // As the client_secret isn't send through the front-channel,
-        // we need to ensure it is added when sending the request through the back-channel.
-        message.SetParameter("client_secret", oidcOptions.ClientSecret);
+
+        // As the client_secret isn't sent through the front-channel, we add it for the back-channel
+        // request — unless mTLS is enabled, where the client certificate is the sole credential.
+        var auth0Options = context.HttpContext.RequestServices
+            .GetRequiredService<IOptionsSnapshot<Auth0WebAppOptions>>()
+            .Get(context.Scheme.Name);
+
+        if (!auth0Options.UseMtls)
+        {
+            message.SetParameter("client_secret", oidcOptions.ClientSecret);
+        }
 
         SetStateParameter(message, properties, oidcOptions);
 

--- a/src/Auth0.AspNetCore.Authentication/TokenClient.cs
+++ b/src/Auth0.AspNetCore.Authentication/TokenClient.cs
@@ -165,9 +165,24 @@ namespace Auth0.AspNetCore.Authentication
         {
             var requestContent = new FormUrlEncodedContent(body.Select(p => new KeyValuePair<string?, string?>(p.Key, p.Value ?? "")));
 
-            var tokenEndpoint = options.UseMtls && _mtlsEndpointResolver != null
-                ? await _mtlsEndpointResolver.ResolveTokenEndpointAsync(tokenEndpointDomain, _httpClient).ConfigureAwait(false)
-                : $"https://{tokenEndpointDomain}/oauth/token";
+            string tokenEndpoint;
+            if (options.UseMtls)
+            {
+                // A missing resolver here means mTLS was enabled without the services WithMtls registers.
+                // Fail loudly rather than fall back to the standard endpoint, which would strip the
+                // certificate routing and surface as a confusing invalid_client from the token endpoint.
+                if (_mtlsEndpointResolver == null)
+                {
+                    throw new InvalidOperationException(
+                        "mTLS is enabled but no mTLS endpoint resolver is available. Ensure the SDK was configured with WithMtls.");
+                }
+
+                tokenEndpoint = await _mtlsEndpointResolver.ResolveTokenEndpointAsync(tokenEndpointDomain, _httpClient).ConfigureAwait(false);
+            }
+            else
+            {
+                tokenEndpoint = $"https://{tokenEndpointDomain}/oauth/token";
+            }
 
             using (var request = new HttpRequestMessage(HttpMethod.Post, tokenEndpoint) { Content = requestContent })
             {

--- a/src/Auth0.AspNetCore.Authentication/TokenClient.cs
+++ b/src/Auth0.AspNetCore.Authentication/TokenClient.cs
@@ -1,5 +1,6 @@
 ﻿using Auth0.AspNetCore.Authentication;
 using Auth0.AspNetCore.Authentication.AuthenticationApi.Models;
+using Auth0.AspNetCore.Authentication.Mtls;
 using Microsoft.IdentityModel.Tokens;
 using System;
 using System.Collections.Generic;
@@ -13,14 +14,18 @@ namespace Auth0.AspNetCore.Authentication
     internal class TokenClient
     {
         private readonly HttpClient _httpClient;
+        private readonly Auth0MtlsEndpointResolver? _mtlsEndpointResolver;
+        private readonly MtlsCnfInspector? _cnfInspector;
         private readonly JsonSerializerOptions _jsonSerializerOptions = new JsonSerializerOptions()
         {
             DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull
         };
 
-        public TokenClient(HttpClient httpClient)
+        public TokenClient(HttpClient httpClient, Auth0MtlsEndpointResolver? mtlsEndpointResolver = null, MtlsCnfInspector? cnfInspector = null)
         {
             _httpClient = httpClient;
+            _mtlsEndpointResolver = mtlsEndpointResolver;
+            _cnfInspector = cnfInspector;
         }
 
         public async Task<TokenRefreshResult> Refresh(Auth0WebAppOptions options, string refreshToken, string? domain = null, string? audience = null, string? scope = null)
@@ -53,7 +58,16 @@ namespace Auth0.AspNetCore.Authentication
 
             ApplyClientAuthentication(options, body, tokenEndpointDomain);
 
-            return await Send(body, tokenEndpointDomain).ConfigureAwait(false);
+            var result = await Send(options, body, tokenEndpointDomain).ConfigureAwait(false);
+
+            // cnf check runs only for the refresh_token grant (this method), which covers both the
+            // cookie-validation refresh and GetAccessTokenAsync (MRRT). Other grants are not cnf-bound.
+            if (result.IsSuccess && options.UseMtls)
+            {
+                _cnfInspector?.Inspect(options.ClientId, result.Response?.AccessToken);
+            }
+
+            return result;
         }
 
         public async Task<TokenRefreshResult> ExchangeRefreshTokenForConnectionToken(
@@ -89,7 +103,7 @@ namespace Auth0.AspNetCore.Authentication
 
             ApplyClientAuthentication(options, body, tokenEndpointDomain);
 
-            return await Send(body, tokenEndpointDomain).ConfigureAwait(false);
+            return await Send(options, body, tokenEndpointDomain).ConfigureAwait(false);
         }
 
         public async Task<TokenRefreshResult> ExchangeCustomToken(
@@ -144,14 +158,18 @@ namespace Auth0.AspNetCore.Authentication
 
             ApplyClientAuthentication(options, body, tokenEndpointDomain);
 
-            return await Send(body, tokenEndpointDomain).ConfigureAwait(false);
+            return await Send(options, body, tokenEndpointDomain).ConfigureAwait(false);
         }
 
-        private async Task<TokenRefreshResult> Send(Dictionary<string, string> body, string tokenEndpointDomain)
+        private async Task<TokenRefreshResult> Send(Auth0WebAppOptions options, Dictionary<string, string> body, string tokenEndpointDomain)
         {
             var requestContent = new FormUrlEncodedContent(body.Select(p => new KeyValuePair<string?, string?>(p.Key, p.Value ?? "")));
 
-            using (var request = new HttpRequestMessage(HttpMethod.Post, $"https://{tokenEndpointDomain}/oauth/token") { Content = requestContent })
+            var tokenEndpoint = options.UseMtls && _mtlsEndpointResolver != null
+                ? await _mtlsEndpointResolver.ResolveTokenEndpointAsync(tokenEndpointDomain, _httpClient).ConfigureAwait(false)
+                : $"https://{tokenEndpointDomain}/oauth/token";
+
+            using (var request = new HttpRequestMessage(HttpMethod.Post, tokenEndpoint) { Content = requestContent })
             {
                 using (var response = await _httpClient.SendAsync(request).ConfigureAwait(false))
                 {
@@ -249,6 +267,12 @@ namespace Auth0.AspNetCore.Authentication
 
         private void ApplyClientAuthentication(Auth0WebAppOptions options, Dictionary<string, string> body, string domain)
         {
+            // Under mTLS the client certificate is the sole credential; never send a secret or assertion.
+            if (options.UseMtls)
+            {
+                return;
+            }
+
             if (options.ClientAssertionSecurityKey != null)
             {
                 body.Add("client_assertion", new JwtTokenFactory(options.ClientAssertionSecurityKey, options.ClientAssertionSecurityKeyAlgorithm ?? SecurityAlgorithms.RsaSha256)
@@ -257,7 +281,7 @@ namespace Auth0.AspNetCore.Authentication
 
                 body.Add("client_assertion_type", "urn:ietf:params:oauth:client-assertion-type:jwt-bearer");
             }
-            else
+            else if (!string.IsNullOrEmpty(options.ClientSecret))
             {
                 body.Add("client_secret", options.ClientSecret!);
             }

--- a/tests/Auth0.AspNetCore.Authentication.IntegrationTests/Auth0.AspNetCore.Authentication.IntegrationTests.csproj
+++ b/tests/Auth0.AspNetCore.Authentication.IntegrationTests/Auth0.AspNetCore.Authentication.IntegrationTests.csproj
@@ -12,6 +12,7 @@
     <EmbeddedResource Include="wellknownconfig_without_par.json" />
     <EmbeddedResource Include="wellknownconfig_with_mtls.json" />
     <EmbeddedResource Include="wellknownconfig_with_mtls_no_aliases.json" />
+    <EmbeddedResource Include="wellknownconfig_with_mtls_token_only.json" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Auth0.AspNetCore.Authentication.IntegrationTests/Auth0.AspNetCore.Authentication.IntegrationTests.csproj
+++ b/tests/Auth0.AspNetCore.Authentication.IntegrationTests/Auth0.AspNetCore.Authentication.IntegrationTests.csproj
@@ -13,6 +13,7 @@
     <EmbeddedResource Include="wellknownconfig_with_mtls.json" />
     <EmbeddedResource Include="wellknownconfig_with_mtls_no_aliases.json" />
     <EmbeddedResource Include="wellknownconfig_with_mtls_token_only.json" />
+    <EmbeddedResource Include="wellknownconfig_with_mtls_token_alias_std_par.json" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Auth0.AspNetCore.Authentication.IntegrationTests/Auth0.AspNetCore.Authentication.IntegrationTests.csproj
+++ b/tests/Auth0.AspNetCore.Authentication.IntegrationTests/Auth0.AspNetCore.Authentication.IntegrationTests.csproj
@@ -10,6 +10,8 @@
     <EmbeddedResource Include="wellknownconfig.json" />
     <EmbeddedResource Include="wellknownconfig_with_par.json" />
     <EmbeddedResource Include="wellknownconfig_without_par.json" />
+    <EmbeddedResource Include="wellknownconfig_with_mtls.json" />
+    <EmbeddedResource Include="wellknownconfig_with_mtls_no_aliases.json" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Auth0.AspNetCore.Authentication.IntegrationTests/Builders/OidcMockBuilder.cs
+++ b/tests/Auth0.AspNetCore.Authentication.IntegrationTests/Builders/OidcMockBuilder.cs
@@ -62,7 +62,7 @@ namespace Auth0.AspNetCore.Authentication.IntegrationTests.Builders
         /// <param name="idTokenFunc">Func that, when called, returns the ID Token to be used in thhe response.</param>
         /// <param name="matcher">Custom matcher Func to only match specific requests.</param>
         /// <returns></returns>
-        public OidcMockBuilder MockToken(Func<string> idTokenFunc, Func<HttpRequestMessage, bool> matcher = null, int expiresIn = 70, bool includeAccessToken = true, HttpStatusCode statusCode = HttpStatusCode.OK, string refreshToken = "456")
+        public OidcMockBuilder MockToken(Func<string> idTokenFunc, Func<HttpRequestMessage, bool> matcher = null, int expiresIn = 70, bool includeAccessToken = true, HttpStatusCode statusCode = HttpStatusCode.OK, string refreshToken = "456", string accessToken = "123")
         {
             _mockHandler
               .Protected()
@@ -74,7 +74,7 @@ namespace Auth0.AspNetCore.Authentication.IntegrationTests.Builders
               .ReturnsAsync(() => new HttpResponseMessage()
               {
                   StatusCode = statusCode,
-                  Content = new StringContent(BuildTokenResponse(idTokenFunc(), expiresIn, includeAccessToken, refreshToken)),
+                  Content = new StringContent(BuildTokenResponse(idTokenFunc(), expiresIn, includeAccessToken, refreshToken, accessToken)),
               })
               .Verifiable();
 
@@ -132,7 +132,7 @@ namespace Auth0.AspNetCore.Authentication.IntegrationTests.Builders
             }
         }
 
-        private string BuildTokenResponse(string idToken, int expiresIn, bool includeAccessToken, string refreshToken)
+        private string BuildTokenResponse(string idToken, int expiresIn, bool includeAccessToken, string refreshToken, string accessToken = "123")
         {
             var tokenContents = new Dictionary<string, object>
             {
@@ -141,7 +141,7 @@ namespace Auth0.AspNetCore.Authentication.IntegrationTests.Builders
             };
             if (includeAccessToken)
             {
-                tokenContents["access_token"] = "123";
+                tokenContents["access_token"] = accessToken;
             }
             if (!string.IsNullOrEmpty(refreshToken))
             {

--- a/tests/Auth0.AspNetCore.Authentication.IntegrationTests/Extensions/HttpRequestMessageExtensions.cs
+++ b/tests/Auth0.AspNetCore.Authentication.IntegrationTests/Extensions/HttpRequestMessageExtensions.cs
@@ -50,6 +50,16 @@ namespace Auth0.AspNetCore.Authentication.IntegrationTests.Extensions
         }
 
         /// <summary>
+        /// Indicate whether or not the HttpRequestMessage points to `mfa/challenge`.
+        /// </summary>
+        /// <param name="me">The HttpRequestMessage to inspect.</param>
+        /// <returns>True if the request points to `mfa/challenge`, false if not.</returns>
+        public static bool IsMfaChallengeEndPoint(this HttpRequestMessage me)
+        {
+            return me.RequestUri.AbsolutePath.Contains("mfa/challenge");
+        }
+
+        /// <summary>
         /// Indicate whether or not the HttpRequestMessage countains the `Auth0-Client` header.
         /// </summary>
         /// <param name="me">The HttpRequestMessage to inspect.</param>

--- a/tests/Auth0.AspNetCore.Authentication.IntegrationTests/HttpContextExtensionsTests.cs
+++ b/tests/Auth0.AspNetCore.Authentication.IntegrationTests/HttpContextExtensionsTests.cs
@@ -1001,6 +1001,71 @@ namespace Auth0.AspNetCore.Authentication.IntegrationTests
             assertion.Which.ErrorDescription.Should().Be("bad profile");
         }
 
+        // A mTLS configuration error (here UseMtls is on but no endpoint resolver is registered, i.e.
+        // WithMtls was not used) surfaces from the token client as an InvalidOperationException. The
+        // public method must not leak it raw: it is wrapped in the documented CustomTokenExchangeException
+        // with the actionable message preserved and the original on InnerException, and it is neither
+        // mislabeled as a connectivity failure nor reported as a token-endpoint rejection.
+        [Fact]
+        public async Task CustomTokenExchangeAsync_WrapsMtlsConfigurationError_AsCustomTokenExchangeException()
+        {
+            var handler = new Mock<HttpMessageHandler>();
+            handler
+                .Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>())
+                .ReturnsAsync(new HttpResponseMessage { StatusCode = HttpStatusCode.OK });
+
+            var context = BuildContext(handler.Object, new AuthenticationProperties(), out _,
+                configureWebApp: o => o.UseMtls = true);
+
+            var act = async () => await context.CustomTokenExchangeAsync(new CustomTokenExchangeRequest
+            {
+                SubjectToken = "ext-token",
+                SubjectTokenType = "urn:acme:legacy-token"
+            });
+
+            var assertion = await act.Should().ThrowAsync<CustomTokenExchangeException>();
+            assertion.Which.Message.Should().Contain("mTLS is enabled but no mTLS endpoint resolver is available");
+            assertion.Which.InnerException.Should().BeOfType<InvalidOperationException>();
+            // The misconfiguration is detected before any network call goes out.
+            handler.Protected().Verify("SendAsync", Times.Never(),
+                ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>());
+        }
+
+        // Under mTLS the token endpoint is resolved from the OpenID Connect discovery document. A
+        // transient discovery failure surfaces from Microsoft.IdentityModel's document retriever as an
+        // IOException (IDX20804/IDX20807), not an HttpRequestException. The public method must still
+        // wrap it in the documented CustomTokenExchangeException rather than letting the IOException
+        // escape raw to the caller.
+        [Fact]
+        public async Task CustomTokenExchangeAsync_WrapsMtlsDiscoveryFailure_AsCustomTokenExchangeException()
+        {
+            var handler = new Mock<HttpMessageHandler>();
+            handler
+                .Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>())
+                .ReturnsAsync(new HttpResponseMessage { StatusCode = HttpStatusCode.InternalServerError });
+
+            var context = BuildContext(handler.Object, new AuthenticationProperties(), out _,
+                configureWebApp: o => o.UseMtls = true,
+                configureServices: s => s.AddSingleton<Auth0.AspNetCore.Authentication.Mtls.Auth0MtlsEndpointResolver>());
+
+            var act = async () => await context.CustomTokenExchangeAsync(new CustomTokenExchangeRequest
+            {
+                SubjectToken = "ext-token",
+                SubjectTokenType = "urn:acme:legacy-token"
+            });
+
+            var assertion = await act.Should().ThrowAsync<CustomTokenExchangeException>();
+            assertion.Which.InnerException.Should().BeOfType<System.IO.IOException>();
+        }
+
         [Fact]
         public async Task CustomTokenExchangeAsync_OnInvalidRequest_ThrowsBeforeNetworkCall()
         {
@@ -1176,7 +1241,9 @@ namespace Auth0.AspNetCore.Authentication.IntegrationTests
             AuthenticationProperties properties,
             out Mock<IAuthenticationService> authService,
             IMfaTokenProtector? mfaTokenProtector = null,
-            Action<Auth0WebAppWithAccessTokenOptions>? configureWithAccessToken = null)
+            Action<Auth0WebAppWithAccessTokenOptions>? configureWithAccessToken = null,
+            Action<Auth0WebAppOptions>? configureWebApp = null,
+            Action<IServiceCollection>? configureServices = null)
         {
             var webAppOptions = new Auth0WebAppOptions
             {
@@ -1186,6 +1253,7 @@ namespace Auth0.AspNetCore.Authentication.IntegrationTests
                 Backchannel = new HttpClient(backchannelHandler),
                 CookieAuthenticationScheme = CookieScheme
             };
+            configureWebApp?.Invoke(webAppOptions);
 
             var withAccessTokenOptions = new Auth0WebAppWithAccessTokenOptions
             {
@@ -1216,6 +1284,7 @@ namespace Auth0.AspNetCore.Authentication.IntegrationTests
             services.AddSingleton(withAccessTokenSnapshot.Object);
             services.AddSingleton<IMfaTokenProtector>(
                 mfaTokenProtector ?? new MfaTokenProtector(new EphemeralDataProtectionProvider()));
+            configureServices?.Invoke(services);
 
             return new DefaultHttpContext
             {

--- a/tests/Auth0.AspNetCore.Authentication.IntegrationTests/Infrastructure/CapturingLoggerProvider.cs
+++ b/tests/Auth0.AspNetCore.Authentication.IntegrationTests/Infrastructure/CapturingLoggerProvider.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using Microsoft.Extensions.Logging;
+
+namespace Auth0.AspNetCore.Authentication.IntegrationTests.Infrastructure
+{
+    /// <summary>
+    /// An <see cref="ILoggerProvider"/> that records every logged message, for asserting on warnings.
+    /// </summary>
+    public sealed class CapturingLoggerProvider : ILoggerProvider
+    {
+        public ConcurrentQueue<CapturedLog> Logs { get; } = new ConcurrentQueue<CapturedLog>();
+
+        public ILogger CreateLogger(string categoryName) => new CapturingLogger(categoryName, Logs);
+
+        public void Dispose() { }
+
+        public sealed record CapturedLog(string Category, LogLevel Level, string Message);
+
+        private sealed class CapturingLogger : ILogger
+        {
+            private readonly string _category;
+            private readonly ConcurrentQueue<CapturedLog> _logs;
+
+            public CapturingLogger(string category, ConcurrentQueue<CapturedLog> logs)
+            {
+                _category = category;
+                _logs = logs;
+            }
+
+            public IDisposable BeginScope<TState>(TState state) => NullScope.Instance;
+
+            public bool IsEnabled(LogLevel logLevel) => true;
+
+            public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, System.Exception exception,
+                System.Func<TState, System.Exception, string> formatter)
+            {
+                _logs.Enqueue(new CapturedLog(_category, logLevel, formatter(state, exception)));
+            }
+
+            private sealed class NullScope : IDisposable
+            {
+                public static readonly NullScope Instance = new NullScope();
+                public void Dispose() { }
+            }
+        }
+    }
+}

--- a/tests/Auth0.AspNetCore.Authentication.IntegrationTests/Infrastructure/TestServerBuilder.cs
+++ b/tests/Auth0.AspNetCore.Authentication.IntegrationTests/Infrastructure/TestServerBuilder.cs
@@ -34,7 +34,7 @@ namespace Auth0.AspNetCore.Authentication.IntegrationTests.Infrastructure
         /// <param name="mockAuthentication">Indicated whether or not the authenitcation should be mocked, useful because some tests require an authenticated user while others require no user to exist.</param>
         /// <param name="authenticationScheme">Optional custom authentication scheme to use.</param>
         /// <returns>The created TestServer instance.</returns>
-        public static TestServer CreateServer(Action<Auth0WebAppOptions> configureOptions = null, Action<Auth0WebAppWithAccessTokenOptions> configureWithAccessTokensOptions = null, bool mockAuthentication = false, bool useServiceCollectionExtension = false, bool addExtraProvider = false, Action<Auth0WebAppOptions> configureAdditionalOptions = null, bool enableBackchannelLogout = false, string authenticationScheme = null, Action<Auth0CustomDomainsOptions> configureCustomDomains = null, Action<Auth0MtlsOptions> configureMtls = null, bool withMtlsAfterAccessToken = false, Microsoft.Extensions.Logging.ILoggerProvider loggerProvider = null)
+        public static TestServer CreateServer(Action<Auth0WebAppOptions> configureOptions = null, Action<Auth0WebAppWithAccessTokenOptions> configureWithAccessTokensOptions = null, bool mockAuthentication = false, bool useServiceCollectionExtension = false, bool addExtraProvider = false, Action<Auth0WebAppOptions> configureAdditionalOptions = null, bool enableBackchannelLogout = false, string authenticationScheme = null, Action<Auth0CustomDomainsOptions> configureCustomDomains = null, Action<Auth0MtlsOptions> configureMtls = null, bool withMtlsAfterAccessToken = false, bool withMtlsBeforeCustomDomains = false, Microsoft.Extensions.Logging.ILoggerProvider loggerProvider = null)
         {
             var configuration = TestConfiguration.GetConfiguration();
             var host = new HostBuilder()
@@ -145,7 +145,7 @@ namespace Auth0.AspNetCore.Authentication.IntegrationTests.Infrastructure
                             }
 
                             // WithMtls must run before WithAccessToken and after WithCustomDomains.
-                            if (configureCustomDomains != null)
+                            if (configureCustomDomains != null && !withMtlsBeforeCustomDomains)
                             {
                                 builder.WithCustomDomains(configureCustomDomains);
                             }
@@ -155,12 +155,18 @@ namespace Auth0.AspNetCore.Authentication.IntegrationTests.Infrastructure
                                 builder.WithMtls(configureMtls);
                             }
 
+                            // Deliberately-wrong ordering, used only to assert the custom-domains ordering guard.
+                            if (configureCustomDomains != null && withMtlsBeforeCustomDomains)
+                            {
+                                builder.WithCustomDomains(configureCustomDomains);
+                            }
+
                             if (configureWithAccessTokensOptions != null)
                             {
                                 builder.WithAccessToken(configureWithAccessTokensOptions);
                             }
 
-                            // Deliberately-wrong ordering, used only to assert the ordering guard.
+                            // Deliberately-wrong ordering, used only to assert the access-token ordering guard.
                             if (configureMtls != null && withMtlsAfterAccessToken)
                             {
                                 builder.WithMtls(configureMtls);

--- a/tests/Auth0.AspNetCore.Authentication.IntegrationTests/Infrastructure/TestServerBuilder.cs
+++ b/tests/Auth0.AspNetCore.Authentication.IntegrationTests/Infrastructure/TestServerBuilder.cs
@@ -10,6 +10,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 
 namespace Auth0.AspNetCore.Authentication.IntegrationTests.Infrastructure
 {
@@ -33,7 +34,7 @@ namespace Auth0.AspNetCore.Authentication.IntegrationTests.Infrastructure
         /// <param name="mockAuthentication">Indicated whether or not the authenitcation should be mocked, useful because some tests require an authenticated user while others require no user to exist.</param>
         /// <param name="authenticationScheme">Optional custom authentication scheme to use.</param>
         /// <returns>The created TestServer instance.</returns>
-        public static TestServer CreateServer(Action<Auth0WebAppOptions> configureOptions = null, Action<Auth0WebAppWithAccessTokenOptions> configureWithAccessTokensOptions = null, bool mockAuthentication = false, bool useServiceCollectionExtension = false, bool addExtraProvider = false, Action<Auth0WebAppOptions> configureAdditionalOptions = null, bool enableBackchannelLogout = false, string authenticationScheme = null, Action<Auth0CustomDomainsOptions> configureCustomDomains = null)
+        public static TestServer CreateServer(Action<Auth0WebAppOptions> configureOptions = null, Action<Auth0WebAppWithAccessTokenOptions> configureWithAccessTokensOptions = null, bool mockAuthentication = false, bool useServiceCollectionExtension = false, bool addExtraProvider = false, Action<Auth0WebAppOptions> configureAdditionalOptions = null, bool enableBackchannelLogout = false, string authenticationScheme = null, Action<Auth0CustomDomainsOptions> configureCustomDomains = null, Action<Auth0MtlsOptions> configureMtls = null, bool withMtlsAfterAccessToken = false, Microsoft.Extensions.Logging.ILoggerProvider loggerProvider = null)
         {
             var configuration = TestConfiguration.GetConfiguration();
             var host = new HostBuilder()
@@ -143,9 +144,26 @@ namespace Auth0.AspNetCore.Authentication.IntegrationTests.Infrastructure
                                 }
                             }
 
+                            // WithMtls must run before WithAccessToken and after WithCustomDomains.
+                            if (configureCustomDomains != null)
+                            {
+                                builder.WithCustomDomains(configureCustomDomains);
+                            }
+
+                            if (configureMtls != null && !withMtlsAfterAccessToken)
+                            {
+                                builder.WithMtls(configureMtls);
+                            }
+
                             if (configureWithAccessTokensOptions != null)
                             {
                                 builder.WithAccessToken(configureWithAccessTokensOptions);
+                            }
+
+                            // Deliberately-wrong ordering, used only to assert the ordering guard.
+                            if (configureMtls != null && withMtlsAfterAccessToken)
+                            {
+                                builder.WithMtls(configureMtls);
                             }
 
                             if (enableBackchannelLogout)
@@ -153,12 +171,12 @@ namespace Auth0.AspNetCore.Authentication.IntegrationTests.Infrastructure
                                 builder.WithBackchannelLogout();
                             }
 
-                            if (configureCustomDomains != null)
-                            {
-                                builder.WithCustomDomains(configureCustomDomains);
-                            }
-
                             services.AddControllersWithViews();
+
+                            if (loggerProvider != null)
+                            {
+                                services.AddLogging(logging => logging.AddProvider(loggerProvider));
+                            }
                         })
                         .ConfigureTestServices(services =>
                         {

--- a/tests/Auth0.AspNetCore.Authentication.IntegrationTests/Mtls/Auth0MtlsConfigurationManagerTests.cs
+++ b/tests/Auth0.AspNetCore.Authentication.IntegrationTests/Mtls/Auth0MtlsConfigurationManagerTests.cs
@@ -1,0 +1,74 @@
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Auth0.AspNetCore.Authentication.Mtls;
+using FluentAssertions;
+using Microsoft.IdentityModel.Protocols;
+using Microsoft.IdentityModel.Protocols.OpenIdConnect;
+using Xunit;
+
+namespace Auth0.AspNetCore.Authentication.IntegrationTests.Mtls
+{
+    public class Auth0MtlsConfigurationManagerTests
+    {
+        private sealed class StubManager : IConfigurationManager<OpenIdConnectConfiguration>
+        {
+            private readonly OpenIdConnectConfiguration _config;
+            public int Calls { get; private set; }
+            public StubManager(OpenIdConnectConfiguration config) => _config = config;
+            public Task<OpenIdConnectConfiguration> GetConfigurationAsync(CancellationToken cancel)
+            {
+                Calls++;
+                return Task.FromResult(_config);
+            }
+            public void RequestRefresh() { }
+        }
+
+        private static OpenIdConnectConfiguration ConfigWithAliases()
+        {
+            var config = new OpenIdConnectConfiguration
+            {
+                TokenEndpoint = "https://tenant.eu.auth0.com/oauth/token",
+                PushedAuthorizationRequestEndpoint = "https://tenant.eu.auth0.com/oauth/par"
+            };
+            using var doc = JsonDocument.Parse(
+                "{\"token_endpoint\":\"https://mtls.tenant.eu.auth0.com/oauth/token\"," +
+                "\"pushed_authorization_request_endpoint\":\"https://mtls.tenant.eu.auth0.com/oauth/par\"}");
+            config.AdditionalData["mtls_endpoint_aliases"] = doc.RootElement.Clone();
+            return config;
+        }
+
+        [Fact]
+        public async Task Rewrites_Endpoints_To_Mtls_Aliases()
+        {
+            var manager = new Auth0MtlsConfigurationManager(new StubManager(ConfigWithAliases()));
+
+            var config = await manager.GetConfigurationAsync(CancellationToken.None);
+
+            config.TokenEndpoint.Should().Be("https://mtls.tenant.eu.auth0.com/oauth/token");
+            config.PushedAuthorizationRequestEndpoint.Should().Be("https://mtls.tenant.eu.auth0.com/oauth/par");
+        }
+
+        [Fact]
+        public async Task Is_Idempotent_Across_Repeated_Calls()
+        {
+            var manager = new Auth0MtlsConfigurationManager(new StubManager(ConfigWithAliases()));
+
+            await manager.GetConfigurationAsync(CancellationToken.None);
+            var config = await manager.GetConfigurationAsync(CancellationToken.None);
+
+            config.TokenEndpoint.Should().Be("https://mtls.tenant.eu.auth0.com/oauth/token");
+        }
+
+        [Fact]
+        public async Task Leaves_Endpoints_Untouched_When_No_Aliases()
+        {
+            var inner = new OpenIdConnectConfiguration { TokenEndpoint = "https://tenant.eu.auth0.com/oauth/token" };
+            var manager = new Auth0MtlsConfigurationManager(new StubManager(inner));
+
+            var config = await manager.GetConfigurationAsync(CancellationToken.None);
+
+            config.TokenEndpoint.Should().Be("https://tenant.eu.auth0.com/oauth/token");
+        }
+    }
+}

--- a/tests/Auth0.AspNetCore.Authentication.IntegrationTests/Mtls/Auth0MtlsConfigurationManagerTests.cs
+++ b/tests/Auth0.AspNetCore.Authentication.IntegrationTests/Mtls/Auth0MtlsConfigurationManagerTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
@@ -61,14 +62,41 @@ namespace Auth0.AspNetCore.Authentication.IntegrationTests.Mtls
         }
 
         [Fact]
-        public async Task Leaves_Endpoints_Untouched_When_No_Aliases()
+        public async Task Throws_When_Token_Endpoint_Alias_Absent()
         {
+            // Fail-closed: the code exchange cannot fall back to the standard host under mTLS, so a
+            // missing token_endpoint alias must raise the same actionable error the back-channel
+            // resolver raises rather than silently leaving the standard endpoint in place.
             var inner = new OpenIdConnectConfiguration { TokenEndpoint = "https://tenant.eu.auth0.com/oauth/token" };
             var manager = new Auth0MtlsConfigurationManager(new StubManager(inner));
 
-            var config = await manager.GetConfigurationAsync(CancellationToken.None);
+            Func<Task> act = () => manager.GetConfigurationAsync(CancellationToken.None);
 
-            config.TokenEndpoint.Should().Be("https://tenant.eu.auth0.com/oauth/token");
+            (await act.Should().ThrowAsync<InvalidOperationException>()).Which.Message.Should().Be(
+                "mTLS is enabled but the authorization server discovery document does not advertise " +
+                "`mtls_endpoint_aliases.token_endpoint`. Ensure mTLS endpoint aliases are enabled on your Auth0 tenant.");
+        }
+
+        [Fact]
+        public async Task Rewrites_Token_Endpoint_And_Leaves_Par_When_Only_Token_Alias_Present()
+        {
+            // PAR is optional: this rewrite runs on every configuration fetch, so a tenant that
+            // advertises the token alias but not a PAR alias must not throw, and the PAR endpoint is
+            // left as discovered.
+            var config = new OpenIdConnectConfiguration
+            {
+                TokenEndpoint = "https://tenant.eu.auth0.com/oauth/token",
+                PushedAuthorizationRequestEndpoint = "https://tenant.eu.auth0.com/oauth/par"
+            };
+            using var doc = JsonDocument.Parse(
+                "{\"token_endpoint\":\"https://mtls.tenant.eu.auth0.com/oauth/token\"}");
+            config.AdditionalData["mtls_endpoint_aliases"] = doc.RootElement.Clone();
+            var manager = new Auth0MtlsConfigurationManager(new StubManager(config));
+
+            var result = await manager.GetConfigurationAsync(CancellationToken.None);
+
+            result.TokenEndpoint.Should().Be("https://mtls.tenant.eu.auth0.com/oauth/token");
+            result.PushedAuthorizationRequestEndpoint.Should().Be("https://tenant.eu.auth0.com/oauth/par");
         }
     }
 }

--- a/tests/Auth0.AspNetCore.Authentication.IntegrationTests/Mtls/Auth0MtlsEndpointResolverTests.cs
+++ b/tests/Auth0.AspNetCore.Authentication.IntegrationTests/Mtls/Auth0MtlsEndpointResolverTests.cs
@@ -84,6 +84,40 @@ namespace Auth0.AspNetCore.Authentication.IntegrationTests.Mtls
             configCalls.Should().Be(1);
         }
 
+        [Fact]
+        public async Task Failed_Discovery_Does_Not_Poison_Cache()
+        {
+            // A transient discovery failure must not cache a faulted task: a later call has to retry and
+            // succeed. This guards the eviction in ResolveAsync's catch against a future GetOrAdd
+            // "simplification" that would cache the failure and cause a self-inflicted outage.
+            var handler = new Mock<HttpMessageHandler>();
+            handler.Protected()
+                .SetupSequence<Task<HttpResponseMessage>>("SendAsync",
+                    ItExpr.Is<HttpRequestMessage>(m => m.RequestUri!.AbsolutePath.Contains(".well-known/openid-configuration")),
+                    ItExpr.IsAny<CancellationToken>())
+                .ReturnsAsync(new HttpResponseMessage(System.Net.HttpStatusCode.InternalServerError)
+                {
+                    Content = new StringContent("transient discovery failure")
+                })
+                .ReturnsAsync(ResourceResponse("wellknownconfig_with_mtls.json"));
+            handler.Protected()
+                .Setup<Task<HttpResponseMessage>>("SendAsync",
+                    ItExpr.Is<HttpRequestMessage>(m => m.RequestUri!.AbsolutePath.Contains(".well-known/jwks.json")),
+                    ItExpr.IsAny<CancellationToken>())
+                .ReturnsAsync(() => ResourceResponse("jwks.json"));
+
+            var resolver = new Auth0MtlsEndpointResolver();
+            var client = new HttpClient(handler.Object);
+
+            // First attempt fails while fetching discovery.
+            Func<Task> firstAttempt = () => resolver.ResolveTokenEndpointAsync(Domain, client);
+            await firstAttempt.Should().ThrowAsync<Exception>();
+
+            // Second attempt must re-fetch discovery (the faulted task was evicted) and succeed.
+            var endpoint = await resolver.ResolveTokenEndpointAsync(Domain, client);
+            endpoint.Should().Be("https://mtls.tenant.eu.auth0.com/oauth/token");
+        }
+
         private static System.Net.Http.HttpResponseMessage ResourceResponse(string resource)
         {
             var name = "Auth0.AspNetCore.Authentication.IntegrationTests." + resource;

--- a/tests/Auth0.AspNetCore.Authentication.IntegrationTests/Mtls/Auth0MtlsEndpointResolverTests.cs
+++ b/tests/Auth0.AspNetCore.Authentication.IntegrationTests/Mtls/Auth0MtlsEndpointResolverTests.cs
@@ -1,0 +1,98 @@
+using System;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Auth0.AspNetCore.Authentication.IntegrationTests.Builders;
+using Auth0.AspNetCore.Authentication.Mtls;
+using FluentAssertions;
+using Moq;
+using Moq.Protected;
+using Xunit;
+
+namespace Auth0.AspNetCore.Authentication.IntegrationTests.Mtls
+{
+    public class Auth0MtlsEndpointResolverTests
+    {
+        private const string Domain = "tenant.eu.auth0.com";
+
+        [Fact]
+        public async Task Resolves_Aliased_Token_Endpoint_From_Discovery()
+        {
+            var handler = new OidcMockBuilder()
+                .MockOpenIdConfig("wellknownconfig_with_mtls.json")
+                .MockJwks()
+                .Build();
+
+            var resolver = new Auth0MtlsEndpointResolver();
+            var endpoint = await resolver.ResolveTokenEndpointAsync(Domain, new HttpClient(handler.Object));
+
+            endpoint.Should().Be("https://mtls.tenant.eu.auth0.com/oauth/token");
+        }
+
+        [Fact]
+        public async Task Resolves_Aliased_Par_Endpoint_From_Discovery()
+        {
+            var handler = new OidcMockBuilder()
+                .MockOpenIdConfig("wellknownconfig_with_mtls.json")
+                .MockJwks()
+                .Build();
+
+            var resolver = new Auth0MtlsEndpointResolver();
+            var endpoint = await resolver.ResolvePushedAuthorizationRequestEndpointAsync(Domain, new HttpClient(handler.Object));
+
+            endpoint.Should().Be("https://mtls.tenant.eu.auth0.com/oauth/par");
+        }
+
+        [Fact]
+        public async Task Throws_Actionable_Message_When_Alias_Absent()
+        {
+            var handler = new OidcMockBuilder()
+                .MockOpenIdConfig("wellknownconfig_with_mtls_no_aliases.json")
+                .MockJwks()
+                .Build();
+
+            var resolver = new Auth0MtlsEndpointResolver();
+            Func<Task> act = () => resolver.ResolveTokenEndpointAsync(Domain, new HttpClient(handler.Object));
+
+            (await act.Should().ThrowAsync<InvalidOperationException>()).Which.Message.Should().Be(
+                "mTLS is enabled but the authorization server discovery document does not advertise " +
+                "`mtls_endpoint_aliases.token_endpoint`. Ensure mTLS endpoint aliases are enabled on your Auth0 tenant.");
+        }
+
+        [Fact]
+        public async Task Caches_Discovery_Per_Domain()
+        {
+            var configCalls = 0;
+            var handler = new Mock<HttpMessageHandler>();
+            handler.Protected()
+                .Setup<Task<HttpResponseMessage>>("SendAsync",
+                    ItExpr.Is<HttpRequestMessage>(m => m.RequestUri!.AbsolutePath.Contains(".well-known/openid-configuration")),
+                    ItExpr.IsAny<CancellationToken>())
+                .Callback(() => configCalls++)
+                .ReturnsAsync(() => ResourceResponse("wellknownconfig_with_mtls.json"));
+            handler.Protected()
+                .Setup<Task<HttpResponseMessage>>("SendAsync",
+                    ItExpr.Is<HttpRequestMessage>(m => m.RequestUri!.AbsolutePath.Contains(".well-known/jwks.json")),
+                    ItExpr.IsAny<CancellationToken>())
+                .ReturnsAsync(() => ResourceResponse("jwks.json"));
+
+            var resolver = new Auth0MtlsEndpointResolver();
+            var client = new HttpClient(handler.Object);
+            await resolver.ResolveTokenEndpointAsync(Domain, client);
+            await resolver.ResolvePushedAuthorizationRequestEndpointAsync(Domain, client);
+
+            configCalls.Should().Be(1);
+        }
+
+        private static System.Net.Http.HttpResponseMessage ResourceResponse(string resource)
+        {
+            var name = "Auth0.AspNetCore.Authentication.IntegrationTests." + resource;
+            using var stream = typeof(Startup).Assembly.GetManifestResourceStream(name)!;
+            using var reader = new System.IO.StreamReader(stream);
+            return new System.Net.Http.HttpResponseMessage(System.Net.HttpStatusCode.OK)
+            {
+                Content = new System.Net.Http.StringContent(reader.ReadToEnd(), System.Text.Encoding.UTF8, "application/json")
+            };
+        }
+    }
+}

--- a/tests/Auth0.AspNetCore.Authentication.IntegrationTests/Mtls/Auth0MtlsEndpointResolverTests.cs
+++ b/tests/Auth0.AspNetCore.Authentication.IntegrationTests/Mtls/Auth0MtlsEndpointResolverTests.cs
@@ -30,20 +30,6 @@ namespace Auth0.AspNetCore.Authentication.IntegrationTests.Mtls
         }
 
         [Fact]
-        public async Task Resolves_Aliased_Par_Endpoint_From_Discovery()
-        {
-            var handler = new OidcMockBuilder()
-                .MockOpenIdConfig("wellknownconfig_with_mtls.json")
-                .MockJwks()
-                .Build();
-
-            var resolver = new Auth0MtlsEndpointResolver();
-            var endpoint = await resolver.ResolvePushedAuthorizationRequestEndpointAsync(Domain, new HttpClient(handler.Object));
-
-            endpoint.Should().Be("https://mtls.tenant.eu.auth0.com/oauth/par");
-        }
-
-        [Fact]
         public async Task Throws_Actionable_Message_When_Alias_Absent()
         {
             var handler = new OidcMockBuilder()
@@ -79,7 +65,7 @@ namespace Auth0.AspNetCore.Authentication.IntegrationTests.Mtls
             var resolver = new Auth0MtlsEndpointResolver();
             var client = new HttpClient(handler.Object);
             await resolver.ResolveTokenEndpointAsync(Domain, client);
-            await resolver.ResolvePushedAuthorizationRequestEndpointAsync(Domain, client);
+            await resolver.ResolveTokenEndpointAsync(Domain, client);
 
             configCalls.Should().Be(1);
         }

--- a/tests/Auth0.AspNetCore.Authentication.IntegrationTests/Mtls/CnfClaimReaderTests.cs
+++ b/tests/Auth0.AspNetCore.Authentication.IntegrationTests/Mtls/CnfClaimReaderTests.cs
@@ -1,0 +1,42 @@
+using Auth0.AspNetCore.Authentication.Mtls;
+using FluentAssertions;
+using Xunit;
+
+namespace Auth0.AspNetCore.Authentication.IntegrationTests.Mtls
+{
+    public class CnfClaimReaderTests
+    {
+        private const string Header = "eyJhbGciOiJSUzI1NiJ9";
+        private const string PayloadWithCnf = "eyJjbmYiOnsieDV0I1MyNTYiOiJhYmMifX0";
+        private const string PayloadNoCnf = "eyJzdWIiOiJ1MSJ9";
+
+        [Fact]
+        public void Returns_True_When_Cnf_Thumbprint_Present()
+        {
+            var jwt = $"{Header}.{PayloadWithCnf}.sig";
+
+            CnfClaimReader.HasThumbprintConfirmation(jwt).Should().Be(true);
+        }
+
+        [Fact]
+        public void Returns_False_When_Jwt_Has_No_Cnf()
+        {
+            var jwt = $"{Header}.{PayloadNoCnf}.sig";
+
+            CnfClaimReader.HasThumbprintConfirmation(jwt).Should().Be(false);
+        }
+
+        [Fact]
+        public void Returns_Null_For_Opaque_Token()
+        {
+            CnfClaimReader.HasThumbprintConfirmation("opaque-access-token").Should().BeNull();
+        }
+
+        [Fact]
+        public void Returns_Null_For_Null_Or_Empty()
+        {
+            CnfClaimReader.HasThumbprintConfirmation(null).Should().BeNull();
+            CnfClaimReader.HasThumbprintConfirmation("").Should().BeNull();
+        }
+    }
+}

--- a/tests/Auth0.AspNetCore.Authentication.IntegrationTests/Mtls/MtlsAuthenticationApiClientTests.cs
+++ b/tests/Auth0.AspNetCore.Authentication.IntegrationTests/Mtls/MtlsAuthenticationApiClientTests.cs
@@ -100,6 +100,26 @@ namespace Auth0.AspNetCore.Authentication.IntegrationTests.Mtls
         }
 
         [Fact]
+        public async Task MfaChallenge_Throws_When_Mtls_Enabled_But_Resolver_Missing()
+        {
+            // UseMtls is true but no resolver was supplied. The client-authenticated path must fail
+            // loudly rather than route a certificate-less request to the standard host.
+            var (handler, _, _) = BuildHandler("{\"challenge_type\":\"oob\"}");
+            var client = new AuthenticationApiClient(
+                new HttpClient(handler.Object),
+                new Uri($"https://{Domain}"),
+                MtlsOptions(),
+                Protector,
+                ownsHttpClient: false,
+                mtlsEndpointResolver: null);
+
+            Func<Task> act = () => client.MfaChallengeAsync(new MfaChallengeRequest { MfaToken = Blob("mt"), ChallengeType = "oob" });
+
+            (await act.Should().ThrowAsync<InvalidOperationException>()).Which.Message.Should().Be(
+                "mTLS is enabled but no mTLS endpoint resolver is available. Ensure the SDK was configured with WithMtls.");
+        }
+
+        [Fact]
         public async Task MfaAuthenticatorsList_Stays_On_Standard_Host()
         {
             var (handler, captured, bodies) = BuildHandler("[{\"id\":\"a1\",\"authenticator_type\":\"otp\",\"active\":true}]");

--- a/tests/Auth0.AspNetCore.Authentication.IntegrationTests/Mtls/MtlsAuthenticationApiClientTests.cs
+++ b/tests/Auth0.AspNetCore.Authentication.IntegrationTests/Mtls/MtlsAuthenticationApiClientTests.cs
@@ -1,0 +1,120 @@
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Auth0.AspNetCore.Authentication.AuthenticationApi;
+using Auth0.AspNetCore.Authentication.AuthenticationApi.Models;
+using Auth0.AspNetCore.Authentication.Mtls;
+using FluentAssertions;
+using Microsoft.AspNetCore.DataProtection;
+using Moq;
+using Moq.Protected;
+using Xunit;
+
+namespace Auth0.AspNetCore.Authentication.IntegrationTests.Mtls
+{
+    public class MtlsAuthenticationApiClientTests
+    {
+        private const string Domain = "tenant.eu.auth0.com";
+        private const string MtlsHost = "mtls.tenant.eu.auth0.com";
+
+        private static readonly IMfaTokenProtector Protector = new MfaTokenProtector(new EphemeralDataProtectionProvider());
+
+        private static Auth0WebAppOptions MtlsOptions() =>
+            new Auth0WebAppOptions { Domain = Domain, ClientId = "cid", UseMtls = true };
+
+        private static string Blob(string rawToken) =>
+            Protector.Protect(new MfaTokenContext
+            {
+                MfaToken = rawToken,
+                ExpiresAtUnix = DateTimeOffset.UtcNow.AddMinutes(5).ToUnixTimeSeconds()
+            });
+
+        private static HttpResponseMessage Resource(string resource)
+        {
+            var name = "Auth0.AspNetCore.Authentication.IntegrationTests." + resource;
+            using var stream = typeof(Startup).Assembly.GetManifestResourceStream(name)!;
+            using var reader = new System.IO.StreamReader(stream);
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(reader.ReadToEnd(), System.Text.Encoding.UTF8, "application/json")
+            };
+        }
+
+        private static (Mock<HttpMessageHandler> Handler, List<HttpRequestMessage> Captured, List<string> Bodies) BuildHandler(string okJson)
+        {
+            var captured = new List<HttpRequestMessage>();
+            var bodies = new List<string>();
+            var handler = new Mock<HttpMessageHandler>();
+
+            handler.Protected()
+                .Setup<Task<HttpResponseMessage>>("SendAsync",
+                    ItExpr.Is<HttpRequestMessage>(m => m.RequestUri!.AbsolutePath.Contains(".well-known/openid-configuration")),
+                    ItExpr.IsAny<CancellationToken>())
+                .ReturnsAsync(() => Resource("wellknownconfig_with_mtls.json"));
+            handler.Protected()
+                .Setup<Task<HttpResponseMessage>>("SendAsync",
+                    ItExpr.Is<HttpRequestMessage>(m => m.RequestUri!.AbsolutePath.Contains(".well-known/jwks.json")),
+                    ItExpr.IsAny<CancellationToken>())
+                .ReturnsAsync(() => Resource("jwks.json"));
+            handler.Protected()
+                .Setup<Task<HttpResponseMessage>>("SendAsync",
+                    ItExpr.Is<HttpRequestMessage>(m =>
+                        m.RequestUri!.AbsolutePath.EndsWith("mfa/challenge") ||
+                        m.RequestUri!.AbsolutePath.EndsWith("oauth/token") ||
+                        m.RequestUri!.AbsolutePath.EndsWith("mfa/authenticators")),
+                    ItExpr.IsAny<CancellationToken>())
+                .Callback<HttpRequestMessage, CancellationToken>((m, _) =>
+                {
+                    captured.Add(m);
+                    bodies.Add(m.Content?.ReadAsStringAsync().Result ?? "");
+                })
+                .ReturnsAsync(() => new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(okJson)
+                });
+
+            return (handler, captured, bodies);
+        }
+
+        [Fact]
+        public async Task MfaChallenge_Routes_To_Mtls_Host_Without_Client_Secret()
+        {
+            var (handler, captured, bodies) = BuildHandler("{\"challenge_type\":\"oob\"}");
+            var client = new AuthenticationApiClient(
+                new HttpClient(handler.Object),
+                new Uri($"https://{Domain}"),
+                MtlsOptions(),
+                Protector,
+                ownsHttpClient: false,
+                mtlsEndpointResolver: new Auth0MtlsEndpointResolver());
+
+            await client.MfaChallengeAsync(new MfaChallengeRequest { MfaToken = Blob("mt"), ChallengeType = "oob" });
+
+            var challengeIdx = captured.FindIndex(r => r.RequestUri!.AbsolutePath.EndsWith("mfa/challenge"));
+            var challenge = captured[challengeIdx];
+            challenge.RequestUri!.Host.Should().Be(MtlsHost);
+            bodies[challengeIdx].Should().NotContain("client_secret=");
+        }
+
+        [Fact]
+        public async Task MfaAuthenticatorsList_Stays_On_Standard_Host()
+        {
+            var (handler, captured, bodies) = BuildHandler("[{\"id\":\"a1\",\"authenticator_type\":\"otp\",\"active\":true}]");
+            var client = new AuthenticationApiClient(
+                new HttpClient(handler.Object),
+                new Uri($"https://{Domain}"),
+                MtlsOptions(),
+                Protector,
+                ownsHttpClient: false,
+                mtlsEndpointResolver: new Auth0MtlsEndpointResolver());
+
+            await client.ListMfaAuthenticatorsAsync("access-token");
+
+            var list = captured.Find(r => r.RequestUri!.AbsolutePath.EndsWith("mfa/authenticators"))!;
+            list.RequestUri!.Host.Should().Be(Domain);
+        }
+    }
+}

--- a/tests/Auth0.AspNetCore.Authentication.IntegrationTests/Mtls/MtlsCnfInspectorTests.cs
+++ b/tests/Auth0.AspNetCore.Authentication.IntegrationTests/Mtls/MtlsCnfInspectorTests.cs
@@ -1,0 +1,69 @@
+using System.Linq;
+using Auth0.AspNetCore.Authentication.IntegrationTests.Infrastructure;
+using Auth0.AspNetCore.Authentication.Mtls;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace Auth0.AspNetCore.Authentication.IntegrationTests.Mtls
+{
+    public class MtlsCnfInspectorTests
+    {
+        private const string Header = "eyJhbGciOiJSUzI1NiJ9";
+        private const string PayloadWithCnf = "eyJjbmYiOnsieDV0I1MyNTYiOiJhYmMifX0";
+        private const string PayloadNoCnf = "eyJzdWIiOiJ1MSJ9";
+
+        private const string ExpectedWarning =
+            "mTLS is enabled but the access token has no `cnf.x5t#S256` claim; the token is not sender-constrained. " +
+            "Configure Token Sender-Constraining on the API.";
+
+        private static (MtlsCnfInspector Inspector, CapturingLoggerProvider Sink) Build()
+        {
+            var sink = new CapturingLoggerProvider();
+            var factory = LoggerFactory.Create(b => b.AddProvider(sink));
+            return (new MtlsCnfInspector(factory), sink);
+        }
+
+        [Fact]
+        public void Warns_When_Jwt_Has_No_Cnf()
+        {
+            var (inspector, sink) = Build();
+
+            inspector.Inspect("client-1", $"{Header}.{PayloadNoCnf}.sig");
+
+            sink.Logs.Should().ContainSingle(l => l.Level == LogLevel.Warning && l.Message == ExpectedWarning);
+        }
+
+        [Fact]
+        public void Silent_When_Cnf_Present()
+        {
+            var (inspector, sink) = Build();
+
+            inspector.Inspect("client-1", $"{Header}.{PayloadWithCnf}.sig");
+
+            sink.Logs.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void Silent_For_Opaque_Token()
+        {
+            var (inspector, sink) = Build();
+
+            inspector.Inspect("client-1", "opaque");
+
+            sink.Logs.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void Warns_Only_Once_Per_ClientId()
+        {
+            var (inspector, sink) = Build();
+
+            inspector.Inspect("client-1", $"{Header}.{PayloadNoCnf}.sig");
+            inspector.Inspect("client-1", $"{Header}.{PayloadNoCnf}.sig");
+            inspector.Inspect("client-1", $"{Header}.{PayloadNoCnf}.sig");
+
+            sink.Logs.Count(l => l.Level == LogLevel.Warning).Should().Be(1);
+        }
+    }
+}

--- a/tests/Auth0.AspNetCore.Authentication.IntegrationTests/Mtls/MtlsEndpointAliasesTests.cs
+++ b/tests/Auth0.AspNetCore.Authentication.IntegrationTests/Mtls/MtlsEndpointAliasesTests.cs
@@ -1,0 +1,54 @@
+using System.Collections.Generic;
+using System.Text.Json;
+using Auth0.AspNetCore.Authentication.Mtls;
+using FluentAssertions;
+using Microsoft.IdentityModel.Protocols.OpenIdConnect;
+using Xunit;
+
+namespace Auth0.AspNetCore.Authentication.IntegrationTests.Mtls
+{
+    public class MtlsEndpointAliasesTests
+    {
+        private static OpenIdConnectConfiguration WithAliases(string aliasesJson)
+        {
+            var config = new OpenIdConnectConfiguration();
+            using var doc = JsonDocument.Parse(aliasesJson);
+            config.AdditionalData["mtls_endpoint_aliases"] = doc.RootElement.Clone();
+            return config;
+        }
+
+        [Fact]
+        public void Returns_Aliased_Token_Endpoint_When_Present()
+        {
+            var config = WithAliases("{\"token_endpoint\":\"https://mtls.tenant.eu.auth0.com/oauth/token\"}");
+
+            MtlsEndpointAliases.TryGetAlias(config, "token_endpoint")
+                .Should().Be("https://mtls.tenant.eu.auth0.com/oauth/token");
+        }
+
+        [Fact]
+        public void Returns_Null_When_Aliases_Absent()
+        {
+            var config = new OpenIdConnectConfiguration();
+
+            MtlsEndpointAliases.TryGetAlias(config, "token_endpoint").Should().BeNull();
+        }
+
+        [Fact]
+        public void Returns_Null_When_Requested_Endpoint_Absent()
+        {
+            var config = WithAliases("{\"token_endpoint\":\"https://mtls.tenant.eu.auth0.com/oauth/token\"}");
+
+            MtlsEndpointAliases.TryGetAlias(config, "pushed_authorization_request_endpoint").Should().BeNull();
+        }
+
+        [Fact]
+        public void Returns_Null_When_Aliases_Is_A_Scalar_String()
+        {
+            var config = new OpenIdConnectConfiguration();
+            config.AdditionalData["mtls_endpoint_aliases"] = "not-an-object";
+
+            MtlsEndpointAliases.TryGetAlias(config, "token_endpoint").Should().BeNull();
+        }
+    }
+}

--- a/tests/Auth0.AspNetCore.Authentication.IntegrationTests/Mtls/MtlsMiddlewareTests.cs
+++ b/tests/Auth0.AspNetCore.Authentication.IntegrationTests/Mtls/MtlsMiddlewareTests.cs
@@ -236,6 +236,57 @@ namespace Auth0.AspNetCore.Authentication.IntegrationTests.Mtls
             capturedPar.RequestUri!.Host.Should().Be("mtls.tenant.eu.auth0.com");
         }
 
+        [Fact]
+        public async Task Par_Under_Mtls_Fails_Closed_When_Only_Standard_Par_Endpoint_Advertised()
+        {
+            // mTLS + PAR enabled, and the tenant advertises the token_endpoint alias plus a *standard*
+            // pushed_authorization_request_endpoint but no mtls PAR alias. The PAR request carries the
+            // client certificate and no client_secret; the standard host does not do client-certificate
+            // authentication and would reject it as invalid_client. The handler must fail closed with the
+            // actionable alias-missing error instead of silently posting to the standard host.
+            HttpRequestMessage capturedPar = null;
+            var handler = new OidcMockBuilder()
+                .MockOpenIdConfig("wellknownconfig_with_mtls_token_alias_std_par.json")
+                .MockJwks()
+                .MockPAR("https://my-par-request-uri", me => { capturedPar = me; return true; })
+                .Build();
+
+            using var server = TestServerBuilder.CreateServer(
+                configureOptions: opt => opt.UsePushedAuthorization = true,
+                configureMtls: mtls => mtls.HttpClient = new HttpClient(handler.Object));
+            using var client = server.CreateClient();
+
+            Func<Task> act = () => client.SendAsync($"{TestServerBuilder.Host}/{TestServerBuilder.Login}");
+
+            (await act.Should().ThrowAsync<InvalidOperationException>())
+                .Which.Message.Should().Contain("mtls_endpoint_aliases.pushed_authorization_request_endpoint");
+            // The certificate-less request never reached the standard PAR host.
+            capturedPar.Should().BeNull();
+        }
+
+        [Fact]
+        public async Task Par_Under_Mtls_Fails_Closed_When_No_Par_Endpoint_Advertised()
+        {
+            // mTLS + PAR enabled, and the discovery document advertises the token_endpoint alias but no
+            // PAR endpoint at all (neither alias nor standard). The handler must surface the actionable
+            // mtls alias-missing error rather than the generic "no PAR endpoint found" message, so the
+            // cause (aliases not enabled on the tenant) is clear.
+            var handler = new OidcMockBuilder()
+                .MockOpenIdConfig("wellknownconfig_with_mtls_token_only.json")
+                .MockJwks()
+                .Build();
+
+            using var server = TestServerBuilder.CreateServer(
+                configureOptions: opt => opt.UsePushedAuthorization = true,
+                configureMtls: mtls => mtls.HttpClient = new HttpClient(handler.Object));
+            using var client = server.CreateClient();
+
+            Func<Task> act = () => client.SendAsync($"{TestServerBuilder.Host}/{TestServerBuilder.Login}");
+
+            (await act.Should().ThrowAsync<InvalidOperationException>())
+                .Which.Message.Should().Contain("mtls_endpoint_aliases.pushed_authorization_request_endpoint");
+        }
+
         private string GenerateToken(int userId, string issuer, string audience, string nonce, string subject, string organization = null, bool expired = false, string extraAudience = null, string azp = null, DateTime? authTime = null)
         {
             var tokenHandler = new JwtSecurityTokenHandler();

--- a/tests/Auth0.AspNetCore.Authentication.IntegrationTests/Mtls/MtlsMiddlewareTests.cs
+++ b/tests/Auth0.AspNetCore.Authentication.IntegrationTests/Mtls/MtlsMiddlewareTests.cs
@@ -1,0 +1,247 @@
+using System;
+using System.Collections.Generic;
+using System.IdentityModel.Tokens.Jwt;
+using System.Linq;
+using System.Net.Http;
+using System.Security.Claims;
+using System.Security.Cryptography;
+using System.Threading.Tasks;
+using Auth0.AspNetCore.Authentication.IntegrationTests.Builders;
+using Auth0.AspNetCore.Authentication.IntegrationTests.Extensions;
+using Auth0.AspNetCore.Authentication.IntegrationTests.Infrastructure;
+using Auth0.AspNetCore.Authentication.IntegrationTests.Utils;
+using FluentAssertions;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Microsoft.IdentityModel.Tokens;
+using Xunit;
+
+namespace Auth0.AspNetCore.Authentication.IntegrationTests.Mtls
+{
+    public class MtlsMiddlewareTests
+    {
+        [Fact]
+        public void WithMtls_Throws_When_HttpClient_Is_Null()
+        {
+            Func<TestServer> act = () => TestServerBuilder.CreateServer(
+                configureMtls: mtls => { /* HttpClient left null */ });
+
+            act.Should().Throw<InvalidOperationException>()
+                .Which.Message.Should().Be("WithMtls requires an HttpClient configured with the client certificate.");
+        }
+
+        [Fact]
+        public void WithMtls_Throws_When_Backchannel_Already_Set()
+        {
+            Func<TestServer> act = () => TestServerBuilder.CreateServer(
+                configureOptions: options => options.Backchannel = new HttpClient(),
+                configureMtls: mtls => mtls.HttpClient = new HttpClient());
+
+            act.Should().Throw<InvalidOperationException>()
+                .Which.Message.Should().Be(
+                    "Backchannel cannot be set when WithMtls supplies an HttpClient. Configure a single HttpClient " +
+                    "with both the client certificate and your transport settings, and pass it to WithMtls.");
+        }
+
+        [Fact]
+        public void WithMtls_Throws_When_Client_Secret_Also_Set()
+        {
+            Func<TestServer> act = () => TestServerBuilder.CreateServer(
+                configureOptions: options => options.ClientSecret = "secret",
+                configureMtls: mtls => mtls.HttpClient = new HttpClient());
+
+            act.Should().Throw<InvalidOperationException>()
+                .Which.Message.Should().Be("mTLS cannot be combined with a client secret or client assertion; the certificate is the sole credential.");
+        }
+
+        [Fact]
+        public void WithMtls_Throws_When_Client_Assertion_Also_Set()
+        {
+            var provider = new RSACryptoServiceProvider();
+            Func<TestServer> act = () => TestServerBuilder.CreateServer(
+                configureOptions: options =>
+                {
+                    options.ClientAssertionSecurityKey = new RsaSecurityKey(provider);
+                    options.ClientAssertionSecurityKeyAlgorithm = SecurityAlgorithms.RsaSha256;
+                },
+                configureMtls: mtls => mtls.HttpClient = new HttpClient());
+
+            act.Should().Throw<InvalidOperationException>()
+                .Which.Message.Should().Be("mTLS cannot be combined with a client secret or client assertion; the certificate is the sole credential.");
+        }
+
+        [Fact]
+        public void WithMtls_Throws_When_Called_After_WithAccessToken()
+        {
+            Func<TestServer> act = () => TestServerBuilder.CreateServer(
+                configureOptions: options => options.ClientSecret = "temp-secret-for-ordering-test",
+                configureWithAccessTokensOptions: at => at.Audience = "http://local.auth0",
+                configureMtls: mtls => mtls.HttpClient = new HttpClient(),
+                withMtlsAfterAccessToken: true);
+
+            act.Should().Throw<InvalidOperationException>()
+                .Which.Message.Should().Be("WithMtls must be called before WithAccessToken.");
+        }
+
+        [Fact]
+        public void WithMtls_Succeeds_With_HttpClient_And_No_Secret()
+        {
+            Func<TestServer> act = () => TestServerBuilder.CreateServer(
+                configureWithAccessTokensOptions: at => at.Audience = "http://local.auth0",
+                configureMtls: mtls => mtls.HttpClient = new HttpClient());
+
+            act.Should().NotThrow();
+        }
+
+        private const string CnfHeader = "eyJhbGciOiJSUzI1NiJ9";
+        private const string CnfPayloadPresent = "eyJjbmYiOnsieDV0I1MyNTYiOiJhYmMifX0";
+        private const string CnfPayloadAbsent = "eyJzdWIiOiJ1MSJ9";
+
+        [Fact]
+        public async Task Par_Request_Goes_To_Mtls_Alias_Without_Client_Secret()
+        {
+            HttpRequestMessage capturedPar = null;
+            var handler = new OidcMockBuilder()
+                .MockOpenIdConfig("wellknownconfig_with_mtls.json")
+                .MockJwks()
+                .MockPAR("https://my-par-request-uri", me => { capturedPar = me; return true; })
+                .Build();
+
+            using var server = TestServerBuilder.CreateServer(
+                configureOptions: opt => opt.UsePushedAuthorization = true,
+                configureMtls: mtls => mtls.HttpClient = new HttpClient(handler.Object));
+            using var client = server.CreateClient();
+
+            var response = await client.SendAsync($"{TestServerBuilder.Host}/{TestServerBuilder.Login}");
+
+            response.Headers.Location.AbsolutePath.Should().Be("/authorize");
+            capturedPar.Should().NotBeNull();
+            capturedPar.RequestUri!.Host.Should().Be("mtls.tenant.eu.auth0.com");
+            var body = await capturedPar.Content!.ReadAsStringAsync();
+            body.Should().NotContain("client_secret=");
+        }
+
+        [Fact]
+        public async Task Code_Exchange_Warns_When_Access_Token_Not_Cnf_Bound()
+        {
+            await RunCodeExchange($"{CnfHeader}.{CnfPayloadAbsent}.sig", sink =>
+                sink.Logs.Should().ContainSingle(l =>
+                    l.Level == LogLevel.Warning &&
+                    l.Message == Auth0.AspNetCore.Authentication.Mtls.MtlsCnfInspector.Warning));
+        }
+
+        [Fact]
+        public async Task Code_Exchange_Silent_When_Access_Token_Cnf_Bound()
+        {
+            await RunCodeExchange($"{CnfHeader}.{CnfPayloadPresent}.sig", sink =>
+                sink.Logs.Should().NotContain(l =>
+                    l.Level == LogLevel.Warning &&
+                    l.Message == Auth0.AspNetCore.Authentication.Mtls.MtlsCnfInspector.Warning));
+        }
+
+        // Drives a full login -> callback code exchange with mTLS enabled and the given access token,
+        // then runs the caller's assertion against the captured logs.
+        private async Task RunCodeExchange(string accessToken, Action<CapturingLoggerProvider> assert)
+        {
+            var nonce = "";
+            var configuration = TestConfiguration.GetConfiguration();
+            var domain = configuration["Auth0:Domain"];
+            var clientId = configuration["Auth0:ClientId"];
+            var sink = new CapturingLoggerProvider();
+
+            var handler = new OidcMockBuilder()
+                .MockOpenIdConfig()
+                .MockJwks()
+                .MockToken(() => GenerateToken(1, $"https://{domain}/", clientId, nonce, "1"),
+                    me => me.HasAuth0ClientHeader(), accessToken: accessToken)
+                .Build();
+
+            using var server = TestServerBuilder.CreateServer(
+                configureMtls: mtls => mtls.HttpClient = new HttpClient(handler.Object),
+                loggerProvider: sink);
+            using var client = server.CreateClient();
+
+            var loginResponse = await client.SendAsync($"{TestServerBuilder.Host}/{TestServerBuilder.Login}");
+            var setCookie = Assert.Single(loginResponse.Headers, h => h.Key == "Set-Cookie");
+            var queryParameters = UriUtils.GetQueryParams(loginResponse.Headers.Location);
+            nonce = queryParameters["nonce"];
+            var state = queryParameters["state"];
+
+            var message = new HttpRequestMessage(HttpMethod.Get,
+                $"{TestServerBuilder.Host}/{TestServerBuilder.Callback}?state={state}&nonce={nonce}&code=123");
+            await client.SendAsync(message, setCookie.Value);
+
+            assert(sink);
+        }
+
+        [Fact]
+        public void WithMtls_Composes_With_WithCustomDomains()
+        {
+            var handler = new OidcMockBuilder()
+                .MockOpenIdConfig("wellknownconfig_with_mtls.json")
+                .MockJwks()
+                .Build();
+
+            Func<TestServer> act = () => TestServerBuilder.CreateServer(
+                configureCustomDomains: cd => cd.DomainResolver = _ => Task.FromResult("tenant.eu.auth0.com"),
+                configureMtls: mtls => mtls.HttpClient = new HttpClient(handler.Object),
+                configureWithAccessTokensOptions: at => at.Audience = "http://local.auth0");
+
+            act.Should().NotThrow();
+        }
+
+        private string GenerateToken(int userId, string issuer, string audience, string nonce, string subject, string organization = null, bool expired = false, string extraAudience = null, string azp = null, DateTime? authTime = null)
+        {
+            var tokenHandler = new JwtSecurityTokenHandler();
+            var claims = new List<Claim>
+            {
+                new Claim(ClaimTypes.NameIdentifier, userId.ToString()),
+            };
+
+            if (subject != null)
+            {
+                claims.Add(new Claim(JwtRegisteredClaimNames.Sub, subject));
+            }
+
+            if (extraAudience != null)
+            {
+                claims.Add(new Claim(JwtRegisteredClaimNames.Aud, extraAudience));
+            }
+
+            if (!string.IsNullOrWhiteSpace(organization))
+            {
+                var organizationClaim = organization.StartsWith("org_") ? "org_id" : "org_name";
+                claims.Add(new Claim(organizationClaim, organization));
+            }
+
+            if (!string.IsNullOrWhiteSpace(nonce))
+            {
+                claims.Add(new Claim(JwtRegisteredClaimNames.Nonce, nonce));
+            }
+
+            if (!string.IsNullOrWhiteSpace(azp))
+            {
+                claims.Add(new Claim(JwtRegisteredClaimNames.Azp, azp));
+            }
+
+            if (authTime != null)
+            {
+                claims.Add(new Claim(JwtRegisteredClaimNames.AuthTime, EpochTime.GetIntDate(authTime.Value).ToString()));
+            }
+
+            var tokenDescriptor = new SecurityTokenDescriptor
+            {
+                Subject = new ClaimsIdentity(claims),
+                NotBefore = expired ? DateTime.UtcNow.Subtract(new TimeSpan(0, 2, 0, 0)) : (DateTime?) null,
+                Expires = expired ? DateTime.UtcNow.Subtract(new TimeSpan(0, 1, 0, 0)) : DateTime.UtcNow.AddDays(7),
+                Issuer = issuer,
+                Audience = audience,
+                IssuedAt = null
+            };
+
+            var token = tokenHandler.CreateToken(tokenDescriptor);
+            return tokenHandler.WriteToken(token);
+        }
+    }
+}

--- a/tests/Auth0.AspNetCore.Authentication.IntegrationTests/Mtls/MtlsMiddlewareTests.cs
+++ b/tests/Auth0.AspNetCore.Authentication.IntegrationTests/Mtls/MtlsMiddlewareTests.cs
@@ -85,6 +85,21 @@ namespace Auth0.AspNetCore.Authentication.IntegrationTests.Mtls
         }
 
         [Fact]
+        public void WithCustomDomains_Throws_When_Called_After_WithMtls()
+        {
+            // mTLS wraps the OpenIdConnect ConfigurationManager while custom domains replaces it, so the
+            // custom-domains registration must come first. Calling WithMtls before WithCustomDomains
+            // would discard the mTLS wrapper on the login/PAR path; the builder fails fast instead.
+            Func<TestServer> act = () => TestServerBuilder.CreateServer(
+                configureCustomDomains: cd => cd.DomainResolver = _ => Task.FromResult("tenant.eu.auth0.com"),
+                configureMtls: mtls => mtls.HttpClient = new HttpClient(),
+                withMtlsBeforeCustomDomains: true);
+
+            act.Should().Throw<InvalidOperationException>()
+                .Which.Message.Should().Be("WithCustomDomains must be called before WithMtls.");
+        }
+
+        [Fact]
         public void WithMtls_Succeeds_With_HttpClient_And_No_Secret()
         {
             Func<TestServer> act = () => TestServerBuilder.CreateServer(
@@ -150,8 +165,11 @@ namespace Auth0.AspNetCore.Authentication.IntegrationTests.Mtls
             var clientId = configuration["Auth0:ClientId"];
             var sink = new CapturingLoggerProvider();
 
+            // Uses a discovery document that advertises a token_endpoint alias (but no PAR alias, so the
+            // handler does not attempt PAR): under mTLS the config manager fails closed when the token
+            // alias is absent, so the standard fixture would break the login redirect here.
             var handler = new OidcMockBuilder()
-                .MockOpenIdConfig()
+                .MockOpenIdConfig("wellknownconfig_with_mtls_token_only.json")
                 .MockJwks()
                 .MockToken(() => GenerateToken(1, $"https://{domain}/", clientId, nonce, "1"),
                     me => me.HasAuth0ClientHeader(), accessToken: accessToken)
@@ -189,6 +207,33 @@ namespace Auth0.AspNetCore.Authentication.IntegrationTests.Mtls
                 configureWithAccessTokensOptions: at => at.Audience = "http://local.auth0");
 
             act.Should().NotThrow();
+        }
+
+        [Fact]
+        public async Task Par_Request_Under_Custom_Domains_Goes_To_Mtls_Alias()
+        {
+            // Verifies the mTLS ConfigurationManager wrapper actually survives composition with custom
+            // domains (rather than merely not throwing at startup): the PAR request on the login path
+            // must be routed to the per-domain mtls alias, which only happens if the mTLS post-configure
+            // wrapped the custom-domains manager instead of being discarded by it.
+            HttpRequestMessage capturedPar = null;
+            var handler = new OidcMockBuilder()
+                .MockOpenIdConfig("wellknownconfig_with_mtls.json")
+                .MockJwks()
+                .MockPAR("https://my-par-request-uri", me => { capturedPar = me; return true; })
+                .Build();
+
+            using var server = TestServerBuilder.CreateServer(
+                configureOptions: opt => opt.UsePushedAuthorization = true,
+                configureCustomDomains: cd => cd.DomainResolver = _ => Task.FromResult("tenant.eu.auth0.com"),
+                configureMtls: mtls => mtls.HttpClient = new HttpClient(handler.Object));
+            using var client = server.CreateClient();
+
+            var response = await client.SendAsync($"{TestServerBuilder.Host}/{TestServerBuilder.Login}");
+
+            response.Headers.Location.AbsolutePath.Should().Be("/authorize");
+            capturedPar.Should().NotBeNull();
+            capturedPar.RequestUri!.Host.Should().Be("mtls.tenant.eu.auth0.com");
         }
 
         private string GenerateToken(int userId, string issuer, string audience, string nonce, string subject, string organization = null, bool expired = false, string extraAudience = null, string azp = null, DateTime? authTime = null)

--- a/tests/Auth0.AspNetCore.Authentication.IntegrationTests/Mtls/MtlsTokenClientTests.cs
+++ b/tests/Auth0.AspNetCore.Authentication.IntegrationTests/Mtls/MtlsTokenClientTests.cs
@@ -127,6 +127,20 @@ namespace Auth0.AspNetCore.Authentication.IntegrationTests.Mtls
         }
 
         [Fact]
+        public async Task Refresh_Throws_When_Mtls_Enabled_But_Resolver_Missing()
+        {
+            // UseMtls is true but no resolver was supplied. Rather than silently fall back to the
+            // standard endpoint (which the edge would reject as invalid_client), fail loudly.
+            var (handler, _, _, _) = BuildHandler($"{Header}.{PayloadWithCnf}.sig");
+            var client = new TokenClient(new HttpClient(handler.Object));
+
+            Func<Task> act = () => client.Refresh(MtlsOptions(), "refresh-123");
+
+            (await act.Should().ThrowAsync<InvalidOperationException>()).Which.Message.Should().Be(
+                "mTLS is enabled but no mTLS endpoint resolver is available. Ensure the SDK was configured with WithMtls.");
+        }
+
+        [Fact]
         public async Task Refresh_Warns_When_Token_Not_Cnf_Bound()
         {
             var (handler, _, _, _) = BuildHandler($"{Header}.{PayloadNoCnf}.sig");

--- a/tests/Auth0.AspNetCore.Authentication.IntegrationTests/Mtls/MtlsTokenClientTests.cs
+++ b/tests/Auth0.AspNetCore.Authentication.IntegrationTests/Mtls/MtlsTokenClientTests.cs
@@ -1,0 +1,186 @@
+using System;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Auth0.AspNetCore.Authentication.IntegrationTests.Builders;
+using Auth0.AspNetCore.Authentication.IntegrationTests.Infrastructure;
+using Auth0.AspNetCore.Authentication.Mtls;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Moq.Protected;
+using Xunit;
+
+namespace Auth0.AspNetCore.Authentication.IntegrationTests.Mtls
+{
+    public class MtlsTokenClientTests
+    {
+        private const string Domain = "tenant.eu.auth0.com";
+        private const string MtlsHost = "mtls.tenant.eu.auth0.com";
+        private const string Header = "eyJhbGciOiJSUzI1NiJ9";
+        private const string PayloadNoCnf = "eyJzdWIiOiJ1MSJ9";
+        private const string PayloadWithCnf = "eyJjbmYiOnsieDV0I1MyNTYiOiJhYmMifX0";
+
+        // Builds a handler that serves discovery + jwks, and captures the token request.
+        private static (Mock<HttpMessageHandler> Handler, System.Collections.Generic.List<HttpRequestMessage> TokenRequests, System.Collections.Generic.Dictionary<HttpRequestMessage, string> Bodies, string AccessTokenJwt) BuildHandler(string accessTokenJwt)
+        {
+            var tokenRequests = new System.Collections.Generic.List<HttpRequestMessage>();
+            var bodies = new System.Collections.Generic.Dictionary<HttpRequestMessage, string>();
+            var handler = new Mock<HttpMessageHandler>();
+
+            handler.Protected()
+                .Setup<Task<HttpResponseMessage>>("SendAsync",
+                    ItExpr.Is<HttpRequestMessage>(m => m.RequestUri!.AbsolutePath.Contains(".well-known/openid-configuration")),
+                    ItExpr.IsAny<CancellationToken>())
+                .ReturnsAsync(() => Resource("wellknownconfig_with_mtls.json"));
+            handler.Protected()
+                .Setup<Task<HttpResponseMessage>>("SendAsync",
+                    ItExpr.Is<HttpRequestMessage>(m => m.RequestUri!.AbsolutePath.Contains(".well-known/jwks.json")),
+                    ItExpr.IsAny<CancellationToken>())
+                .ReturnsAsync(() => Resource("jwks.json"));
+            handler.Protected()
+                .Setup<Task<HttpResponseMessage>>("SendAsync",
+                    ItExpr.Is<HttpRequestMessage>(m => m.RequestUri!.AbsolutePath == "/oauth/token"),
+                    ItExpr.IsAny<CancellationToken>())
+                .Callback<HttpRequestMessage, CancellationToken>((m, _) =>
+                {
+                    tokenRequests.Add(m);
+                    bodies[m] = m.Content!.ReadAsStringAsync().Result;
+                })
+                .ReturnsAsync(() => new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(
+                        $"{{\"access_token\":\"{accessTokenJwt}\",\"token_type\":\"Bearer\",\"expires_in\":86400,\"id_token\":\"{Header}.{PayloadNoCnf}.sig\"}}")
+                });
+
+            return (handler, tokenRequests, bodies, accessTokenJwt);
+        }
+
+        private static HttpResponseMessage Resource(string resource)
+        {
+            var name = "Auth0.AspNetCore.Authentication.IntegrationTests." + resource;
+            using var stream = typeof(Startup).Assembly.GetManifestResourceStream(name)!;
+            using var reader = new System.IO.StreamReader(stream);
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(reader.ReadToEnd(), System.Text.Encoding.UTF8, "application/json")
+            };
+        }
+
+        private static Auth0WebAppOptions MtlsOptions() =>
+            new Auth0WebAppOptions { Domain = Domain, ClientId = "cid", UseMtls = true };
+
+        [Fact]
+        public async Task Refresh_Routes_To_Mtls_Alias_And_Omits_Client_Secret()
+        {
+            var (handler, tokenRequests, bodies, _) = BuildHandler($"{Header}.{PayloadWithCnf}.sig");
+            var httpClient = new HttpClient(handler.Object);
+            var client = new TokenClient(httpClient, new Auth0MtlsEndpointResolver());
+
+            var result = await client.Refresh(MtlsOptions(), "refresh-123");
+
+            result.IsSuccess.Should().BeTrue();
+            tokenRequests.Should().ContainSingle();
+            tokenRequests[0].RequestUri!.Host.Should().Be(MtlsHost);
+            bodies[tokenRequests[0]].Should().NotContain("client_secret=");
+        }
+
+        [Fact]
+        public async Task FederatedConnectionExchange_Routes_To_Mtls_Alias_And_Omits_Client_Secret()
+        {
+            var (handler, tokenRequests, bodies, _) = BuildHandler($"{Header}.{PayloadWithCnf}.sig");
+            var client = new TokenClient(new HttpClient(handler.Object), new Auth0MtlsEndpointResolver());
+
+            await client.ExchangeRefreshTokenForConnectionToken(MtlsOptions(), "refresh-123", "google-oauth2");
+
+            tokenRequests.Should().ContainSingle();
+            tokenRequests[0].RequestUri!.Host.Should().Be(MtlsHost);
+            bodies[tokenRequests[0]].Should().NotContain("client_secret=");
+        }
+
+        [Fact]
+        public async Task CustomTokenExchange_Routes_To_Mtls_Alias_And_Omits_Client_Secret()
+        {
+            var (handler, tokenRequests, bodies, _) = BuildHandler($"{Header}.{PayloadWithCnf}.sig");
+            var client = new TokenClient(new HttpClient(handler.Object), new Auth0MtlsEndpointResolver());
+
+            await client.ExchangeCustomToken(MtlsOptions(), "subject-token", "urn:example:token-type");
+
+            tokenRequests.Should().ContainSingle();
+            tokenRequests[0].RequestUri!.Host.Should().Be(MtlsHost);
+            bodies[tokenRequests[0]].Should().NotContain("client_secret=");
+        }
+
+        [Fact]
+        public async Task Refresh_Without_Mtls_Uses_Standard_Host()
+        {
+            var (handler, tokenRequests, bodies, _) = BuildHandler($"{Header}.{PayloadWithCnf}.sig");
+            var client = new TokenClient(new HttpClient(handler.Object), new Auth0MtlsEndpointResolver());
+
+            await client.Refresh(new Auth0WebAppOptions { Domain = Domain, ClientId = "cid", ClientSecret = "secret" }, "refresh-123");
+
+            tokenRequests.Should().ContainSingle();
+            tokenRequests[0].RequestUri!.Host.Should().Be(Domain);
+            bodies[tokenRequests[0]].Should().Contain("client_secret=secret");
+        }
+
+        [Fact]
+        public async Task Refresh_Warns_When_Token_Not_Cnf_Bound()
+        {
+            var (handler, _, _, _) = BuildHandler($"{Header}.{PayloadNoCnf}.sig");
+            var sink = new CapturingLoggerProvider();
+            var factory = LoggerFactory.Create(b => b.AddProvider(sink));
+            var client = new TokenClient(new HttpClient(handler.Object), new Auth0MtlsEndpointResolver(), new MtlsCnfInspector(factory));
+
+            await client.Refresh(MtlsOptions(), "refresh-123");
+
+            sink.Logs.Should().ContainSingle(l => l.Level == LogLevel.Warning && l.Message == MtlsCnfInspector.Warning);
+        }
+
+        [Fact]
+        public async Task Refresh_Silent_When_Token_Is_Cnf_Bound()
+        {
+            var (handler, _, _, _) = BuildHandler($"{Header}.{PayloadWithCnf}.sig");
+            var sink = new CapturingLoggerProvider();
+            var factory = LoggerFactory.Create(b => b.AddProvider(sink));
+            var client = new TokenClient(new HttpClient(handler.Object), new Auth0MtlsEndpointResolver(), new MtlsCnfInspector(factory));
+
+            await client.Refresh(MtlsOptions(), "refresh-123");
+
+            sink.Logs.Should().BeEmpty();
+        }
+
+        [Fact]
+        public async Task Invalid_Client_Error_Reaches_TokenRefreshResult_Under_Mtls()
+        {
+            var handler = new Mock<HttpMessageHandler>();
+            handler.Protected()
+                .Setup<Task<HttpResponseMessage>>("SendAsync",
+                    ItExpr.Is<HttpRequestMessage>(m => m.RequestUri!.AbsolutePath.Contains(".well-known/openid-configuration")),
+                    ItExpr.IsAny<CancellationToken>())
+                .ReturnsAsync(() => Resource("wellknownconfig_with_mtls.json"));
+            handler.Protected()
+                .Setup<Task<HttpResponseMessage>>("SendAsync",
+                    ItExpr.Is<HttpRequestMessage>(m => m.RequestUri!.AbsolutePath.Contains(".well-known/jwks.json")),
+                    ItExpr.IsAny<CancellationToken>())
+                .ReturnsAsync(() => Resource("jwks.json"));
+            handler.Protected()
+                .Setup<Task<HttpResponseMessage>>("SendAsync",
+                    ItExpr.Is<HttpRequestMessage>(m => m.RequestUri!.AbsolutePath == "/oauth/token"),
+                    ItExpr.IsAny<CancellationToken>())
+                .ReturnsAsync(() => new HttpResponseMessage(HttpStatusCode.Unauthorized)
+                {
+                    Content = new StringContent("{\"error\":\"invalid_client\",\"error_description\":\"bad cert\"}")
+                });
+
+            var client = new TokenClient(new HttpClient(handler.Object), new Auth0MtlsEndpointResolver());
+            var result = await client.Refresh(MtlsOptions(), "refresh-123");
+
+            result.IsSuccess.Should().BeFalse();
+            result.Error.Should().Be("invalid_client");
+            result.ErrorDescription.Should().Be("bad cert");
+        }
+    }
+}

--- a/tests/Auth0.AspNetCore.Authentication.IntegrationTests/SessionTransferTokenTests.cs
+++ b/tests/Auth0.AspNetCore.Authentication.IntegrationTests/SessionTransferTokenTests.cs
@@ -62,7 +62,8 @@ namespace Auth0.AspNetCore.Authentication.IntegrationTests
             out Mock<IAuthenticationService> authService,
             string? resolvedDomain = null,
             string? audience = null,
-            TimeSpan? accessTokenExpirationLeeway = null)
+            TimeSpan? accessTokenExpirationLeeway = null,
+            Action<Auth0WebAppOptions>? configureWebApp = null)
         {
             var webAppOptions = new Auth0WebAppOptions
             {
@@ -72,6 +73,7 @@ namespace Auth0.AspNetCore.Authentication.IntegrationTests
                 Backchannel = new HttpClient(backchannelHandler),
                 CookieAuthenticationScheme = CookieScheme
             };
+            configureWebApp?.Invoke(webAppOptions);
 
             var withAccessTokenOptions = new Auth0WebAppWithAccessTokenOptions { Audience = audience };
             if (accessTokenExpirationLeeway.HasValue)
@@ -904,6 +906,58 @@ namespace Auth0.AspNetCore.Authentication.IntegrationTests
 
             var ex = (await act.Should().ThrowAsync<CustomTokenExchangeException>()).Which;
             ex.InnerException.Should().BeOfType<HttpRequestException>();
+        }
+
+        // A mTLS configuration error (UseMtls on but no endpoint resolver registered, i.e. WithMtls
+        // was not used) surfaces from the token client as an InvalidOperationException. Whether it
+        // happens on the exchange (explicit actor) or the actor refresh (auto-sourced, stale id_token),
+        // it must be wrapped in the documented CustomTokenExchangeException with its actionable message
+        // preserved and the original on InnerException — never leaked raw, and never mislabeled as a
+        // connectivity failure.
+        [Theory]
+        [InlineData(true)]   // fail on the actor refresh
+        [InlineData(false)]  // fail on the exchange
+        public async Task RequestSessionTransferTokenAsync_WrapsMtlsConfigurationError(bool failOnActorRefresh)
+        {
+            var handler = new Mock<HttpMessageHandler>();
+            handler
+                .Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>())
+                .ReturnsAsync(new HttpResponseMessage { StatusCode = HttpStatusCode.OK });
+
+            var properties = new AuthenticationProperties();
+            var request = new SessionTransferTokenRequest
+            {
+                SubjectToken = "customer-token",
+                SubjectTokenType = "urn:acme:customer"
+            };
+
+            if (failOnActorRefresh)
+            {
+                // Stale id_token + refresh token, so the actor refresh runs and is the call that fails.
+                properties.Items[".Token.id_token"] = IdTokenExpiringIn(-5);
+                properties.Items[".Token.refresh_token"] = "rt";
+            }
+            else
+            {
+                // Explicit actor skips the refresh entirely, so the exchange is the only call.
+                request.ActorToken = "agent-jwt";
+            }
+
+            var context = BuildContext(handler.Object, properties, out _,
+                configureWebApp: o => o.UseMtls = true);
+
+            var act = () => context.RequestSessionTransferTokenAsync(request);
+
+            var ex = (await act.Should().ThrowAsync<CustomTokenExchangeException>()).Which;
+            ex.Message.Should().Contain("mTLS is enabled but no mTLS endpoint resolver is available");
+            ex.InnerException.Should().BeOfType<InvalidOperationException>();
+            // The misconfiguration is detected before any network call goes out.
+            handler.Protected().Verify("SendAsync", Times.Never(),
+                ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>());
         }
 
         [Fact]

--- a/tests/Auth0.AspNetCore.Authentication.IntegrationTests/wellknownconfig_with_mtls.json
+++ b/tests/Auth0.AspNetCore.Authentication.IntegrationTests/wellknownconfig_with_mtls.json
@@ -1,0 +1,36 @@
+{
+  "issuer": "https://tenant.eu.auth0.com/",
+  "authorization_endpoint": "https://tenant.eu.auth0.com/authorize",
+  "token_endpoint": "https://tenant.eu.auth0.com/oauth/token",
+  "device_authorization_endpoint": "https://tenant.eu.auth0.com/oauth/device/code",
+  "userinfo_endpoint": "https://tenant.eu.auth0.com/userinfo",
+  "mfa_challenge_endpoint": "https://tenant.eu.auth0.com/mfa/challenge",
+  "jwks_uri": "https://tenant.eu.auth0.com/.well-known/jwks.json",
+  "registration_endpoint": "https://tenant.eu.auth0.com/oidc/register",
+  "revocation_endpoint": "https://tenant.eu.auth0.com/oauth/revoke",
+  "pushed_authorization_request_endpoint": "https://tenant.eu.auth0.com/oauth/par",
+  "mtls_endpoint_aliases": {
+    "token_endpoint": "https://mtls.tenant.eu.auth0.com/oauth/token",
+    "pushed_authorization_request_endpoint": "https://mtls.tenant.eu.auth0.com/oauth/par"
+  },
+  "scopes_supported": [
+    "openid", "profile", "offline_access", "name", "given_name", "family_name",
+    "nickname", "email", "email_verified", "picture", "created_at", "identities",
+    "phone", "address"
+  ],
+  "response_types_supported": [
+    "code", "token", "id_token", "code token", "code id_token", "token id_token",
+    "code token id_token"
+  ],
+  "code_challenge_methods_supported": [ "S256", "plain" ],
+  "response_modes_supported": [ "query", "fragment", "form_post" ],
+  "subject_types_supported": [ "public" ],
+  "id_token_signing_alg_values_supported": [ "HS256", "RS256" ],
+  "token_endpoint_auth_methods_supported": [ "client_secret_basic", "client_secret_post" ],
+  "claims_supported": [
+    "aud", "auth_time", "created_at", "email", "email_verified", "exp",
+    "family_name", "given_name", "iat", "identities", "iss", "name", "nickname",
+    "phone_number", "picture", "sub"
+  ],
+  "request_uri_parameter_supported": false
+}

--- a/tests/Auth0.AspNetCore.Authentication.IntegrationTests/wellknownconfig_with_mtls_no_aliases.json
+++ b/tests/Auth0.AspNetCore.Authentication.IntegrationTests/wellknownconfig_with_mtls_no_aliases.json
@@ -1,0 +1,31 @@
+{
+  "issuer": "https://tenant.eu.auth0.com/",
+  "authorization_endpoint": "https://tenant.eu.auth0.com/authorize",
+  "token_endpoint": "https://tenant.eu.auth0.com/oauth/token",
+  "device_authorization_endpoint": "https://tenant.eu.auth0.com/oauth/device/code",
+  "userinfo_endpoint": "https://tenant.eu.auth0.com/userinfo",
+  "mfa_challenge_endpoint": "https://tenant.eu.auth0.com/mfa/challenge",
+  "jwks_uri": "https://tenant.eu.auth0.com/.well-known/jwks.json",
+  "registration_endpoint": "https://tenant.eu.auth0.com/oidc/register",
+  "revocation_endpoint": "https://tenant.eu.auth0.com/oauth/revoke",
+  "scopes_supported": [
+    "openid", "profile", "offline_access", "name", "given_name", "family_name",
+    "nickname", "email", "email_verified", "picture", "created_at", "identities",
+    "phone", "address"
+  ],
+  "response_types_supported": [
+    "code", "token", "id_token", "code token", "code id_token", "token id_token",
+    "code token id_token"
+  ],
+  "code_challenge_methods_supported": [ "S256", "plain" ],
+  "response_modes_supported": [ "query", "fragment", "form_post" ],
+  "subject_types_supported": [ "public" ],
+  "id_token_signing_alg_values_supported": [ "HS256", "RS256" ],
+  "token_endpoint_auth_methods_supported": [ "client_secret_basic", "client_secret_post" ],
+  "claims_supported": [
+    "aud", "auth_time", "created_at", "email", "email_verified", "exp",
+    "family_name", "given_name", "iat", "identities", "iss", "name", "nickname",
+    "phone_number", "picture", "sub"
+  ],
+  "request_uri_parameter_supported": false
+}

--- a/tests/Auth0.AspNetCore.Authentication.IntegrationTests/wellknownconfig_with_mtls_token_alias_std_par.json
+++ b/tests/Auth0.AspNetCore.Authentication.IntegrationTests/wellknownconfig_with_mtls_token_alias_std_par.json
@@ -1,0 +1,35 @@
+{
+  "issuer": "https://tenant.eu.auth0.com/",
+  "authorization_endpoint": "https://tenant.eu.auth0.com/authorize",
+  "token_endpoint": "https://tenant.eu.auth0.com/oauth/token",
+  "pushed_authorization_request_endpoint": "https://tenant.eu.auth0.com/oauth/par",
+  "device_authorization_endpoint": "https://tenant.eu.auth0.com/oauth/device/code",
+  "userinfo_endpoint": "https://tenant.eu.auth0.com/userinfo",
+  "mfa_challenge_endpoint": "https://tenant.eu.auth0.com/mfa/challenge",
+  "jwks_uri": "https://tenant.eu.auth0.com/.well-known/jwks.json",
+  "registration_endpoint": "https://tenant.eu.auth0.com/oidc/register",
+  "revocation_endpoint": "https://tenant.eu.auth0.com/oauth/revoke",
+  "mtls_endpoint_aliases": {
+    "token_endpoint": "https://mtls.tenant.eu.auth0.com/oauth/token"
+  },
+  "scopes_supported": [
+    "openid", "profile", "offline_access", "name", "given_name", "family_name",
+    "nickname", "email", "email_verified", "picture", "created_at", "identities",
+    "phone", "address"
+  ],
+  "response_types_supported": [
+    "code", "token", "id_token", "code token", "code id_token", "token id_token",
+    "code token id_token"
+  ],
+  "code_challenge_methods_supported": [ "S256", "plain" ],
+  "response_modes_supported": [ "query", "fragment", "form_post" ],
+  "subject_types_supported": [ "public" ],
+  "id_token_signing_alg_values_supported": [ "HS256", "RS256" ],
+  "token_endpoint_auth_methods_supported": [ "client_secret_basic", "client_secret_post" ],
+  "claims_supported": [
+    "aud", "auth_time", "created_at", "email", "email_verified", "exp",
+    "family_name", "given_name", "iat", "identities", "iss", "name", "nickname",
+    "phone_number", "picture", "sub"
+  ],
+  "request_uri_parameter_supported": false
+}

--- a/tests/Auth0.AspNetCore.Authentication.IntegrationTests/wellknownconfig_with_mtls_token_only.json
+++ b/tests/Auth0.AspNetCore.Authentication.IntegrationTests/wellknownconfig_with_mtls_token_only.json
@@ -1,0 +1,34 @@
+{
+  "issuer": "https://tenant.eu.auth0.com/",
+  "authorization_endpoint": "https://tenant.eu.auth0.com/authorize",
+  "token_endpoint": "https://tenant.eu.auth0.com/oauth/token",
+  "device_authorization_endpoint": "https://tenant.eu.auth0.com/oauth/device/code",
+  "userinfo_endpoint": "https://tenant.eu.auth0.com/userinfo",
+  "mfa_challenge_endpoint": "https://tenant.eu.auth0.com/mfa/challenge",
+  "jwks_uri": "https://tenant.eu.auth0.com/.well-known/jwks.json",
+  "registration_endpoint": "https://tenant.eu.auth0.com/oidc/register",
+  "revocation_endpoint": "https://tenant.eu.auth0.com/oauth/revoke",
+  "mtls_endpoint_aliases": {
+    "token_endpoint": "https://mtls.tenant.eu.auth0.com/oauth/token"
+  },
+  "scopes_supported": [
+    "openid", "profile", "offline_access", "name", "given_name", "family_name",
+    "nickname", "email", "email_verified", "picture", "created_at", "identities",
+    "phone", "address"
+  ],
+  "response_types_supported": [
+    "code", "token", "id_token", "code token", "code id_token", "token id_token",
+    "code token id_token"
+  ],
+  "code_challenge_methods_supported": [ "S256", "plain" ],
+  "response_modes_supported": [ "query", "fragment", "form_post" ],
+  "subject_types_supported": [ "public" ],
+  "id_token_signing_alg_values_supported": [ "HS256", "RS256" ],
+  "token_endpoint_auth_methods_supported": [ "client_secret_basic", "client_secret_post" ],
+  "claims_supported": [
+    "aud", "auth_time", "created_at", "email", "email_verified", "exp",
+    "family_name", "given_name", "iat", "identities", "iss", "name", "nickname",
+    "phone_number", "picture", "sub"
+  ],
+  "request_uri_parameter_supported": false
+}


### PR DESCRIPTION
### Description

This PR adds support for **Mutual TLS (mTLS)** to the SDK, following [RFC 8705](https://datatracker.ietf.org/doc/html/rfc8705)

With mTLS, an application authenticates to Auth0 using a **client certificate** instead of a client secret or client assertion. Access tokens can additionally be **certificate-bound** (sender-constrained), so a token that is stolen cannot be replayed without the corresponding private key. This is aimed at highly-regulated scenarios where holder-of-key assurance is required.

Enabling the feature is a single, opt-in call:

  ```csharp
  builder.Services
      .AddAuth0WebAppAuthentication(options => { /* Domain, ClientId */ })
      .WithMtls(options => { options.HttpClient = mtlsHttpClient; })
      .WithAccessToken(options => { /* Audience, etc. */ });
  ```
- **The application owns the certificate.** User supplies an `HttpClient` that presents the client certificate. The SDK never reads, stores, or rotates it. This keeps certificate management  like loading, storage and rotation in the hands of the user and out of the SDK.
- **The certificate becomes the sole credential.** When mTLS is enabled, all client-authenticated back-channel calls, the code exchange, token refresh, MRRT and Token Vault exchanges, session transfer, MFA challenge, and Pushed Authorization Requests are routed through the tenant's mTLS endpoint aliases and present the certificate rather than a secret. Bearer-token endpoints continue to use the standard host.
- **Fail-fast configuration.** Combining mTLS with a client secret, client assertion, or a custom backchannel throws at startup. The SDK validates the required ordering of the builder calls, so misconfiguration surfaces immediately rather than at runtime.
- **Certificate-binding awareness.** When a token that should be certificate-bound is not, the SDK emits a one-time warning per client rather than failing silently.

This is a purely additive, opt-in feature. Applications that do not call `.WithMtls()` are unaffected.

### References

- [RFC 8705](https://datatracker.ietf.org/doc/html/rfc8705)

### Testing

- The PR adds unit and integration test coverage for the new functionality, including endpoint-alias resolution, certificate-bound token inspection, the token/authentication clients, and the mTLS middleware and configuration behaviour. Existing tests continue to pass.

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `main`